### PR TITLE
Reduce daemon/log-stream overhead and move runner workspace to .noindex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
 .PHONY: dev-web dev-docs build-web build-demo deploy-demo build-docs build check \
        test-web lint-web fix-web \
        test-docs lint-docs fix-docs \
-       cargo-check run-daemon run-runner register-runner run-cli doctor \
+       cargo-check run-daemon run-daemon-debug run-daemon-release \
+       run-runner register-runner run-cli doctor \
        docs-check ui-init install-local validate
 
 RUNNER_DAEMON_URL ?= http://127.0.0.1:8787
 RUNNER_CONFIG ?= $(HOME)/.oore/runner.json
 RUNNER_SESSION_TOKEN ?=
 RUNNER_NAME ?= $(shell hostname)
+OORED_LOG_LEVEL ?= info
 
 # ── Frontend: Web App ─────────────────────────────────────────────
 dev-web:
@@ -52,7 +54,13 @@ cargo-check:
 	cargo check --workspace
 
 run-daemon:
+	RUST_LOG=$(OORED_LOG_LEVEL) cargo run -p oored -- run --listen 127.0.0.1:8787
+
+run-daemon-debug:
 	RUST_LOG=debug cargo run -p oored -- run --listen 127.0.0.1:8787
+
+run-daemon-release:
+	RUST_LOG=info cargo run -p oored --release -- run --listen 127.0.0.1:8787
 
 run-runner:
 	cargo run -p oore -- runner start --daemon-url $(RUNNER_DAEMON_URL) --config $(RUNNER_CONFIG)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ Feature docs are validated by:
 make run-daemon
 ```
 
+By default this runs with `RUST_LOG=info`. For higher verbosity or lower runtime overhead:
+
+```bash
+make run-daemon-debug    # RUST_LOG=debug
+make run-daemon-release  # Release build + RUST_LOG=info
+```
+
 ### 2. Open a setup window
 ```bash
 # Generate a bootstrap token valid for 15 minutes

--- a/apps/docs-site/docs/guide/installation.md
+++ b/apps/docs-site/docs/guide/installation.md
@@ -113,6 +113,7 @@ Start the development servers to verify the full stack:
 ```bash [Daemon]
 make run-daemon
 # Starts oored on 127.0.0.1:8787
+# Uses RUST_LOG=info by default
 # Default mode auto-starts an embedded local runner
 ```
 
@@ -142,7 +143,9 @@ All common commands are available as `make` targets from the repository root:
 | `make lint-web` | ESLint |
 | `make fix-web` | Prettier + ESLint auto-fix |
 | `make cargo-check` | Compile check all Rust crates |
-| `make run-daemon` | Run oored on 127.0.0.1:8787 |
+| `make run-daemon` | Run oored on 127.0.0.1:8787 (`RUST_LOG=info` by default) |
+| `make run-daemon-debug` | Run oored with verbose logs (`RUST_LOG=debug`) |
+| `make run-daemon-release` | Run optimized release binary (`--release`, `RUST_LOG=info`) |
 | `make register-runner` | Register an external runner (advanced) |
 | `make run-runner` | Start external runner process (advanced) |
 | `make run-cli` | Run `oore setup open --ttl 15m` |

--- a/apps/web/src/hooks/use-log-stream.ts
+++ b/apps/web/src/hooks/use-log-stream.ts
@@ -148,6 +148,8 @@ export function useLogStream(
         eventSourceRef.current = es
 
         es.addEventListener('open', () => {
+          // SSE is healthy, so suspend polling reconciliation until disconnect.
+          stopPolling()
           setIsStreaming(true)
           setError(null)
         })
@@ -176,6 +178,7 @@ export function useLogStream(
           eventSourceRef.current = null
           setIsStreaming(false)
           setError('Live stream disconnected. Continuing with polling.')
+          startPolling()
         })
       } catch {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- abort may happen concurrently

--- a/crates/oore-runner/src/lib.rs
+++ b/crates/oore-runner/src/lib.rs
@@ -22,6 +22,8 @@ const OORE_ANDROID_KEY_ALIAS_ENV: &str = "OORE_ANDROID_KEY_ALIAS";
 const OORE_ANDROID_KEY_PASSWORD_ENV: &str = "OORE_ANDROID_KEY_PASSWORD";
 const OORE_ANDROID_KEY_PROPERTIES_PATH_ENV: &str = "OORE_ANDROID_KEY_PROPERTIES_PATH";
 const IOS_SIGNING_DIR: &str = ".oore/ios-signing";
+const BUILD_WORKSPACE_ROOT: &str = "/tmp/oore-builds.noindex";
+const SPOTLIGHT_NO_INDEX_SENTINEL: &str = ".metadata_never_index";
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RunnerConfig {
@@ -36,6 +38,20 @@ fn now_unix() -> i64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs() as i64
+}
+
+fn try_mark_no_spotlight_index(path: &Path) {
+    let sentinel = path.join(SPOTLIGHT_NO_INDEX_SENTINEL);
+    if sentinel.exists() {
+        return;
+    }
+    if let Err(err) = fs::write(&sentinel, b"") {
+        eprintln!(
+            "Warning: failed to write Spotlight no-index marker {}: {}",
+            sentinel.display(),
+            err
+        );
+    }
 }
 
 pub async fn detect_capabilities() -> serde_json::Value {
@@ -1681,7 +1697,13 @@ async fn execute_build(
     daemon_url: &str,
     config: &RunnerConfig,
 ) -> (Vec<StepResult>, anyhow::Result<()>) {
-    let workspace = PathBuf::from(format!("/tmp/oore-builds/{}", job.build_id));
+    let workspace_root = PathBuf::from(BUILD_WORKSPACE_ROOT);
+    if let Err(e) = fs::create_dir_all(&workspace_root) {
+        return (vec![], Err(e.into()));
+    }
+    try_mark_no_spotlight_index(&workspace_root);
+
+    let workspace = workspace_root.join(&job.build_id);
     if let Err(e) = fs::create_dir_all(&workspace) {
         return (vec![], Err(e.into()));
     }

--- a/crates/oored/src/logs.rs
+++ b/crates/oored/src/logs.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use axum::Json;
 use axum::extract::{Path, Query, State};
@@ -34,7 +34,10 @@ const MAX_LOG_LINES_PER_BUILD: i64 = 10_000;
 const MAX_LINE_BYTES: usize = 4096;
 
 /// Polling interval for SSE log streaming.
-const SSE_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const SSE_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// How often to query build status while streaming logs.
+const SSE_STATUS_CHECK_INTERVAL: Duration = Duration::from_secs(2);
 
 /// Streaming token TTL: 5 minutes.
 const STREAM_TOKEN_TTL_SECS: i64 = 300;
@@ -442,6 +445,8 @@ fn build_log_sse_stream(
     async_stream::stream! {
         let mut last_seq = initial_last_seq;
         let mut interval = tokio::time::interval(SSE_POLL_INTERVAL);
+        let mut last_status_check_at = Instant::now();
+        let mut check_status_now = true;
 
         loop {
             interval.tick().await;
@@ -482,33 +487,38 @@ fn build_log_sse_stream(
                 }
             }
 
-            // Check if build is in terminal state
-            let status_result: Result<Option<String>, _> =
-                sqlx::query_scalar("SELECT status FROM builds WHERE id = ?1")
-                    .bind(&build_id)
-                    .fetch_optional(&pool)
-                    .await;
+            if check_status_now || last_status_check_at.elapsed() >= SSE_STATUS_CHECK_INTERVAL {
+                check_status_now = false;
+                last_status_check_at = Instant::now();
 
-            match status_result {
-                Ok(Some(status)) => {
-                    let is_terminal = matches!(
-                        status.as_str(),
-                        "succeeded" | "failed" | "canceled" | "timed_out" | "expired"
-                    );
-                    if is_terminal {
-                        let done_event = Event::default().event("done").data("build_finished");
+                // Check if build is in terminal state
+                let status_result: Result<Option<String>, _> =
+                    sqlx::query_scalar("SELECT status FROM builds WHERE id = ?1")
+                        .bind(&build_id)
+                        .fetch_optional(&pool)
+                        .await;
+
+                match status_result {
+                    Ok(Some(status)) => {
+                        let is_terminal = matches!(
+                            status.as_str(),
+                            "succeeded" | "failed" | "canceled" | "timed_out" | "expired"
+                        );
+                        if is_terminal {
+                            let done_event = Event::default().event("done").data("build_finished");
+                            yield Ok(done_event);
+                            break;
+                        }
+                    }
+                    Ok(None) => {
+                        // Build was deleted
+                        let done_event = Event::default().event("done").data("build_not_found");
                         yield Ok(done_event);
                         break;
                     }
-                }
-                Ok(None) => {
-                    // Build was deleted
-                    let done_event = Event::default().event("done").data("build_not_found");
-                    yield Ok(done_event);
-                    break;
-                }
-                Err(e) => {
-                    warn!(error = %e, build_id = %build_id, "failed to check build status for SSE");
+                    Err(e) => {
+                        warn!(error = %e, build_id = %build_id, "failed to check build status for SSE");
+                    }
                 }
             }
         }

--- a/docs/features/2026-02-08-build-isolation.md
+++ b/docs/features/2026-02-08-build-isolation.md
@@ -55,7 +55,8 @@ When Flutter version is resolved, runner executes `fvm use <version> --force` fi
 ## Security Considerations
 
 - **Process-level isolation**: each build runs in its own child process tree.
-- **Dedicated workspace**: `/tmp/oore-builds/{build_id}`.
+- **Dedicated workspace**: `/tmp/oore-builds.noindex/{build_id}`.
+- **Reduced Spotlight indexing churn**: runner uses a `.noindex` workspace root (`/tmp/oore-builds.noindex`) and writes `.metadata_never_index` at that root as a compatibility fallback.
 - **Deterministic cleanup**: workspace removed at end of run (including failures/cancellations).
 - **Fail-fast config validation**: malformed repo config fails build immediately, preventing accidental fallback to stale UI settings.
 - **Immutable snapshot**: fallback execution settings are captured at build creation time and cannot drift mid-run.
@@ -68,7 +69,7 @@ When Flutter version is resolved, runner executes `fvm use <version> --force` fi
 
 ## Acceptance Criteria
 
-- [x] Each build uses a unique ephemeral workspace under `/tmp/oore-builds/{build_id}`.
+- [x] Each build uses a unique ephemeral workspace under `/tmp/oore-builds.noindex/{build_id}`.
 - [x] Checkout uses commit-pinned fetch when `commit_sha` is present, branch fallback otherwise.
 - [x] Runner resolves config source as file-first with UI fallback only when file is absent.
 - [x] Invalid repository YAML fails the build immediately.
@@ -81,4 +82,4 @@ oore.build team
 
 ## Last Updated
 
-`2026-02-09`
+`2026-02-11`

--- a/docs/features/2026-02-08-live-build-logs.md
+++ b/docs/features/2026-02-08-live-build-logs.md
@@ -56,6 +56,11 @@ Migration 007 adds the `build_logs` table. No data migration is needed — exist
 
 SSE streaming requires no additional infrastructure beyond the existing Axum HTTP server. Tokio's async runtime handles concurrent SSE connections efficiently.
 
+Runtime performance tuning (2026-02-11):
+
+- Frontend polling reconciliation now pauses while SSE is healthy and resumes only on disconnect/fallback, avoiding duplicate fetch pressure during active streams.
+- Backend SSE polling cadence is relaxed to 1 second, and build terminal-status checks are performed every 2 seconds instead of every stream tick.
+
 ## Acceptance Criteria
 
 - [x] Runner can upload ordered log chunks during build execution
@@ -74,4 +79,4 @@ Platform team
 
 ## Last Updated
 
-`2026-02-08`
+`2026-02-11`


### PR DESCRIPTION
## Summary
- default `make run-daemon` to `RUST_LOG=info`, with explicit `run-daemon-debug` and `run-daemon-release` targets
- reduce live log stream overhead by pausing frontend polling while SSE is healthy
- reduce backend SSE pressure by relaxing poll cadence and throttling terminal-status checks
- move runner build workspace root to `/tmp/oore-builds.noindex` (and keep root no-index sentinel fallback)
- update README/install docs and feature docs to reflect runtime/performance behavior changes

## Validation
- `make validate` passed
