### PR TITLE
OOR-67: Improve landing page contrast + demo link

### DIFF
--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -61,7 +61,8 @@
         --text: #fafafa;
         --text-soft: #d4d4d4;
         --text-muted: #737373;
-        --text-dim: #525252;
+        /* Keep "dim" copy accessible on --bg (Lighthouse contrast). */
+        --text-dim: #8a8a8a;
         --amber: #f59e0b;
         --warning-bg: rgba(234, 179, 8, 0.1);
         --warning-border: rgba(234, 179, 8, 0.2);
@@ -276,7 +277,7 @@
       }
 
       footer a {
-        color: #737373;
+        color: var(--text-dim);
         text-decoration: none;
       }
 
@@ -382,6 +383,7 @@ curl http://127.0.0.1:8787/healthz
           <div class="links">
             <a href="https://github.com/devaryakjha/oore.build">GitHub</a>
             <a href="https://ci.oore.build">Hosted UI</a>
+            <a href="https://demo.oore.build">Demo</a>
             <a href="https://docs.oore.build">Docs</a>
           </div>
         </section>

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -85,3 +85,5 @@ Rules:
   - OOR-63: https://linear.app/oorebuild/issue/OOR-63/p0-fix-requests-not-going-to-mock-service-worker-for-non-initial-pages
 - Public alpha release docs: added a first-time onboarding “Public Alpha (v0.1.x)” page and updated docs homepage wording to reflect remote-vs-loopback auth reality.
   - OOR-62: https://linear.app/oorebuild/issue/OOR-62/public-alpha-release-messaging-onboarding-checklist-docs
+- Site: improved landing page contrast for secondary text and added a Demo link.
+  - OOR-67: https://linear.app/oorebuild/issue/OOR-67/p0-improve-landing-page


### PR DESCRIPTION
Changes:
- Improve secondary text contrast on landing page (Lighthouse contrast).
- Add Demo link to https://demo.oore.build.

Validation:
- make validate

Linear:
- https://linear.app/oorebuild/issue/OOR-67/p0-improve-landing-page