### PR TITLE
Harden Rust webhook/auth security and optimize backend hot paths

### DIFF
--- a/crates/oored/src/artifacts.rs
+++ b/crates/oored/src/artifacts.rs
@@ -28,6 +28,9 @@ const UPLOAD_URL_TTL_SECS: u64 = 30 * 60;
 /// Download URL TTL: 15 minutes for downloads.
 const DOWNLOAD_URL_TTL_SECS: u64 = 15 * 60;
 
+/// Maximum accepted local artifact upload payload size (512 MiB).
+pub const MAX_LOCAL_UPLOAD_BYTES: usize = 512 * 1024 * 1024;
+
 /// Valid artifact types.
 const VALID_ARTIFACT_TYPES: &[&str] = &["apk", "ipa", "app", "generic"];
 
@@ -100,13 +103,15 @@ pub async fn create_artifact(
         ));
     }
 
-    let store = state.store.lock().await;
-    let pool = store.pool();
+    let pool = {
+        let store = state.store.lock().await;
+        store.pool().clone()
+    };
 
     // Verify build exists and is assigned to this runner
     let build_row = sqlx::query("SELECT id, runner_id FROM builds WHERE id = ?1")
         .bind(&job_id)
-        .fetch_optional(pool)
+        .fetch_optional(&pool)
         .await
         .map_err(|e| {
             error!(error = %e, "failed to fetch build");
@@ -140,7 +145,7 @@ pub async fn create_artifact(
         )
         .bind(&build_id)
         .bind(checksum_value)
-        .fetch_optional(pool)
+        .fetch_optional(&pool)
         .await
         .map_err(|e| {
             error!(error = %e, "failed to check duplicate artifact checksum");
@@ -205,7 +210,7 @@ pub async fn create_artifact(
     .bind(&checksum)
     .bind(&metadata_str)
     .bind(now)
-    .execute(pool)
+    .execute(&pool)
     .await;
 
     if let Err(e) = insert_result {
@@ -218,7 +223,7 @@ pub async fn create_artifact(
                 )
                 .bind(&build_id)
                 .bind(checksum_value)
-                .fetch_optional(pool)
+                .fetch_optional(&pool)
                 .await
                 .map_err(|lookup_err| {
                     error!(error = %lookup_err, "failed to fetch deduplicated artifact");
@@ -286,14 +291,16 @@ pub async fn list_artifacts(
 ) -> ApiResult<ListArtifactsResponse> {
     check_permission(&state.enforcer, &auth.0.role, "builds", "read").await?;
 
-    let store = state.store.lock().await;
-    let pool = store.pool();
+    let pool = {
+        let store = state.store.lock().await;
+        store.pool().clone()
+    };
 
     let rows = sqlx::query(
         "SELECT * FROM artifacts WHERE build_id = ?1 ORDER BY created_at ASC",
     )
     .bind(&build_id)
-    .fetch_all(pool)
+    .fetch_all(&pool)
     .await
     .map_err(|e| {
         error!(error = %e, "failed to list artifacts");
@@ -313,13 +320,15 @@ pub async fn generate_download_link(
 ) -> ApiResult<ArtifactDownloadLinkResponse> {
     check_permission(&state.enforcer, &auth.0.role, "builds", "read").await?;
 
-    let store = state.store.lock().await;
-    let pool = store.pool();
+    let pool = {
+        let store = state.store.lock().await;
+        store.pool().clone()
+    };
 
     // Look up artifact
     let row = sqlx::query("SELECT * FROM artifacts WHERE id = ?1")
         .bind(&artifact_id)
-        .fetch_optional(pool)
+        .fetch_optional(&pool)
         .await
         .map_err(|e| {
             error!(error = %e, "failed to fetch artifact");
@@ -362,7 +371,7 @@ pub async fn generate_download_link(
     })
     .to_string();
     let _ = write_audit_log(
-        pool,
+        &pool,
         Some(&auth.0.user_id),
         "artifact_download_link_generated",
         "artifact",
@@ -391,6 +400,14 @@ pub async fn upload_local_artifact(
     Path(token): Path<String>,
     body: Bytes,
 ) -> Result<StatusCode, (StatusCode, Json<ApiError>)> {
+    if body.len() > MAX_LOCAL_UPLOAD_BYTES {
+        return Err(api_err(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "payload_too_large",
+            format!("Upload exceeds {} bytes", MAX_LOCAL_UPLOAD_BYTES),
+        ));
+    }
+
     let stored = {
         let storage = state.storage.read().await;
         storage

--- a/crates/oored/src/integrations/github.rs
+++ b/crates/oored/src/integrations/github.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::extract::{Query, State};
 use axum::http::{header::SET_COOKIE, HeaderMap, HeaderValue, StatusCode};
@@ -27,6 +28,104 @@ type ApiResult<T> = Result<Json<T>, (StatusCode, Json<ApiError>)>;
 const STATE_MAX_AGE_SECS: i64 = 600; // 10 minutes
 /// Maximum age (seconds) for GitHub install-callback browser cookie.
 const INSTALL_STATE_MAX_AGE_SECS: i64 = 1800; // 30 minutes
+
+fn build_http_client() -> Result<reqwest::Client, reqwest::Error> {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+}
+
+fn configured_redirect_origins() -> Vec<url::Url> {
+    let raw_origins = std::env::var("OORE_AUTH_REDIRECT_ORIGINS")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .or_else(|| {
+            std::env::var("OORE_CORS_ORIGINS")
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+        })
+        .or_else(|| std::env::var("OORE_CORS_ORIGIN").ok())
+        .unwrap_or_else(|| "http://localhost:3000".to_string());
+
+    let mut origins = Vec::new();
+    for raw in raw_origins.split(',') {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match url::Url::parse(trimmed) {
+            Ok(url) => origins.push(url),
+            Err(err) => warn!(origin = trimmed, error = %err, "ignoring invalid redirect origin"),
+        }
+    }
+    if origins.is_empty() {
+        vec![url::Url::parse("http://localhost:3000")
+            .expect("default redirect origin must be valid")]
+    } else {
+        origins
+    }
+}
+
+fn validate_redirect_origin(url: &str) -> Result<(), (StatusCode, Json<ApiError>)> {
+    let parsed = url::Url::parse(url).map_err(|_| {
+        api_err(
+            StatusCode::BAD_REQUEST,
+            "invalid_redirect_url",
+            "redirect_url is not a valid URL",
+        )
+    })?;
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "invalid_redirect_url",
+            "redirect_url must not contain credentials",
+        ));
+    }
+
+    let allowed = configured_redirect_origins();
+    let matches_allowed = allowed.iter().any(|candidate| {
+        parsed.scheme() == candidate.scheme()
+            && parsed.host_str() == candidate.host_str()
+            && parsed.port_or_known_default() == candidate.port_or_known_default()
+    });
+    if !matches_allowed {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "invalid_redirect_url",
+            "redirect_url must match a configured redirect origin",
+        ));
+    }
+    Ok(())
+}
+
+fn cookie_secure_enabled(default_secure: bool) -> bool {
+    match std::env::var("OORE_COOKIE_SECURE") {
+        Ok(raw) => match parse_cookie_secure_override(&raw) {
+            Some(value) => value,
+            None => {
+                warn!(
+                    value = raw.trim(),
+                    "invalid OORE_COOKIE_SECURE value; using default behavior"
+                );
+                default_secure
+            }
+        },
+        Err(_) => default_secure,
+    }
+}
+
+fn parse_cookie_secure_override(raw: &str) -> Option<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+fn secure_cookie_attr(secure: bool) -> &'static str {
+    if secure { "; Secure" } else { "" }
+}
 
 // ── State token ──────────────────────────────────────────────────
 
@@ -187,6 +286,7 @@ pub async fn github_start(
             "redirect_url is required",
         ));
     }
+    validate_redirect_origin(&req.redirect_url)?;
 
     let oauth_state = GitHubOAuthState {
         user_id: auth.0.user_id.clone(),
@@ -335,6 +435,20 @@ pub async fn github_callback(
             .into_response();
         }
     };
+    if validate_redirect_origin(&oauth_state.redirect_url).is_err() {
+        warn!(
+            redirect_url = %oauth_state.redirect_url,
+            "github callback redirect_url does not match configured origins"
+        );
+        return Html(error_page(
+            "Invalid redirect",
+            "The redirect URL does not match configured frontend origins.",
+        ))
+        .into_response();
+    }
+    let cookie_secure = cookie_secure_enabled(
+        base_url_from_webhook(&oauth_state.webhook_url).starts_with("https://"),
+    );
 
     // Exchange code for credentials
     match exchange_and_store(
@@ -364,7 +478,8 @@ pub async fn github_callback(
                 let mut resp = Redirect::to(&install_url).into_response();
                 if let Some(token) = sealed_install_state {
                     let cookie = format!(
-                        "oore_gh_install_state={token}; Max-Age={INSTALL_STATE_MAX_AGE_SECS}; Path=/v1/integrations/github/installed; HttpOnly; SameSite=Lax"
+                        "oore_gh_install_state={token}; Max-Age={INSTALL_STATE_MAX_AGE_SECS}; Path=/v1/integrations/github/installed; HttpOnly; SameSite=Lax{}",
+                        secure_cookie_attr(cookie_secure),
                     );
                     set_cookie_headers(&mut resp, &cookie);
                 }
@@ -383,7 +498,8 @@ pub async fn github_callback(
                 let mut resp = Redirect::to(&redirect_url).into_response();
                 if let Some(token) = sealed_install_state {
                     let cookie = format!(
-                        "oore_gh_install_state={token}; Max-Age={INSTALL_STATE_MAX_AGE_SECS}; Path=/v1/integrations/github/installed; HttpOnly; SameSite=Lax"
+                        "oore_gh_install_state={token}; Max-Age={INSTALL_STATE_MAX_AGE_SECS}; Path=/v1/integrations/github/installed; HttpOnly; SameSite=Lax{}",
+                        secure_cookie_attr(cookie_secure),
                     );
                     set_cookie_headers(&mut resp, &cookie);
                 }
@@ -522,10 +638,18 @@ pub async fn github_installed(
     );
 
     let mut resp = Html(html).into_response();
+    let cookie_secure = cookie_secure_enabled(
+        std::env::var("OORE_PUBLIC_URL")
+            .ok()
+            .is_some_and(|u| u.starts_with("https://")),
+    );
     // Clear install-state cookie after callback handling.
     set_cookie_headers(
         &mut resp,
-        "oore_gh_install_state=; Max-Age=0; Path=/v1/integrations/github/installed; HttpOnly; SameSite=Lax",
+        &format!(
+            "oore_gh_install_state=; Max-Age=0; Path=/v1/integrations/github/installed; HttpOnly; SameSite=Lax{}",
+            secure_cookie_attr(cookie_secure)
+        ),
     );
     resp
 }
@@ -538,7 +662,7 @@ async fn exchange_and_store(
     user_id: &str,
     user_email: &str,
 ) -> Result<Integration, String> {
-    let client = reqwest::Client::new();
+    let client = build_http_client().map_err(|e| format!("failed to build HTTP client: {e}"))?;
     let conversion_url = format!(
         "https://api.github.com/app-manifests/{}/conversions",
         code
@@ -570,8 +694,10 @@ async fn exchange_and_store(
         .map(|o| format!("{} ({})", conversion.name, o.login))
         .unwrap_or_else(|| conversion.name.clone());
 
-    let store = state.store.lock().await;
-    let pool = store.pool();
+    let pool = {
+        let store = state.store.lock().await;
+        store.pool().clone()
+    };
 
     // Insert integration record
     sqlx::query(
@@ -584,7 +710,7 @@ async fn exchange_and_store(
     .bind(&conversion.slug)
     .bind(user_id)
     .bind(now)
-    .execute(pool)
+    .execute(&pool)
     .await
     .map_err(|e| format!("Failed to create integration: {e}"))?;
 
@@ -608,7 +734,7 @@ async fn exchange_and_store(
         .bind(*cred_type)
         .bind(&encrypted)
         .bind(now)
-        .execute(pool)
+        .execute(&pool)
         .await
         .map_err(|e| format!("Failed to store {cred_type}: {e}"))?;
     }
@@ -626,7 +752,7 @@ async fn exchange_and_store(
         .bind(&integration_id)
         .bind(&encrypted)
         .bind(now)
-        .execute(pool)
+        .execute(&pool)
         .await
         .map_err(|e| format!("Failed to store webhook_secret: {e}"))?;
     }
@@ -639,7 +765,7 @@ async fn exchange_and_store(
     })
     .to_string();
     let _ = write_audit_log(
-        pool,
+        &pool,
         Some(user_id),
         "integration_created",
         "integration",
@@ -796,7 +922,7 @@ async fn perform_sync(
     let jwt = generate_github_jwt(&app_id, &private_key)
         .map_err(|(_, e)| format!("JWT generation failed: {}", e.0.error))?;
 
-    let client = reqwest::Client::new();
+    let client = build_http_client().map_err(|e| format!("failed to build HTTP client: {e}"))?;
     let resp = client
         .get("https://api.github.com/app/installations")
         .header("Authorization", format!("Bearer {jwt}"))
@@ -852,7 +978,7 @@ async fn perform_sync(
         .map_err(|e| format!("Failed to fetch installation: {e}"))?;
 
         installations.push(IntegrationInstallation {
-            id: actual_id,
+            id: actual_id.clone(),
             integration_id: integration_id.to_string(),
             external_id,
             account_name: gh_inst.account.login.clone(),
@@ -867,7 +993,7 @@ async fn perform_sync(
             &app_id,
             &private_key,
             gh_inst.id,
-            &installations.last().unwrap().id,
+            &actual_id,
             now,
         )
         .await
@@ -929,10 +1055,12 @@ pub async fn sync_installations(
 ) -> ApiResult<SyncInstallationsResponse> {
     check_permission(&state.enforcer, &auth.0.role, "integrations", "write").await?;
 
-    let store = state.store.lock().await;
-    let pool = store.pool();
+    let pool = {
+        let store = state.store.lock().await;
+        store.pool().clone()
+    };
 
-    let installations = perform_sync(pool, &state.encryption_key, &integration_id)
+    let installations = perform_sync(&pool, &state.encryption_key, &integration_id)
         .await
         .map_err(|msg| {
             error!(error = %msg, "sync failed");
@@ -1093,3 +1221,47 @@ async fn sync_installation_repos(
 
 // ── HTML helpers (re-exported from parent module) ─────────────────
 use super::{error_page, favicon_data_uri, html_escape};
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_cookie_secure_override, validate_redirect_origin};
+
+    #[test]
+    fn redirect_origin_accepts_default_localhost_origin() {
+        assert!(validate_redirect_origin("http://localhost:3000/callback?ok=1").is_ok());
+    }
+
+    #[test]
+    fn redirect_origin_rejects_untrusted_origin() {
+        let err = validate_redirect_origin("https://evil.example/callback")
+            .expect_err("untrusted origin should be rejected");
+        assert_eq!(err.0, axum::http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn redirect_origin_rejects_embedded_credentials() {
+        let err = validate_redirect_origin("http://user:pass@localhost:3000/callback")
+            .expect_err("credential-bearing URL should be rejected");
+        assert_eq!(err.0, axum::http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn cookie_secure_override_true_values() {
+        for value in ["1", "true", "TRUE", " yes ", "on"] {
+            assert_eq!(parse_cookie_secure_override(value), Some(true));
+        }
+    }
+
+    #[test]
+    fn cookie_secure_override_false_values() {
+        for value in ["0", "false", "FALSE", " no ", "off"] {
+            assert_eq!(parse_cookie_secure_override(value), Some(false));
+        }
+    }
+
+    #[test]
+    fn cookie_secure_override_invalid_value() {
+        assert_eq!(parse_cookie_secure_override("maybe"), None);
+        assert_eq!(parse_cookie_secure_override(""), None);
+    }
+}

--- a/crates/oored/src/integrations/gitlab.rs
+++ b/crates/oored/src/integrations/gitlab.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
@@ -25,6 +26,44 @@ type ApiResult<T> = Result<Json<T>, (StatusCode, Json<ApiError>)>;
 
 /// Maximum age (seconds) for a GitLab OAuth state token.
 const STATE_MAX_AGE_SECS: i64 = 600; // 10 minutes
+
+fn build_http_client() -> Result<reqwest::Client, reqwest::Error> {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+}
+
+fn configured_redirect_origins() -> Vec<url::Url> {
+    let raw_origins = std::env::var("OORE_AUTH_REDIRECT_ORIGINS")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .or_else(|| {
+            std::env::var("OORE_CORS_ORIGINS")
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+        })
+        .or_else(|| std::env::var("OORE_CORS_ORIGIN").ok())
+        .unwrap_or_else(|| "http://localhost:3000".to_string());
+
+    let mut origins = Vec::new();
+    for raw in raw_origins.split(',') {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match url::Url::parse(trimmed) {
+            Ok(url) => origins.push(url),
+            Err(err) => warn!(origin = trimmed, error = %err, "ignoring invalid redirect origin"),
+        }
+    }
+    if origins.is_empty() {
+        vec![url::Url::parse("http://localhost:3000")
+            .expect("default redirect origin must be valid")]
+    } else {
+        origins
+    }
+}
 
 /// `POST /v1/integrations/gitlab/start` — create GitLab integration (OAuth or token mode).
 ///
@@ -84,7 +123,10 @@ pub async fn gitlab_start(
     }
 
     // Validate token/credentials by calling GitLab API
-    let client = reqwest::Client::new();
+    let client = build_http_client().map_err(|e| {
+        error!(error = %e, "failed to build HTTP client");
+        api_err(StatusCode::INTERNAL_SERVER_ERROR, "http_client_error", "Failed to create HTTP client")
+    })?;
     let api_base = format!("{}/api/v4", host_url);
 
     let (display_name, username) = match auth_mode {
@@ -171,8 +213,10 @@ pub async fn gitlab_start(
         "active"
     };
 
-    let store = state.store.lock().await;
-    let pool = store.pool();
+    let pool = {
+        let store = state.store.lock().await;
+        store.pool().clone()
+    };
 
     // Insert integration
     sqlx::query(
@@ -186,7 +230,7 @@ pub async fn gitlab_start(
     .bind(&full_display_name)
     .bind(&auth.0.user_id)
     .bind(now)
-    .execute(pool)
+    .execute(&pool)
     .await
     .map_err(|e| {
         error!(error = %e, "failed to insert GitLab integration");
@@ -207,7 +251,7 @@ pub async fn gitlab_start(
     .bind(&integration_id)
     .bind(&encrypted_webhook_secret)
     .bind(now)
-    .execute(pool)
+    .execute(&pool)
     .await
     .map_err(|e| {
         error!(error = %e, "failed to store webhook secret");
@@ -230,7 +274,7 @@ pub async fn gitlab_start(
             .bind(&integration_id)
             .bind(&encrypted)
             .bind(now)
-            .execute(pool)
+            .execute(&pool)
             .await
             .map_err(|e| {
                 error!(error = %e, "failed to store access token");
@@ -256,7 +300,7 @@ pub async fn gitlab_start(
                 .bind(cred_type)
                 .bind(&encrypted)
                 .bind(now)
-                .execute(pool)
+                .execute(&pool)
                 .await
                 .map_err(|e| {
                     error!(error = %e, "failed to store credential");
@@ -279,7 +323,7 @@ pub async fn gitlab_start(
         .bind(&username)
         .bind(&username)
         .bind(now)
-        .execute(pool)
+        .execute(&pool)
         .await
         .map_err(|e| {
             error!(error = %e, "failed to create default installation");
@@ -288,7 +332,7 @@ pub async fn gitlab_start(
 
         // Fetch accessible projects via GitLab API
         let token = req.access_token.as_ref().unwrap();
-        if let Err(e) = sync_gitlab_projects(&client, pool, &host_url, token, &inst_id, false, now).await {
+        if let Err(e) = sync_gitlab_projects(&client, &pool, &host_url, token, &inst_id, false, now).await {
             error!(error = ?e, "failed to sync GitLab projects (non-fatal)");
         }
     }
@@ -302,7 +346,7 @@ pub async fn gitlab_start(
     })
     .to_string();
     let _ = write_audit_log(
-        pool,
+        &pool,
         Some(&auth.0.user_id),
         "integration_created",
         "integration",
@@ -454,30 +498,29 @@ fn open_gitlab_state(token: &str, key: &[u8]) -> Result<GitLabOAuthState, String
     Ok(state)
 }
 
-/// Validate that a redirect URL belongs to the configured frontend origin.
-///
-/// The allowed origin comes from `OORE_CORS_ORIGIN` (default `http://localhost:3000`).
-/// Only URLs whose scheme + host + port match the allowed origin are accepted.
+/// Validate that a redirect URL belongs to configured trusted frontend origins.
 fn validate_redirect_origin(url: &str) -> Result<(), (StatusCode, Json<ApiError>)> {
-    let allowed = std::env::var("OORE_CORS_ORIGIN")
-        .unwrap_or_else(|_| "http://localhost:3000".to_string());
-
     let parsed = url::Url::parse(url).map_err(|_| {
         api_err(StatusCode::BAD_REQUEST, "invalid_redirect_url", "redirect_url is not a valid URL")
     })?;
-
-    let allowed_parsed = url::Url::parse(&allowed).map_err(|_| {
-        api_err(StatusCode::INTERNAL_SERVER_ERROR, "config_error", "OORE_CORS_ORIGIN is not a valid URL")
-    })?;
-
-    if parsed.scheme() != allowed_parsed.scheme()
-        || parsed.host_str() != allowed_parsed.host_str()
-        || parsed.port() != allowed_parsed.port()
-    {
+    if !parsed.username().is_empty() || parsed.password().is_some() {
         return Err(api_err(
             StatusCode::BAD_REQUEST,
             "invalid_redirect_url",
-            "redirect_url must match the configured frontend origin",
+            "redirect_url must not contain credentials",
+        ));
+    }
+
+    let matches_allowed = configured_redirect_origins().iter().any(|candidate| {
+        parsed.scheme() == candidate.scheme()
+            && parsed.host_str() == candidate.host_str()
+            && parsed.port_or_known_default() == candidate.port_or_known_default()
+    });
+    if !matches_allowed {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "invalid_redirect_url",
+            "redirect_url must match a configured redirect origin",
         ));
     }
 
@@ -505,13 +548,15 @@ pub async fn gitlab_authorize(
     // Validate redirect against configured frontend origin
     validate_redirect_origin(&req.redirect_url)?;
 
-    let store = state.store.lock().await;
-    let pool = store.pool();
+    let pool = {
+        let store = state.store.lock().await;
+        store.pool().clone()
+    };
 
     // Load the integration
     let row = sqlx::query("SELECT * FROM integrations WHERE id = ?1")
         .bind(&req.integration_id)
-        .fetch_optional(pool)
+        .fetch_optional(&pool)
         .await
         .map_err(|e| {
             error!(error = %e, "failed to fetch integration");
@@ -536,7 +581,7 @@ pub async fn gitlab_authorize(
          WHERE integration_id = ?1 AND credential_type = 'oauth_client_id'",
     )
     .bind(&req.integration_id)
-    .fetch_optional(pool)
+    .fetch_optional(&pool)
     .await
     .map_err(|e| {
         error!(error = %e, "failed to fetch client_id");
@@ -647,7 +692,7 @@ pub async fn gitlab_callback(
     };
 
     // Validate the redirect_url from the sealed state against the configured frontend origin
-    if let Err(_) = validate_redirect_origin(&oauth_state.redirect_url) {
+    if validate_redirect_origin(&oauth_state.redirect_url).is_err() {
         warn!(redirect_url = %oauth_state.redirect_url, "callback redirect_url does not match configured origin");
         return Html(error_page(
             "Invalid redirect",
@@ -747,7 +792,7 @@ async fn exchange_gitlab_code(
         .unwrap_or_else(|_| "http://localhost:8787".to_string());
     let callback_url = format!("{}/v1/integrations/gitlab/callback", public_url);
 
-    let http_client = reqwest::Client::new();
+    let http_client = build_http_client().map_err(|e| format!("failed to build HTTP client: {e}"))?;
 
     #[derive(Deserialize)]
     struct GitLabTokenResponse {
@@ -921,4 +966,28 @@ async fn exchange_gitlab_code(
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_redirect_origin;
+
+    #[test]
+    fn redirect_origin_accepts_default_localhost_origin() {
+        assert!(validate_redirect_origin("http://localhost:3000/settings/integrations").is_ok());
+    }
+
+    #[test]
+    fn redirect_origin_rejects_untrusted_origin() {
+        let err = validate_redirect_origin("https://evil.example/callback")
+            .expect_err("untrusted origin should be rejected");
+        assert_eq!(err.0, axum::http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn redirect_origin_rejects_embedded_credentials() {
+        let err = validate_redirect_origin("http://user:pass@localhost:3000/settings")
+            .expect_err("credential-bearing URL should be rejected");
+        assert_eq!(err.0, axum::http::StatusCode::BAD_REQUEST);
+    }
 }

--- a/crates/oored/src/integrations/webhooks.rs
+++ b/crates/oored/src/integrations/webhooks.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use axum::body::Bytes;
 use axum::extract::State;
@@ -20,6 +20,143 @@ const MAX_WEBHOOK_BODY_SIZE: usize = 1_048_576;
 
 /// Maximum age of a webhook event before rejection (5 minutes).
 const MAX_WEBHOOK_AGE_SECS: i64 = 300;
+/// Webhook secret cache TTL (seconds).
+const WEBHOOK_SECRET_CACHE_TTL_SECS: i64 = 60;
+
+#[derive(Debug, Clone)]
+struct CachedWebhookSecret {
+    integration_id: String,
+    secret: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+struct ProviderSecretCache {
+    refreshed_at: i64,
+    entries: Arc<Vec<CachedWebhookSecret>>,
+}
+
+impl Default for ProviderSecretCache {
+    fn default() -> Self {
+        Self {
+            refreshed_at: 0,
+            entries: Arc::new(Vec::new()),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct WebhookSecretCache {
+    github: ProviderSecretCache,
+    gitlab: ProviderSecretCache,
+}
+
+impl WebhookSecretCache {
+    fn provider(&self, provider: WebhookProvider) -> &ProviderSecretCache {
+        match provider {
+            WebhookProvider::Github => &self.github,
+            WebhookProvider::Gitlab => &self.gitlab,
+        }
+    }
+
+    fn provider_mut(&mut self, provider: WebhookProvider) -> &mut ProviderSecretCache {
+        match provider {
+            WebhookProvider::Github => &mut self.github,
+            WebhookProvider::Gitlab => &mut self.gitlab,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum WebhookProvider {
+    Github,
+    Gitlab,
+}
+
+impl WebhookProvider {
+    fn as_str(self) -> &'static str {
+        match self {
+            WebhookProvider::Github => "github",
+            WebhookProvider::Gitlab => "gitlab",
+        }
+    }
+}
+
+static WEBHOOK_SECRET_CACHE: OnceLock<tokio::sync::RwLock<WebhookSecretCache>> = OnceLock::new();
+
+fn webhook_secret_cache() -> &'static tokio::sync::RwLock<WebhookSecretCache> {
+    WEBHOOK_SECRET_CACHE.get_or_init(|| tokio::sync::RwLock::new(WebhookSecretCache::default()))
+}
+
+async fn get_webhook_secrets(
+    pool: &sqlx::SqlitePool,
+    encryption_key: &[u8],
+    provider: WebhookProvider,
+    force_refresh: bool,
+) -> Result<Arc<Vec<CachedWebhookSecret>>, (StatusCode, Json<ApiError>)> {
+    let now = now_unix();
+
+    if !force_refresh {
+        let cached = {
+            let cache = webhook_secret_cache().read().await;
+            let slot = cache.provider(provider);
+            if now - slot.refreshed_at <= WEBHOOK_SECRET_CACHE_TTL_SECS {
+                Some(slot.entries.clone())
+            } else {
+                None
+            }
+        };
+
+        if let Some(entries) = cached {
+            return Ok(entries);
+        }
+    }
+
+    let rows = sqlx::query(
+        "SELECT i.id, c.encrypted_value \
+         FROM integrations i \
+         JOIN integration_credentials c ON c.integration_id = i.id \
+         WHERE i.provider = ?1 AND i.status = 'active' \
+         AND c.credential_type = 'webhook_secret'",
+    )
+    .bind(provider.as_str())
+    .fetch_all(pool)
+    .await
+    .map_err(|e| {
+        error!(error = %e, provider = provider.as_str(), "failed to fetch webhook integrations");
+        api_err(StatusCode::INTERNAL_SERVER_ERROR, "store_error", "Internal error")
+    })?;
+
+    let mut decrypted = Vec::with_capacity(rows.len());
+    for row in rows {
+        let integration_id: String = row.get("id");
+        let encrypted_secret: String = row.get("encrypted_value");
+        let secret = match crypto::decrypt(&encrypted_secret, encryption_key) {
+            Ok(s) => s.into_bytes(),
+            Err(e) => {
+                error!(
+                    error = %e,
+                    integration_id = %integration_id,
+                    provider = provider.as_str(),
+                    "failed to decrypt webhook secret"
+                );
+                continue;
+            }
+        };
+        decrypted.push(CachedWebhookSecret {
+            integration_id,
+            secret,
+        });
+    }
+
+    let entries = Arc::new(decrypted);
+    let mut cache = webhook_secret_cache().write().await;
+    let slot = cache.provider_mut(provider);
+    slot.refreshed_at = now;
+    slot.entries = entries.clone();
+    drop(cache);
+
+    Ok(entries)
+}
 
 /// Normalized webhook event for downstream processing.
 #[derive(Debug, Clone, Serialize)]
@@ -78,43 +215,38 @@ pub async fn github_webhook(
         api_err(StatusCode::BAD_REQUEST, "invalid_payload", "Invalid JSON payload")
     })?;
 
-    // Resolve the integration by checking webhook secrets
-    let store = state.store.lock().await;
-    let pool = store.pool();
+    let pool = {
+        let store = state.store.lock().await;
+        store.pool().clone()
+    };
 
-    // Find all GitHub integrations with webhook secrets
-    let integrations = sqlx::query(
-        "SELECT i.id, c.encrypted_value \
-         FROM integrations i \
-         JOIN integration_credentials c ON c.integration_id = i.id \
-         WHERE i.provider = 'github' AND i.status = 'active' \
-         AND c.credential_type = 'webhook_secret'",
+    let secrets = get_webhook_secrets(
+        &pool,
+        &state.encryption_key,
+        WebhookProvider::Github,
+        false,
     )
-    .fetch_all(pool)
-    .await
-    .map_err(|e| {
-        error!(error = %e, "failed to fetch GitHub integrations");
-        api_err(StatusCode::INTERNAL_SERVER_ERROR, "store_error", "Internal error")
-    })?;
+    .await?;
 
-    // Try each integration's webhook secret to find a match
-    let mut matched_integration_id: Option<String> = None;
+    let mut matched_integration_id = secrets
+        .iter()
+        .find(|candidate| verify_github_signature(signature, &body, &candidate.secret))
+        .map(|candidate| candidate.integration_id.clone());
 
-    for row in &integrations {
-        let integration_id: String = row.get("id");
-        let encrypted_secret: String = row.get("encrypted_value");
+    if matched_integration_id.is_none() {
+        let refreshed = get_webhook_secrets(
+            &pool,
+            &state.encryption_key,
+            WebhookProvider::Github,
+            true,
+        )
+        .await?;
 
-        let secret = match crypto::decrypt(&encrypted_secret, &state.encryption_key) {
-            Ok(s) => s,
-            Err(e) => {
-                error!(error = %e, integration_id = %integration_id, "failed to decrypt webhook secret");
-                continue;
-            }
-        };
-
-        if verify_github_signature(signature, &body, secret.as_bytes()) {
-            matched_integration_id = Some(integration_id);
-            break;
+        if !Arc::ptr_eq(&secrets, &refreshed) {
+            matched_integration_id = refreshed
+                .iter()
+                .find(|candidate| verify_github_signature(signature, &body, &candidate.secret))
+                .map(|candidate| candidate.integration_id.clone());
         }
     }
 
@@ -131,7 +263,7 @@ pub async fn github_webhook(
         )
         .bind(&integration_id)
         .bind(&delivery_id)
-        .fetch_one(pool)
+        .fetch_one(&pool)
         .await
         .unwrap_or(false);
 
@@ -155,7 +287,7 @@ pub async fn github_webhook(
     .bind(&event_type)
     .bind(payload.to_string())
     .bind(now)
-    .execute(pool)
+    .execute(&pool)
     .await
     .map_err(|e| {
         error!(error = %e, "failed to store webhook record");
@@ -307,43 +439,38 @@ pub async fn gitlab_webhook(
         api_err(StatusCode::BAD_REQUEST, "invalid_payload", "Invalid JSON payload")
     })?;
 
-    let store = state.store.lock().await;
-    let pool = store.pool();
+    let pool = {
+        let store = state.store.lock().await;
+        store.pool().clone()
+    };
 
-    // Find matching GitLab integration by checking webhook secrets
-    // GitLab webhook tokens are stored as 'webhook_secret' credential type
-    let integrations = sqlx::query(
-        "SELECT i.id, c.encrypted_value \
-         FROM integrations i \
-         JOIN integration_credentials c ON c.integration_id = i.id \
-         WHERE i.provider = 'gitlab' AND i.status = 'active' \
-         AND c.credential_type = 'webhook_secret'",
+    let secrets = get_webhook_secrets(
+        &pool,
+        &state.encryption_key,
+        WebhookProvider::Gitlab,
+        false,
     )
-    .fetch_all(pool)
-    .await
-    .map_err(|e| {
-        error!(error = %e, "failed to fetch GitLab integrations");
-        api_err(StatusCode::INTERNAL_SERVER_ERROR, "store_error", "Internal error")
-    })?;
+    .await?;
 
-    let mut matched_integration_id: Option<String> = None;
+    let mut matched_integration_id = secrets
+        .iter()
+        .find(|candidate| constant_time_eq(gitlab_token.as_bytes(), &candidate.secret))
+        .map(|candidate| candidate.integration_id.clone());
 
-    for row in &integrations {
-        let integration_id: String = row.get("id");
-        let encrypted_secret: String = row.get("encrypted_value");
+    if matched_integration_id.is_none() {
+        let refreshed = get_webhook_secrets(
+            &pool,
+            &state.encryption_key,
+            WebhookProvider::Gitlab,
+            true,
+        )
+        .await?;
 
-        let secret = match crypto::decrypt(&encrypted_secret, &state.encryption_key) {
-            Ok(s) => s,
-            Err(e) => {
-                error!(error = %e, integration_id = %integration_id, "failed to decrypt webhook secret");
-                continue;
-            }
-        };
-
-        // GitLab uses a simple token comparison
-        if constant_time_eq(gitlab_token.as_bytes(), secret.as_bytes()) {
-            matched_integration_id = Some(integration_id);
-            break;
+        if !Arc::ptr_eq(&secrets, &refreshed) {
+            matched_integration_id = refreshed
+                .iter()
+                .find(|candidate| constant_time_eq(gitlab_token.as_bytes(), &candidate.secret))
+                .map(|candidate| candidate.integration_id.clone());
         }
     }
 
@@ -360,7 +487,7 @@ pub async fn gitlab_webhook(
         )
         .bind(&integration_id)
         .bind(&event_uuid)
-        .fetch_one(pool)
+        .fetch_one(&pool)
         .await
         .unwrap_or(false);
 
@@ -405,7 +532,7 @@ pub async fn gitlab_webhook(
     .bind(&event_type)
     .bind(payload.to_string())
     .bind(now)
-    .execute(pool)
+    .execute(&pool)
     .await
     .map_err(|e| {
         error!(error = %e, "failed to store webhook record");

--- a/crates/oored/src/lib.rs
+++ b/crates/oored/src/lib.rs
@@ -909,6 +909,10 @@ async fn build_router_inner(store: SetupStore, encryption_key: Vec<u8>, _skip_oi
     // CORS origins from env var(s), defaults to local web + hosted UI.
     let cors_origins = resolve_cors_origins();
     info!(origins = ?cors_origins, "configured CORS origins");
+    info!(
+        max_bytes = artifacts::MAX_LOCAL_UPLOAD_BYTES,
+        "configured local artifact upload size limit"
+    );
 
     let cors = CorsLayer::new()
         .allow_origin(cors_origins)
@@ -1025,8 +1029,8 @@ async fn build_router_inner(store: SetupStore, encryption_key: Vec<u8>, _skip_oi
         .route(
             "/v1/artifacts/local-upload/{token}",
             axum::routing::put(artifacts::upload_local_artifact)
-                // Local artifact uploads can be large (APK/IPA), so disable default 2MB body cap.
-                .layer(DefaultBodyLimit::disable()),
+                // Local artifact uploads can be large (APK/IPA), but must remain bounded.
+                .layer(DefaultBodyLimit::max(artifacts::MAX_LOCAL_UPLOAD_BYTES)),
         )
         // Backend-agnostic local signed download URL (preferred)
         .route("/v1/artifacts/download/{token}", get(artifacts::download_local_artifact))

--- a/crates/oored/src/logs.rs
+++ b/crates/oored/src/logs.rs
@@ -11,7 +11,7 @@ use oore_contract::{
     ApiError, AppendBuildLogsRequest, AppendBuildLogsResponse, BuildLogChunk, BuildLogsResponse,
 };
 use serde::Deserialize;
-use sqlx::Row;
+use sqlx::{QueryBuilder, Row, Sqlite};
 use tokio::sync::Mutex;
 use tokio_stream::Stream;
 use tracing::{error, info, warn};
@@ -130,13 +130,15 @@ pub async fn append_build_logs(
         ));
     }
 
-    let store = state.store.lock().await;
-    let pool = store.pool();
+    let pool = {
+        let store = state.store.lock().await;
+        store.pool().clone()
+    };
 
     // Verify build exists and belongs to this runner
     let build_row = sqlx::query("SELECT runner_id FROM builds WHERE id = ?1")
         .bind(&job_id)
-        .fetch_optional(pool)
+        .fetch_optional(&pool)
         .await
         .map_err(|e| {
             error!(error = %e, "failed to fetch build");
@@ -165,7 +167,7 @@ pub async fn append_build_logs(
     let current_count: i64 =
         sqlx::query_scalar("SELECT COUNT(*) FROM build_logs WHERE build_id = ?1")
             .bind(&job_id)
-            .fetch_one(pool)
+            .fetch_one(&pool)
             .await
             .map_err(|e| {
                 error!(error = %e, "failed to count build logs");
@@ -195,39 +197,34 @@ pub async fn append_build_logs(
     let now = now_unix();
     let mut appended: i64 = 0;
 
-    for chunk in chunks_to_insert {
-        // Truncate content if longer than MAX_LINE_BYTES (UTF-8 safe)
-        let content = if chunk.content.len() > MAX_LINE_BYTES {
-            &chunk.content[..chunk.content.floor_char_boundary(MAX_LINE_BYTES)]
-        } else {
-            &chunk.content
-        };
-
-        let id = Uuid::new_v4().to_string();
-
-        // INSERT OR IGNORE to silently skip duplicate sequence numbers
-        let result =
-            sqlx::query("INSERT OR IGNORE INTO build_logs (id, build_id, sequence, content, stream, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)")
-                .bind(&id)
-                .bind(&job_id)
-                .bind(chunk.sequence)
-                .bind(content)
-                .bind(&chunk.stream)
-                .bind(now)
-                .execute(pool)
-                .await
-                .map_err(|e| {
-                    error!(error = %e, build_id = %job_id, "failed to insert build log chunk");
-                    api_err(
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        "store_error",
-                        "Failed to insert log chunk",
-                    )
-                })?;
-
-        if result.rows_affected() > 0 {
-            appended += 1;
-        }
+    // Batch insert to reduce per-row SQL overhead. 100 keeps us safely under
+    // SQLite's bind parameter limit (6 params/row => 600 params/query).
+    for batch in chunks_to_insert.chunks(100) {
+        let mut qb = QueryBuilder::<Sqlite>::new(
+            "INSERT OR IGNORE INTO build_logs (id, build_id, sequence, content, stream, created_at) ",
+        );
+        qb.push_values(batch, |mut b, chunk| {
+            let content = if chunk.content.len() > MAX_LINE_BYTES {
+                &chunk.content[..chunk.content.floor_char_boundary(MAX_LINE_BYTES)]
+            } else {
+                &chunk.content
+            };
+            b.push_bind(Uuid::new_v4().to_string())
+                .push_bind(&job_id)
+                .push_bind(chunk.sequence)
+                .push_bind(content)
+                .push_bind(&chunk.stream)
+                .push_bind(now);
+        });
+        let result = qb.build().execute(&pool).await.map_err(|e| {
+            error!(error = %e, build_id = %job_id, "failed to insert build log chunk batch");
+            api_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "store_error",
+                "Failed to insert log chunk",
+            )
+        })?;
+        appended += result.rows_affected() as i64;
     }
 
     info!(
@@ -249,13 +246,15 @@ pub async fn get_build_logs(
 ) -> ApiResult<BuildLogsResponse> {
     check_permission(&state.enforcer, &auth.0.role, "builds", "read").await?;
 
-    let store = state.store.lock().await;
-    let pool = store.pool();
+    let pool = {
+        let store = state.store.lock().await;
+        store.pool().clone()
+    };
 
     // Verify build exists
     let exists: bool = sqlx::query_scalar("SELECT COUNT(*) > 0 FROM builds WHERE id = ?1")
         .bind(&build_id)
-        .fetch_one(pool)
+        .fetch_one(&pool)
         .await
         .unwrap_or(false);
 
@@ -278,7 +277,7 @@ pub async fn get_build_logs(
     .bind(&build_id)
     .bind(after_seq)
     .bind(limit)
-    .fetch_all(pool)
+    .fetch_all(&pool)
     .await
     .map_err(|e| {
         error!(error = %e, "failed to fetch build logs");
@@ -300,7 +299,7 @@ pub async fn get_build_logs(
 
     let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM build_logs WHERE build_id = ?1")
         .bind(&build_id)
-        .fetch_one(pool)
+        .fetch_one(&pool)
         .await
         .unwrap_or(0);
 
@@ -316,11 +315,13 @@ pub async fn create_stream_token(
     check_permission(&state.enforcer, &auth.0.role, "builds", "read").await?;
 
     // Verify build exists
-    let store = state.store.lock().await;
-    let pool = store.pool();
+    let pool = {
+        let store = state.store.lock().await;
+        store.pool().clone()
+    };
     let exists: bool = sqlx::query_scalar("SELECT COUNT(*) > 0 FROM builds WHERE id = ?1")
         .bind(&build_id)
-        .fetch_one(pool)
+        .fetch_one(&pool)
         .await
         .unwrap_or(false);
 
@@ -331,7 +332,6 @@ pub async fn create_stream_token(
             "Build not found",
         ));
     }
-    drop(store);
 
     let token = state.stream_tokens.create(&auth.0).await;
     let expires_at = now_unix() + STREAM_TOKEN_TTL_SECS;
@@ -404,22 +404,21 @@ pub async fn stream_build_logs(
     check_permission(&state.enforcer, &role, "builds", "read").await?;
 
     // Verify build exists
-    {
+    let pool = {
         let store = state.store.lock().await;
-        let pool = store.pool();
-        let exists: bool = sqlx::query_scalar("SELECT COUNT(*) > 0 FROM builds WHERE id = ?1")
-            .bind(&build_id)
-            .fetch_one(pool)
-            .await
-            .unwrap_or(false);
-
-        if !exists {
-            return Err(api_err(
-                StatusCode::NOT_FOUND,
-                "not_found",
-                "Build not found",
-            ));
-        }
+        store.pool().clone()
+    };
+    let exists: bool = sqlx::query_scalar("SELECT COUNT(*) > 0 FROM builds WHERE id = ?1")
+        .bind(&build_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap_or(false);
+    if !exists {
+        return Err(api_err(
+            StatusCode::NOT_FOUND,
+            "not_found",
+            "Build not found",
+        ));
     }
 
     // Check for Last-Event-ID header for reconnection support
@@ -429,14 +428,14 @@ pub async fn stream_build_logs(
         .and_then(|s| s.parse::<i64>().ok())
         .unwrap_or(-1);
 
-    let stream = build_log_sse_stream(state, build_id, last_event_id);
+    let stream = build_log_sse_stream(pool, build_id, last_event_id);
 
     Ok(Sse::new(stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15))))
 }
 
 /// Produce an SSE stream that polls the DB for new log entries.
 fn build_log_sse_stream(
-    state: Arc<AppState>,
+    pool: sqlx::SqlitePool,
     build_id: String,
     initial_last_seq: i64,
 ) -> impl Stream<Item = Result<Event, Infallible>> {
@@ -447,9 +446,6 @@ fn build_log_sse_stream(
         loop {
             interval.tick().await;
 
-            let store = state.store.lock().await;
-            let pool = store.pool();
-
             // Fetch new log entries
             let rows = sqlx::query(
                 "SELECT sequence, content, stream FROM build_logs \
@@ -458,7 +454,7 @@ fn build_log_sse_stream(
             )
             .bind(&build_id)
             .bind(last_seq)
-            .fetch_all(pool)
+            .fetch_all(&pool)
             .await;
 
             match rows {
@@ -490,11 +486,8 @@ fn build_log_sse_stream(
             let status_result: Result<Option<String>, _> =
                 sqlx::query_scalar("SELECT status FROM builds WHERE id = ?1")
                     .bind(&build_id)
-                    .fetch_optional(pool)
+                    .fetch_optional(&pool)
                     .await;
-
-            // Drop the store lock before potentially yielding the done event
-            drop(store);
 
             match status_result {
                 Ok(Some(status)) => {

--- a/crates/oored/tests/webhook_integration.rs
+++ b/crates/oored/tests/webhook_integration.rs
@@ -139,6 +139,71 @@ async fn test_github_webhook_invalid_signature() {
 }
 
 #[tokio::test]
+async fn test_github_webhook_secret_rotation_refreshes_cache_without_restart() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let db_path = tmp.path().join("test.db");
+    let app = common::create_test_app(&db_path).await;
+    let pool = common::connect_pool(&db_path).await;
+
+    let user_id = common::seed_test_user(&pool).await;
+    let old_secret = "gh-rotate-old-secret";
+    let new_secret = "gh-rotate-new-secret";
+    let integration_id = common::seed_github_integration(&pool, &user_id, old_secret).await;
+    let (project_id, _) =
+        common::seed_project_chain(&pool, &integration_id, &user_id, "org/rotate-repo").await;
+
+    // First webhook uses old secret and warms the in-process cache.
+    let payload1 = common::github_push_payload("org/rotate-repo", "main", "sha-old");
+    let body1 = serde_json::to_vec(&payload1).unwrap();
+    let sig1 = common::github_hmac_signature(&body1, old_secret);
+    let req1 = Request::post("/v1/webhooks/github")
+        .header("content-type", "application/json")
+        .header("x-hub-signature-256", &sig1)
+        .header("x-github-delivery", "delivery-rotate-1")
+        .header("x-github-event", "push")
+        .body(Body::from(body1))
+        .unwrap();
+    let resp1 = app.clone().oneshot(req1).await.unwrap();
+    assert_eq!(resp1.status(), 200);
+    let builds1 = common::wait_for_builds(&pool, &project_id, 1, 2000).await;
+    assert_eq!(builds1.len(), 1);
+
+    // Rotate the stored webhook secret in DB.
+    let encrypted_new = oored::crypto::encrypt(new_secret, &common::TEST_ENCRYPTION_KEY)
+        .expect("failed to encrypt rotated secret");
+    sqlx::query(
+        "UPDATE integration_credentials \
+         SET encrypted_value = ?1, updated_at = ?2 \
+         WHERE integration_id = ?3 AND credential_type = 'webhook_secret'",
+    )
+    .bind(&encrypted_new)
+    .bind(common::now_unix())
+    .bind(&integration_id)
+    .execute(&pool)
+    .await
+    .expect("failed to rotate webhook secret");
+
+    // Second webhook uses new secret. It should still succeed without restart
+    // by forcing a cache refresh after the initial cached-signature miss.
+    let payload2 = common::github_push_payload("org/rotate-repo", "main", "sha-new");
+    let body2 = serde_json::to_vec(&payload2).unwrap();
+    let sig2 = common::github_hmac_signature(&body2, new_secret);
+    let req2 = Request::post("/v1/webhooks/github")
+        .header("content-type", "application/json")
+        .header("x-hub-signature-256", &sig2)
+        .header("x-github-delivery", "delivery-rotate-2")
+        .header("x-github-event", "push")
+        .body(Body::from(body2))
+        .unwrap();
+    let resp2 = app.oneshot(req2).await.unwrap();
+    assert_eq!(resp2.status(), 200);
+
+    let builds2 = common::wait_for_builds(&pool, &project_id, 2, 2000).await;
+    assert_eq!(builds2.len(), 2, "rotated secret should still trigger a build");
+    assert_eq!(builds2[1]["commit_sha"], "sha-new");
+}
+
+#[tokio::test]
 async fn test_github_webhook_missing_signature() {
     let tmp = tempfile::TempDir::new().unwrap();
     let db_path = tmp.path().join("test.db");
@@ -308,6 +373,69 @@ async fn test_gitlab_webhook_idempotency() {
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     let builds_after = common::wait_for_builds(&pool, &project_id, 1, 500).await;
     assert_eq!(builds_after.len(), 1, "duplicate should not create extra build");
+}
+
+#[tokio::test]
+async fn test_gitlab_webhook_secret_rotation_refreshes_cache_without_restart() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let db_path = tmp.path().join("test.db");
+    let app = common::create_test_app(&db_path).await;
+    let pool = common::connect_pool(&db_path).await;
+
+    let user_id = common::seed_test_user(&pool).await;
+    let old_secret = "gl-rotate-old-secret";
+    let new_secret = "gl-rotate-new-secret";
+    let integration_id = common::seed_gitlab_integration(&pool, &user_id, old_secret).await;
+    let (project_id, _) =
+        common::seed_project_chain(&pool, &integration_id, &user_id, "group/rotate-proj").await;
+
+    // First webhook uses old secret and warms the in-process cache.
+    let payload1 = common::gitlab_push_payload("group/rotate-proj", "main", "gl-sha-old");
+    let body1 = serde_json::to_vec(&payload1).unwrap();
+    let req1 = Request::post("/v1/webhooks/gitlab")
+        .header("content-type", "application/json")
+        .header("x-gitlab-token", old_secret)
+        .header("x-gitlab-event-uuid", "gl-delivery-rotate-1")
+        .header("x-gitlab-event", "Push Hook")
+        .body(Body::from(body1))
+        .unwrap();
+    let resp1 = app.clone().oneshot(req1).await.unwrap();
+    assert_eq!(resp1.status(), 200);
+    let builds1 = common::wait_for_builds(&pool, &project_id, 1, 2000).await;
+    assert_eq!(builds1.len(), 1);
+
+    // Rotate stored webhook secret in DB.
+    let encrypted_new = oored::crypto::encrypt(new_secret, &common::TEST_ENCRYPTION_KEY)
+        .expect("failed to encrypt rotated secret");
+    sqlx::query(
+        "UPDATE integration_credentials \
+         SET encrypted_value = ?1, updated_at = ?2 \
+         WHERE integration_id = ?3 AND credential_type = 'webhook_secret'",
+    )
+    .bind(&encrypted_new)
+    .bind(common::now_unix())
+    .bind(&integration_id)
+    .execute(&pool)
+    .await
+    .expect("failed to rotate webhook secret");
+
+    // Second webhook uses new secret. It should still succeed without restart
+    // by forcing a cache refresh after the initial cached-token miss.
+    let payload2 = common::gitlab_push_payload("group/rotate-proj", "main", "gl-sha-new");
+    let body2 = serde_json::to_vec(&payload2).unwrap();
+    let req2 = Request::post("/v1/webhooks/gitlab")
+        .header("content-type", "application/json")
+        .header("x-gitlab-token", new_secret)
+        .header("x-gitlab-event-uuid", "gl-delivery-rotate-2")
+        .header("x-gitlab-event", "Push Hook")
+        .body(Body::from(body2))
+        .unwrap();
+    let resp2 = app.oneshot(req2).await.unwrap();
+    assert_eq!(resp2.status(), 200);
+
+    let builds2 = common::wait_for_builds(&pool, &project_id, 2, 2000).await;
+    assert_eq!(builds2.len(), 2, "rotated token should still trigger a build");
+    assert_eq!(builds2[1]["commit_sha"], "gl-sha-new");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- harden local artifact upload endpoint with explicit body caps and guardrails
- enforce trusted redirect-origin validation for GitHub/GitLab integration flows and reject credential-bearing redirect URLs
- harden integration outbound HTTP clients (timeouts, redirects disabled)
- improve cookie security handling with explicit `OORE_COOKIE_SECURE` parsing and defaults
- optimize webhook verification by caching decrypted webhook secrets with refresh-on-miss behavior
- reduce DB lock contention by cloning pools out of state mutexes
- batch log ingestion inserts and remove per-tick mutex contention in SSE log streaming
- add focused tests for redirect-origin checks, cookie parsing, and webhook secret-rotation cache refresh for both GitHub and GitLab

## Validation
- `cargo test -p oored --lib integrations::github::tests:: -- --nocapture`
- `cargo test -p oored --lib integrations::gitlab::tests:: -- --nocapture`
- `cargo test -p oored --features test-support --test webhook_integration`
- `make validate`
