### PR TITLE
Fix Pages deploy branch flag whitespace (OOR-64)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,9 @@ PAGES_PROJECT_DOCS ?= oore-docs
 PAGES_BRANCH ?=
 
 # If PAGES_BRANCH is set (e.g. alpha/beta), deploy to a Pages preview branch.
-PAGES_BRANCH_FLAG :=
-ifneq ($(strip $(PAGES_BRANCH)),)
-PAGES_BRANCH_FLAG := --branch=$(PAGES_BRANCH)
-endif
+# Important: avoid leaving behind extra whitespace in the shell command when unset.
+# `$(if ...)` preserves the leading space in the "then" clause, while plain `:=` assignments do not.
+PAGES_BRANCH_FLAG :=$(if $(strip $(PAGES_BRANCH)), --branch=$(PAGES_BRANCH),)
 
 # ── Frontend: Web App ─────────────────────────────────────────────
 dev-web:
@@ -39,13 +38,13 @@ build-web:
 	bun run build:web
 
 deploy-web: build-web
-	$(WRANGLER) pages deploy apps/web/dist --project-name=$(PAGES_PROJECT_WEB) $(PAGES_BRANCH_FLAG) --commit-dirty=true
+	$(WRANGLER) pages deploy apps/web/dist --project-name=$(PAGES_PROJECT_WEB)$(PAGES_BRANCH_FLAG) --commit-dirty=true
 
 build-demo:
 	cd apps/web && VITE_DEMO_MODE=true bun run build
 
 deploy-demo: build-demo
-	$(WRANGLER) pages deploy apps/web/dist --project-name=$(PAGES_PROJECT_DEMO) $(PAGES_BRANCH_FLAG) --commit-dirty=true
+	$(WRANGLER) pages deploy apps/web/dist --project-name=$(PAGES_PROJECT_DEMO)$(PAGES_BRANCH_FLAG) --commit-dirty=true
 
 test-web:
 	cd apps/web && bun run test
@@ -70,10 +69,10 @@ build-site:
 	bun run build:site
 
 deploy-site: build-site
-	$(WRANGLER) pages deploy apps/site/dist --project-name=$(PAGES_PROJECT_SITE) $(PAGES_BRANCH_FLAG) --commit-dirty=true
+	$(WRANGLER) pages deploy apps/site/dist --project-name=$(PAGES_PROJECT_SITE)$(PAGES_BRANCH_FLAG) --commit-dirty=true
 
 deploy-docs: build-docs
-	$(WRANGLER) pages deploy apps/docs-site/docs/.vitepress/dist --project-name=$(PAGES_PROJECT_DOCS) $(PAGES_BRANCH_FLAG) --commit-dirty=true
+	$(WRANGLER) pages deploy apps/docs-site/docs/.vitepress/dist --project-name=$(PAGES_PROJECT_DOCS)$(PAGES_BRANCH_FLAG) --commit-dirty=true
 
 test-docs:
 	cd apps/docs-site && bun run test

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -67,6 +67,8 @@ Rules:
   - Apps: added missing `eslint` dependency to `apps/docs-site`, ignored generated VitePress artifacts in lint, and made docs tests pass when no test files exist (`vitest --passWithNoTests`).
   - Web: resolved TypeScript lint failures (`no-unnecessary-condition`) and ignored a non-TS tool script in eslint config.
   - CLI: updated `oore` status CLI test to assert the current (implemented) behavior when the daemon is unreachable.
+- Tooling: fixed `PAGES_BRANCH_FLAG` whitespace/empty-arg behavior so Pages deploy commands don’t fail when no branch is configured.
+  - OOR-64: https://linear.app/oorebuild/issue/OOR-64/p0-fix-pages-branch-flag-adding-additional-space-to-wrangler-commands
 - Installer: improved `OORE_CHANNEL=stable` behavior when no stable GitHub release exists yet (fallback + clearer guidance to use `OORE_CHANNEL=beta`/`alpha`).
   - OOR-61: https://linear.app/oorebuild/issue/OOR-61/beta-readiness-fix-linttest-gates-webdocscli
 - Rust hardening: fixed all `cargo clippy --workspace --all-targets --all-features -- -D warnings` findings and aligned formatting (`cargo fmt`).


### PR DESCRIPTION
Fixes a Makefile bug where an empty `PAGES_BRANCH_FLAG` introduced stray whitespace/empty args in wrangler Pages deploy commands, leading to silent deploy failures.

Changes
- Makefile: compute `PAGES_BRANCH_FLAG` via `$(if ...)` and concatenate it into deploy commands.
- docs/changes.md: add OOR-64 entry.

Validation
- `make validate`
