### PR TITLE
Public alpha onboarding docs (OOR-62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ For source development, also install [Rust](https://rustup.rs/) and [Bun](https:
 curl -fsSL https://oore.build/install | bash
 ```
 
+Public alpha onboarding guide (common first-time blockers + fastest paths):
+
+- https://docs.oore.build/getting-started/public-alpha
+
 Install prerelease channels:
 
 ```bash

--- a/apps/docs-site/docs/.vitepress/config.mts
+++ b/apps/docs-site/docs/.vitepress/config.mts
@@ -173,6 +173,7 @@ export default defineConfig({
           text: "Getting Started",
           items: [
             { text: "What is oore.build?", link: "/getting-started/" },
+            { text: "Public Alpha (v0.1.x)", link: "/getting-started/public-alpha" },
             { text: "Prerequisites", link: "/getting-started/prerequisites" },
             { text: "Install", link: "/getting-started/install" },
             {

--- a/apps/docs-site/docs/getting-started/index.md
+++ b/apps/docs-site/docs/getting-started/index.md
@@ -38,3 +38,5 @@ Follow these pages in order to get your first instance running:
 2. [**Install**](/getting-started/install) — install release binaries via `curl -fsSL https://oore.build/install | bash`
 3. [**Hosted UI Onboarding**](/getting-started/hosted-ui-onboarding) — connect your backend to `ci.oore.build`
 4. [**Set Up Your Instance**](/getting-started/first-instance) — run the setup wizard and connect your identity provider
+
+If you’re new, start with: [**Public Alpha (v0.1.x)**](/getting-started/public-alpha) (common blockers + fastest paths).

--- a/apps/docs-site/docs/getting-started/public-alpha.md
+++ b/apps/docs-site/docs/getting-started/public-alpha.md
@@ -1,0 +1,88 @@
+---
+status: implemented
+description: "Public alpha release notes + the fastest paths to first success (and how to avoid common setup blockers)."
+---
+
+# Public Alpha (v0.1.x)
+
+oore.build is in **public alpha**.
+
+- Expect breaking changes (APIs, config formats, and CLI flags) between `v0.1.x` releases.
+- We still publish a `stable` channel to mean “the default install/update channel”, not “1.0 production maturity”.
+
+If you’re evaluating oore.build, this page is the shortest path to your first green build.
+
+## The two supported onboarding paths
+
+### Path A: Local-first (no HTTPS required)
+
+Best when you want to try it on a single Mac first.
+
+1. Install:
+
+```bash
+curl -fsSL https://oore.build/install | bash
+```
+
+2. Start the daemon:
+
+```bash
+oored run
+```
+
+3. Complete setup from the CLI:
+
+```bash
+oore setup
+```
+
+Continue with:
+- [Install](/getting-started/install)
+- [Set Up Your Instance](/getting-started/first-instance)
+
+### Path B: Hosted UI (requires an HTTPS-reachable backend URL)
+
+Best when you want the hosted UI at `https://ci.oore.build` from day one.
+
+Important constraint: a browser page loaded from `https://ci.oore.build` cannot call `http://127.0.0.1:*`.
+
+1. Install + start the daemon as above.
+2. Make your backend reachable over HTTPS (for example, via a tunnel):
+
+```bash
+cloudflared tunnel --url http://127.0.0.1:8787
+```
+
+3. Open `https://ci.oore.build`, add your tunnel URL as the backend, and follow the setup wizard.
+
+Continue with:
+- [Hosted UI Onboarding](/getting-started/hosted-ui-onboarding)
+
+## Common first-time blockers (and fixes)
+
+### `oore` / `oored` not found after install
+
+The installer adds `~/.oore/bin` to your PATH for future shells.
+
+- Open a new terminal, then try `oore version`, or
+- Use the full path once: `~/.oore/bin/oore version`.
+
+### Hosted UI can’t connect to a localhost backend
+
+If your backend URL is `http://127.0.0.1:8787`, the hosted UI will not be able to reach it.
+
+- Use local setup (`oore setup`), or
+- expose the backend over HTTPS (tunnel / reverse proxy) and use that URL in hosted UI.
+
+### “Do I need OIDC on day one?”
+
+Remote access defaults to OIDC, but local-first onboarding supports loopback-only login (no local passwords).
+
+If you want a remote-first path without configuring OIDC immediately, see the deployment docs for the `trusted_proxy` option:
+- [Deployment](/operations/deployment)
+
+## How to report issues and security findings
+
+- Bugs/UX issues: GitHub issues
+- Security reports: follow [SECURITY.md](https://github.com/devaryakjha/oore.build/blob/master/SECURITY.md) (private disclosure)
+

--- a/apps/docs-site/docs/index.md
+++ b/apps/docs-site/docs/index.md
@@ -5,7 +5,7 @@ description: "Documentation for oore.build, a self-hosted Flutter-first mobile C
 hero:
   name: oore.build
   text: Flutter-first mobile CI
-  tagline: Self-hosted build system with internal app distribution. OIDC-secured, macOS-native, no vendor lock-in.
+  tagline: Self-hosted build system with internal app distribution. OIDC for remote access, macOS-native, no vendor lock-in.
   actions:
     - theme: brand
       text: Get Started
@@ -20,7 +20,7 @@ features:
   - title: Flutter-First
     details: Purpose-built for Flutter. Android, iOS, and macOS builds with automatic Flutter version management via FVM and file-first pipeline configuration.
   - title: OIDC Security
-    details: Enterprise-grade authentication with your existing identity provider. Google, Okta, Azure AD, Auth0, and Keycloak — no local passwords, ever.
+    details: OIDC for non-loopback (remote) access, plus loopback-only local login for local-first onboarding. Google, Okta, Azure AD, Auth0, and Keycloak — no local passwords, ever.
 ---
 
 ## Who is this for?

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -77,3 +77,5 @@ Rules:
   - OOR-61: https://linear.app/oorebuild/issue/OOR-61/beta-readiness-fix-linttest-gates-webdocscli
 - Web: switched Zod imports to use the default export to avoid CI/runtime edge cases where the named `z` import is undefined.
   - OOR-61: https://linear.app/oorebuild/issue/OOR-61/beta-readiness-fix-linttest-gates-webdocscli
+- Public alpha release docs: added a first-time onboarding “Public Alpha (v0.1.x)” page and updated docs homepage wording to reflect remote-vs-loopback auth reality.
+  - OOR-62: https://linear.app/oorebuild/issue/OOR-62/public-alpha-release-messaging-onboarding-checklist-docs


### PR DESCRIPTION
Adds a Public Alpha (v0.1.x) onboarding page to reduce first-time setup blockers, updates docs homepage auth wording, and links from README.

- Linear: https://linear.app/oorebuild/issue/OOR-62/public-alpha-release-messaging-onboarding-checklist-docs\n- Validation: make validate