### PR TITLE
ci(stable): fix Node not found by adding Homebrew PATH

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -25,7 +25,7 @@ steps:
       HOME: /Users/arya
       CARGO_HOME: /Users/arya/.cargo
       RUSTUP_HOME: /Users/arya/.rustup
-      PATH: /Users/arya/opt/bin:/Users/arya/.cargo/bin:/Users/arya/.bun/bin:/usr/bin:/bin:/usr/sbin:/sbin
+      PATH: /Users/arya/opt/bin:/Users/arya/.cargo/bin:/Users/arya/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
     commands:
       - set -euo pipefail
       - ulimit -n 8192
@@ -46,7 +46,7 @@ steps:
       HOME: /Users/arya
       CARGO_HOME: /Users/arya/.cargo
       RUSTUP_HOME: /Users/arya/.rustup
-      PATH: /Users/arya/opt/bin:/Users/arya/.cargo/bin:/Users/arya/.bun/bin:/usr/bin:/bin:/usr/sbin:/sbin
+      PATH: /Users/arya/opt/bin:/Users/arya/.cargo/bin:/Users/arya/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
     commands:
       - set -euo pipefail
       - ulimit -n 8192
@@ -438,7 +438,7 @@ steps:
       HOME: /Users/arya
       CARGO_HOME: /Users/arya/.cargo
       RUSTUP_HOME: /Users/arya/.rustup
-      PATH: /Users/arya/opt/bin:/Users/arya/.cargo/bin:/Users/arya/.bun/bin:/usr/bin:/bin:/usr/sbin:/sbin
+      PATH: /Users/arya/opt/bin:/Users/arya/.cargo/bin:/Users/arya/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
     commands:
       - set -euo pipefail
       - tag="$(printenv CI_COMMIT_TAG || true)"
@@ -492,7 +492,7 @@ steps:
       HOME: /Users/arya
       CARGO_HOME: /Users/arya/.cargo
       RUSTUP_HOME: /Users/arya/.rustup
-      PATH: /Users/arya/opt/bin:/Users/arya/.cargo/bin:/Users/arya/.bun/bin:/usr/bin:/bin:/usr/sbin:/sbin
+      PATH: /Users/arya/opt/bin:/Users/arya/.cargo/bin:/Users/arya/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
       CLOUDFLARE_ACCOUNT_ID: bf288a8d0e450c22157076593bc1f6be
       CLOUDFLARE_API_TOKEN:
         from_secret: CLOUDFLARE_API_TOKEN

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,5 +1,5 @@
 ## 2026-02-17
-- OOR-65: Fix Woodpecker CI duplication/inefficiency: split pipelines to stop clone-only runs, avoid rebuilding web in release deploy, pin Node wrangler for reliable Pages deploys, and generate correct release compare links.
+- OOR-65: Fix Woodpecker CI duplication/inefficiency: avoid clone-only runs, avoid rebuilding web in release deploy, pin wrangler for reliable Pages deploys (ensure CI PATH includes Homebrew node), and generate correct release compare links.
 # Change Ledger (Internal Docs Pointer)
 
 This file is the only required in-repo internal documentation artifact.


### PR DESCRIPTION
Fixes the `node: command not found` failure in the `release-deploy-pages` tag pipeline on the macOS Woodpecker agent.

Root cause: CI overrides PATH and excluded Homebrew locations, so `node` (and anything installed via brew) was not visible even though it exists on the machine.

Changes:
- Add `/opt/homebrew/bin` and `/usr/local/bin` to `PATH` for CI steps (PR/push/release).
- Update docs/changes entry wording for OOR-65 to reflect PATH fix (not Node install).