### PR TITLE
Fix demo deep links bypassing MSW (OOR-63)

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -8,20 +8,21 @@ import { routeTree } from './routeTree.gen'
 import './styles.css'
 import reportWebVitals from './reportWebVitals.ts'
 
-// Create a new router instance
-const router = createRouter({
-  routeTree,
-  context: {},
-  defaultPreload: 'intent',
-  scrollRestoration: true,
-  defaultStructuralSharing: true,
-  defaultPreloadStaleTime: 0,
-})
+function createAppRouter() {
+  return createRouter({
+    routeTree,
+    context: {},
+    defaultPreload: 'intent',
+    scrollRestoration: true,
+    defaultStructuralSharing: true,
+    defaultPreloadStaleTime: 0,
+  })
+}
 
 // Register the router instance for type safety
 declare module '@tanstack/react-router' {
   interface Register {
-    router: typeof router
+    router: ReturnType<typeof createAppRouter>
   }
   interface StaticDataRouteOption {
     breadcrumbLabel?: string
@@ -34,6 +35,11 @@ async function boot() {
     const { enableDemoMode } = await import('./demo/enable-demo')
     await enableDemoMode()
   }
+
+  // Create the router only after optional demo bootstrapping.
+  // Some routes read local/session storage in `beforeLoad` guards,
+  // so demo seeding must happen first to support deep links.
+  const router = createAppRouter()
 
   const rootElement = document.getElementById('app')
   if (rootElement && !rootElement.dataset.reactRoot) {

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -77,5 +77,7 @@ Rules:
   - OOR-61: https://linear.app/oorebuild/issue/OOR-61/beta-readiness-fix-linttest-gates-webdocscli
 - Web: switched Zod imports to use the default export to avoid CI/runtime edge cases where the named `z` import is undefined.
   - OOR-61: https://linear.app/oorebuild/issue/OOR-61/beta-readiness-fix-linttest-gates-webdocscli
+- Web demo mode: create the TanStack Router instance only after demo bootstrapping so deep links reliably seed storage and MSW intercepts page API requests.
+  - OOR-63: https://linear.app/oorebuild/issue/OOR-63/p0-fix-requests-not-going-to-mock-service-worker-for-non-initial-pages
 - Public alpha release docs: added a first-time onboarding “Public Alpha (v0.1.x)” page and updated docs homepage wording to reflect remote-vs-loopback auth reality.
   - OOR-62: https://linear.app/oorebuild/issue/OOR-62/public-alpha-release-messaging-onboarding-checklist-docs


### PR DESCRIPTION
Fix demo mode deep links by creating the TanStack Router only after demo bootstrap seeds instance/auth storage and starts MSW.

Linear: OOR-63