### PR TITLE
feat(oor-141): SSO/OIDC provider management post-setup

### DIFF
--- a/apps/docs-site/docs/public/openapi.json
+++ b/apps/docs-site/docs/public/openapi.json
@@ -3337,6 +3337,51 @@
       }
     },
     "/v1/settings/external-access/oidc": {
+      "get": {
+        "tags": [
+          "Instance Settings"
+        ],
+        "summary": "Get current OIDC configuration for External Access",
+        "description": "Returns the current runtime OIDC provider configuration (issuer, client ID,\ndiscovered endpoints). Never exposes the client secret.",
+        "operationId": "get_external_access_oidc",
+        "responses": {
+          "200": {
+            "description": "Current OIDC configuration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetExternalAccessOidcResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "OIDC not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Setup not ready",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      },
       "put": {
         "tags": [
           "Instance Settings"
@@ -3387,6 +3432,63 @@
           },
           "409": {
             "description": "Setup state does not allow runtime OIDC configuration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/v1/settings/external-access/oidc/test-connection": {
+      "post": {
+        "tags": [
+          "Instance Settings"
+        ],
+        "summary": "Test OIDC provider connection",
+        "description": "Owner-only endpoint to test OIDC provider discovery without committing changes.\nValidates that the issuer URL is reachable and returns discovered endpoints.",
+        "operationId": "test_oidc_connection",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestOidcConnectionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Connection test succeeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestOidcConnectionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input or OIDC discovery failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Owner-only operation",
             "content": {
               "application/json": {
                 "schema": {
@@ -6342,6 +6444,48 @@
           }
         }
       },
+      "GetExternalAccessOidcResponse": {
+        "type": "object",
+        "required": [
+          "issuer_url",
+          "client_id",
+          "has_client_secret",
+          "authorization_endpoint",
+          "token_endpoint",
+          "jwks_uri",
+          "configured_at"
+        ],
+        "properties": {
+          "authorization_endpoint": {
+            "type": "string"
+          },
+          "client_id": {
+            "type": "string"
+          },
+          "configured_at": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "has_client_secret": {
+            "type": "boolean"
+          },
+          "issuer_url": {
+            "type": "string"
+          },
+          "jwks_uri": {
+            "type": "string"
+          },
+          "token_endpoint": {
+            "type": "string"
+          },
+          "userinfo_endpoint": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
       "GitHubAppCompleteRequest": {
         "type": "object",
         "required": [
@@ -8623,6 +8767,57 @@
           },
           "success": {
             "type": "boolean"
+          }
+        }
+      },
+      "TestOidcConnectionRequest": {
+        "type": "object",
+        "required": [
+          "issuer_url"
+        ],
+        "properties": {
+          "issuer_url": {
+            "type": "string"
+          }
+        }
+      },
+      "TestOidcConnectionResponse": {
+        "type": "object",
+        "required": [
+          "success",
+          "discovered_issuer",
+          "authorization_endpoint",
+          "token_endpoint",
+          "jwks_uri",
+          "scopes_supported"
+        ],
+        "properties": {
+          "authorization_endpoint": {
+            "type": "string"
+          },
+          "discovered_issuer": {
+            "type": "string"
+          },
+          "jwks_uri": {
+            "type": "string"
+          },
+          "scopes_supported": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "success": {
+            "type": "boolean"
+          },
+          "token_endpoint": {
+            "type": "string"
+          },
+          "userinfo_endpoint": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },

--- a/apps/web/src/demo/handlers/settings.ts
+++ b/apps/web/src/demo/handlers/settings.ts
@@ -215,10 +215,35 @@ export const settingsHandlers = [
     },
   ),
 
+  http.get('/v1/settings/external-access/oidc', async () => {
+    await delay(150)
+    if (!oidcConfigured) {
+      return new HttpResponse(
+        JSON.stringify({
+          code: 'oidc_not_configured',
+          message: 'No OIDC provider is configured',
+        }),
+        { status: 404 },
+      )
+    }
+    const base = oidcIssuer.replace(/\/$/, '')
+    return HttpResponse.json({
+      issuer_url: oidcIssuer,
+      client_id: 'demo-client-id',
+      has_client_secret: oidcHasClientSecret,
+      authorization_endpoint: `${base}/o/oauth2/v2/auth`,
+      token_endpoint: `${base}/token`,
+      userinfo_endpoint: `${base}/userinfo`,
+      jwks_uri: `${base}/jwks`,
+      configured_at: oidcConfiguredAt,
+    })
+  }),
+
   http.put('/v1/settings/external-access/oidc', async ({ request }) => {
     await delay(250)
     const body = (await request.json()) as {
       issuer_url?: string
+      client_id?: string
       client_secret?: string
     }
 
@@ -233,4 +258,22 @@ export const settingsHandlers = [
       configured_at: oidcConfiguredAt,
     })
   }),
+
+  http.post(
+    '/v1/settings/external-access/oidc/test-connection',
+    async ({ request }) => {
+      await delay(500)
+      const body = (await request.json()) as { issuer_url?: string }
+      const issuer = (body.issuer_url ?? DEMO_OIDC_ISSUER).replace(/\/$/, '')
+      return HttpResponse.json({
+        success: true,
+        discovered_issuer: issuer,
+        authorization_endpoint: `${issuer}/o/oauth2/v2/auth`,
+        token_endpoint: `${issuer}/token`,
+        userinfo_endpoint: `${issuer}/userinfo`,
+        jwks_uri: `${issuer}/jwks`,
+        scopes_supported: ['openid', 'email', 'profile'],
+      })
+    },
+  ),
 ]

--- a/apps/web/src/hooks/use-artifact-storage.ts
+++ b/apps/web/src/hooks/use-artifact-storage.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import type {
   ConfigureExternalAccessOidcRequest,
+  TestOidcConnectionRequest,
   UpdateArtifactStorageSettingsRequest,
   UpdateExternalAccessNetworkSettingsRequest,
   UpdateInstancePreferencesRequest,
@@ -10,8 +11,10 @@ import {
   configureExternalAccessOidc,
   getArtifactStorageSettings,
   getExternalAccessNetworkSettings,
+  getExternalAccessOidc,
   getExternalAccessPreflight,
   getInstancePreferences,
+  testOidcConnection,
   updateArtifactStorageSettings,
   updateExternalAccessNetworkSettings,
   updateInstancePreferences,
@@ -101,6 +104,18 @@ export function useUpdateInstancePreferences() {
   })
 }
 
+export function useExternalAccessOidc() {
+  const baseUrl = useBaseUrl()
+  const token = useAuthToken()
+  const instance = useActiveInstance()
+
+  return useQuery({
+    queryKey: [instance?.id ?? '__none__', 'external-access-oidc'],
+    queryFn: () => getExternalAccessOidc(baseUrl!, token!),
+    enabled: !!baseUrl && !!token,
+  })
+}
+
 export function useConfigureExternalAccessOidc() {
   const queryClient = useQueryClient()
   const baseUrl = useBaseUrl()
@@ -118,6 +133,23 @@ export function useConfigureExternalAccessOidc() {
       void queryClient.invalidateQueries({
         queryKey: [instance?.id ?? '__none__', 'external-access-preflight'],
       })
+      void queryClient.invalidateQueries({
+        queryKey: [instance?.id ?? '__none__', 'external-access-oidc'],
+      })
+    },
+  })
+}
+
+export function useTestOidcConnection() {
+  const baseUrl = useBaseUrl()
+  const token = useAuthToken()
+
+  return useMutation({
+    mutationFn: (data: TestOidcConnectionRequest) => {
+      if (!baseUrl || !token) {
+        return Promise.reject(new Error('Not authenticated'))
+      }
+      return testOidcConnection(baseUrl, token, data)
     },
   })
 }

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -2,15 +2,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   ApiClientError,
   completeSetup,
+  configureExternalAccessOidc,
   configureOidc,
   createPipeline,
   getApiErrorMessage,
   getArtifactStorageSettings,
+  getExternalAccessOidc,
   getInstancePreferences,
   getPipeline,
   getSetupStatus,
   listPipelines,
   listRunners,
+  testOidcConnection,
   updateArtifactStorageSettings,
   updateInstancePreferences,
   updatePipeline,
@@ -411,6 +414,140 @@ describe('instance preferences api', () => {
         body: JSON.stringify({
           key_storage_mode: 'file',
           runtime_mode: 'remote',
+        }),
+      },
+    )
+    expect(result).toEqual(payload)
+  })
+})
+
+describe('external access oidc api', () => {
+  it('calls GET /v1/settings/external-access/oidc with auth header', async () => {
+    const payload = {
+      issuer_url: 'https://accounts.google.com',
+      client_id: 'my-client-id',
+      has_client_secret: true,
+      authorization_endpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
+      token_endpoint: 'https://oauth2.googleapis.com/token',
+      userinfo_endpoint: 'https://openidconnect.googleapis.com/v1/userinfo',
+      jwks_uri: 'https://www.googleapis.com/oauth2/v3/certs',
+      configured_at: 1700000000,
+    }
+    mockFetch.mockReturnValue(mockJsonResponse(200, payload))
+
+    const result = await getExternalAccessOidc(
+      'https://ci.example.com',
+      'session-token',
+    )
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://ci.example.com/v1/settings/external-access/oidc',
+      {
+        headers: {
+          Authorization: 'Bearer session-token',
+        },
+      },
+    )
+    expect(result).toEqual(payload)
+  })
+
+  it('calls PUT /v1/settings/external-access/oidc with payload', async () => {
+    const payload = {
+      discovered_issuer: 'https://accounts.google.com',
+      has_client_secret: true,
+      configured_at: 1700000000,
+    }
+    mockFetch.mockReturnValue(mockJsonResponse(200, payload))
+
+    const result = await configureExternalAccessOidc(
+      'https://ci.example.com',
+      'session-token',
+      {
+        issuer_url: 'https://accounts.google.com',
+        client_id: 'my-client-id',
+        client_secret: 'my-secret',
+      },
+    )
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://ci.example.com/v1/settings/external-access/oidc',
+      {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer session-token',
+        },
+        body: JSON.stringify({
+          issuer_url: 'https://accounts.google.com',
+          client_id: 'my-client-id',
+          client_secret: 'my-secret',
+        }),
+      },
+    )
+    expect(result).toEqual(payload)
+  })
+
+  it('calls PUT without client_secret when omitted (preserve existing)', async () => {
+    const payload = {
+      discovered_issuer: 'https://accounts.google.com',
+      has_client_secret: true,
+      configured_at: 1700000000,
+    }
+    mockFetch.mockReturnValue(mockJsonResponse(200, payload))
+
+    await configureExternalAccessOidc(
+      'https://ci.example.com',
+      'session-token',
+      {
+        issuer_url: 'https://accounts.google.com',
+        client_id: 'my-client-id',
+      },
+    )
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://ci.example.com/v1/settings/external-access/oidc',
+      {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer session-token',
+        },
+        body: JSON.stringify({
+          issuer_url: 'https://accounts.google.com',
+          client_id: 'my-client-id',
+        }),
+      },
+    )
+  })
+
+  it('calls POST /v1/settings/external-access/oidc/test-connection', async () => {
+    const payload = {
+      success: true,
+      discovered_issuer: 'https://accounts.google.com',
+      authorization_endpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
+      token_endpoint: 'https://oauth2.googleapis.com/token',
+      userinfo_endpoint: 'https://openidconnect.googleapis.com/v1/userinfo',
+      jwks_uri: 'https://www.googleapis.com/oauth2/v3/certs',
+      scopes_supported: ['openid', 'email', 'profile'],
+    }
+    mockFetch.mockReturnValue(mockJsonResponse(200, payload))
+
+    const result = await testOidcConnection(
+      'https://ci.example.com',
+      'session-token',
+      { issuer_url: 'https://accounts.google.com' },
+    )
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://ci.example.com/v1/settings/external-access/oidc/test-connection',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer session-token',
+        },
+        body: JSON.stringify({
+          issuer_url: 'https://accounts.google.com',
         }),
       },
     )

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -22,6 +22,7 @@ import type {
   EffectiveProjectRetentionResponse,
   ExternalAccessNetworkSettingsResponse,
   ExternalAccessPreflightResponse,
+  GetExternalAccessOidcResponse,
   GitHubAppCompleteRequest,
   GitHubAppCompleteResponse,
   GitHubAppStartRequest,
@@ -76,6 +77,8 @@ import type {
   SyncInstallationsResponse,
   SyncPipelineIosSigningResponse,
   TestNotificationChannelResponse,
+  TestOidcConnectionRequest,
+  TestOidcConnectionResponse,
   TrustedProxySettingsResponse,
   UpdateArtifactStorageSettingsRequest,
   UpdateExternalAccessNetworkSettingsRequest,
@@ -749,6 +752,17 @@ export function updateExternalAccessTrustedProxySettings(
   )
 }
 
+export function getExternalAccessOidc(
+  baseUrl: string,
+  token: string,
+): Promise<GetExternalAccessOidcResponse> {
+  return request<GetExternalAccessOidcResponse>(
+    baseUrl,
+    '/v1/settings/external-access/oidc',
+    { headers: authHeaders(token) },
+  )
+}
+
 export function configureExternalAccessOidc(
   baseUrl: string,
   token: string,
@@ -759,6 +773,22 @@ export function configureExternalAccessOidc(
     '/v1/settings/external-access/oidc',
     {
       method: 'PUT',
+      headers: authHeaders(token),
+      body: JSON.stringify(data),
+    },
+  )
+}
+
+export function testOidcConnection(
+  baseUrl: string,
+  token: string,
+  data: TestOidcConnectionRequest,
+): Promise<TestOidcConnectionResponse> {
+  return request<TestOidcConnectionResponse>(
+    baseUrl,
+    '/v1/settings/external-access/oidc/test-connection',
+    {
+      method: 'POST',
       headers: authHeaders(token),
       body: JSON.stringify(data),
     },

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -569,6 +569,31 @@ export interface ConfigureExternalAccessOidcResponse {
   configured_at: number
 }
 
+export interface GetExternalAccessOidcResponse {
+  issuer_url: string
+  client_id: string
+  has_client_secret: boolean
+  authorization_endpoint: string
+  token_endpoint: string
+  userinfo_endpoint?: string
+  jwks_uri: string
+  configured_at: number
+}
+
+export interface TestOidcConnectionRequest {
+  issuer_url: string
+}
+
+export interface TestOidcConnectionResponse {
+  success: boolean
+  discovered_issuer: string
+  authorization_endpoint: string
+  token_endpoint: string
+  userinfo_endpoint?: string
+  jwks_uri: string
+  scopes_supported: Array<string>
+}
+
 export interface TrustedProxySettingsPublic {
   user_email_header: string
   trusted_proxy_cidrs: Array<string>

--- a/apps/web/src/routes/settings/preferences.tsx
+++ b/apps/web/src/routes/settings/preferences.tsx
@@ -26,8 +26,10 @@ import {
   useArtifactStorageSettings,
   useConfigureExternalAccessOidc,
   useExternalAccessNetworkSettings,
+  useExternalAccessOidc,
   useExternalAccessPreflight,
   useInstancePreferences,
+  useTestOidcConnection,
   useUpdateArtifactStorageSettings,
   useUpdateExternalAccessNetworkSettings,
   useUpdateInstancePreferences,
@@ -234,7 +236,9 @@ function PreferencesPage() {
   const preferencesQuery = useInstancePreferences()
   const preflightQuery = useExternalAccessPreflight()
   const networkSettingsQuery = useExternalAccessNetworkSettings()
+  const oidcConfigQuery = useExternalAccessOidc()
   const configureExternalAccessOidcMutation = useConfigureExternalAccessOidc()
+  const testOidcConnectionMutation = useTestOidcConnection()
   const updateNetworkSettingsMutation = useUpdateExternalAccessNetworkSettings()
   const updateStorageMutation = useUpdateArtifactStorageSettings()
   const updatePreferencesMutation = useUpdateInstancePreferences()
@@ -288,6 +292,7 @@ function PreferencesPage() {
     mode: 'onBlur',
   })
 
+  const oidcConfig = oidcConfigQuery.data
   const externalAccessOidcForm = useForm<ExternalAccessOidcFormValues>({
     resolver: zodResolver(externalAccessOidcSchema),
     defaultValues: {
@@ -295,6 +300,13 @@ function PreferencesPage() {
       client_id: '',
       client_secret: '',
     },
+    values: oidcConfig
+      ? {
+          issuer_url: oidcConfig.issuer_url,
+          client_id: oidcConfig.client_id,
+          client_secret: '',
+        }
+      : undefined,
     mode: 'onBlur',
   })
   const networkSettings = networkSettingsQuery.data?.settings
@@ -716,8 +728,36 @@ function PreferencesPage() {
                         {oidcReady ? 'Ready' : 'Setup'}
                       </Badge>
                     </div>
+                    {oidcConfig ? (
+                      <div className="mt-2 space-y-1 text-xs text-muted-foreground">
+                        <p>
+                          <span className="font-medium text-foreground">
+                            Issuer:
+                          </span>{' '}
+                          <span className="font-mono">
+                            {oidcConfig.issuer_url}
+                          </span>
+                        </p>
+                        <p>
+                          <span className="font-medium text-foreground">
+                            Client ID:
+                          </span>{' '}
+                          <span className="font-mono">
+                            {oidcConfig.client_id}
+                          </span>
+                        </p>
+                        <p>
+                          <span className="font-medium text-foreground">
+                            Secret:
+                          </span>{' '}
+                          {oidcConfig.has_client_secret
+                            ? 'Stored'
+                            : 'None (public client)'}
+                        </p>
+                      </div>
+                    ) : null}
                     <p className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-primary">
-                      Configure
+                      {oidcReady ? 'Reconfigure' : 'Configure'}
                       <HugeiconsIcon icon={ArrowRight01Icon} size={14} />
                     </p>
                   </button>
@@ -973,13 +1013,26 @@ function PreferencesPage() {
         </DialogContent>
       </Dialog>
 
-      <Dialog open={oidcDialogOpen} onOpenChange={setOidcDialogOpen}>
+      <Dialog
+        open={oidcDialogOpen}
+        onOpenChange={(open) => {
+          setOidcDialogOpen(open)
+          if (!open) testOidcConnectionMutation.reset()
+        }}
+      >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Configure OIDC for External Access</DialogTitle>
+            <DialogTitle>
+              {oidcConfig
+                ? 'Update OIDC Provider'
+                : 'Configure OIDC for External Access'}
+            </DialogTitle>
             <DialogDescription>
               Owner-only. This updates runtime OIDC settings used by External
               Access sign-in.
+              {oidcConfig?.has_client_secret ? (
+                <> Leave the secret field empty to keep the existing secret.</>
+              ) : null}
             </DialogDescription>
           </DialogHeader>
 
@@ -1042,18 +1095,47 @@ function PreferencesPage() {
                     <FormControl>
                       <Input
                         type="password"
-                        placeholder="Leave empty for public clients"
+                        placeholder={
+                          oidcConfig?.has_client_secret
+                            ? 'Leave empty to keep existing secret'
+                            : 'Leave empty for public clients'
+                        }
                         {...field}
                         disabled={configureExternalAccessOidcMutation.isPending}
                       />
                     </FormControl>
                     <FormDescription>
-                      If omitted, any existing stored client secret is removed.
+                      {oidcConfig?.has_client_secret
+                        ? 'Leave empty to keep the existing secret. Enter a new value to rotate.'
+                        : 'If omitted, any existing stored client secret is removed.'}
                     </FormDescription>
                     <FormMessage />
                   </FormItem>
                 )}
               />
+
+              {testOidcConnectionMutation.isSuccess ? (
+                <Alert>
+                  <HugeiconsIcon
+                    icon={CheckmarkCircle02Icon}
+                    size={16}
+                    className="text-emerald-500"
+                  />
+                  <AlertDescription>
+                    Connection successful.{' '}
+                    <span className="font-mono text-xs">
+                      {testOidcConnectionMutation.data.discovered_issuer}
+                    </span>
+                  </AlertDescription>
+                </Alert>
+              ) : testOidcConnectionMutation.isError ? (
+                <Alert variant="destructive">
+                  <HugeiconsIcon icon={AlertCircleIcon} size={16} />
+                  <AlertDescription>
+                    Connection failed. Verify the issuer URL and try again.
+                  </AlertDescription>
+                </Alert>
+              ) : null}
 
               <DialogFooter>
                 <Button
@@ -1063,6 +1145,46 @@ function PreferencesPage() {
                   disabled={configureExternalAccessOidcMutation.isPending}
                 >
                   Cancel
+                </Button>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  disabled={
+                    !isOwner ||
+                    testOidcConnectionMutation.isPending ||
+                    configureExternalAccessOidcMutation.isPending ||
+                    !externalAccessOidcForm.watch('issuer_url').trim()
+                  }
+                  onClick={() => {
+                    const issuerUrl =
+                      externalAccessOidcForm.getValues('issuer_url').trim()
+                    if (issuerUrl) {
+                      testOidcConnectionMutation.mutate(
+                        { issuer_url: issuerUrl },
+                        {
+                          onError: (error) => {
+                            toast.error(
+                              getApiErrorMessage(error, {
+                                oidc_discovery_failed:
+                                  'OIDC discovery failed. Verify issuer URL and provider availability.',
+                                invalid_input:
+                                  'Invalid issuer URL. Enter a valid URL.',
+                              }),
+                            )
+                          },
+                        },
+                      )
+                    }
+                  }}
+                >
+                  {testOidcConnectionMutation.isPending ? (
+                    <>
+                      <Spinner className="size-4" />
+                      Testing...
+                    </>
+                  ) : (
+                    'Test Connection'
+                  )}
                 </Button>
                 <Button
                   type="submit"
@@ -1076,7 +1198,7 @@ function PreferencesPage() {
                       Saving...
                     </>
                   ) : (
-                    'Save OIDC Settings'
+                    'Update OIDC Provider'
                   )}
                 </Button>
               </DialogFooter>

--- a/crates/oore-contract/src/lib.rs
+++ b/crates/oore-contract/src/lib.rs
@@ -1427,6 +1427,36 @@ pub struct ConfigureExternalAccessOidcResponse {
     pub configured_at: i64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct GetExternalAccessOidcResponse {
+    pub issuer_url: String,
+    pub client_id: String,
+    pub has_client_secret: bool,
+    pub authorization_endpoint: String,
+    pub token_endpoint: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub userinfo_endpoint: Option<String>,
+    pub jwks_uri: String,
+    pub configured_at: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct TestOidcConnectionRequest {
+    pub issuer_url: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct TestOidcConnectionResponse {
+    pub success: bool,
+    pub discovered_issuer: String,
+    pub authorization_endpoint: String,
+    pub token_endpoint: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub userinfo_endpoint: Option<String>,
+    pub jwks_uri: String,
+    pub scopes_supported: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct TrustedProxySettingsPublic {
     pub user_email_header: String,

--- a/crates/oored/src/bin/openapi_export.rs
+++ b/crates/oored/src/bin/openapi_export.rs
@@ -63,7 +63,9 @@ use utoipa::OpenApi;
         paths::get_external_access_trusted_proxy_settings,
         paths::update_external_access_trusted_proxy_settings,
         paths::get_external_access_preflight,
+        paths::get_external_access_oidc,
         paths::configure_external_access_oidc,
+        paths::test_oidc_connection,
         // ── Retention Policy ──
         paths::get_retention_policy,
         paths::update_retention_policy,
@@ -316,6 +318,9 @@ use utoipa::OpenApi;
         oore_contract::ExternalAccessPreflightResponse,
         oore_contract::ConfigureExternalAccessOidcRequest,
         oore_contract::ConfigureExternalAccessOidcResponse,
+        oore_contract::GetExternalAccessOidcResponse,
+        oore_contract::TestOidcConnectionRequest,
+        oore_contract::TestOidcConnectionResponse,
         oore_contract::InstancePreferences,
         oore_contract::InstancePreferencesResponse,
         oore_contract::UpdateInstancePreferencesRequest,
@@ -837,6 +842,20 @@ mod paths {
     )]
     pub(super) async fn get_external_access_preflight() {}
 
+    /// Get current OIDC configuration for External Access
+    ///
+    /// Returns the current runtime OIDC provider configuration (issuer, client ID,
+    /// discovered endpoints). Never exposes the client secret.
+    #[utoipa::path(get, path = "/v1/settings/external-access/oidc", tag = "Instance Settings",
+        security(("bearer_auth" = [])),
+        responses(
+            (status = 200, description = "Current OIDC configuration", body = GetExternalAccessOidcResponse),
+            (status = 404, description = "OIDC not configured", body = ApiError),
+            (status = 409, description = "Setup not ready", body = ApiError),
+        )
+    )]
+    pub(super) async fn get_external_access_oidc() {}
+
     /// Configure OIDC for External Access
     ///
     /// Owner-only endpoint to configure runtime OIDC after setup is complete.
@@ -852,6 +871,21 @@ mod paths {
         )
     )]
     pub(super) async fn configure_external_access_oidc() {}
+
+    /// Test OIDC provider connection
+    ///
+    /// Owner-only endpoint to test OIDC provider discovery without committing changes.
+    /// Validates that the issuer URL is reachable and returns discovered endpoints.
+    #[utoipa::path(post, path = "/v1/settings/external-access/oidc/test-connection", tag = "Instance Settings",
+        request_body = TestOidcConnectionRequest,
+        security(("bearer_auth" = [])),
+        responses(
+            (status = 200, description = "Connection test succeeded", body = TestOidcConnectionResponse),
+            (status = 400, description = "Invalid input or OIDC discovery failure", body = ApiError),
+            (status = 403, description = "Owner-only operation", body = ApiError),
+        )
+    )]
+    pub(super) async fn test_oidc_connection() {}
 
     // ── Retention Policy ──
 

--- a/crates/oored/src/instance_settings.rs
+++ b/crates/oored/src/instance_settings.rs
@@ -11,8 +11,9 @@ use oore_contract::{
     ConfigureExternalAccessOidcRequest, ConfigureExternalAccessOidcResponse,
     ExternalAccessNetworkSettings, ExternalAccessNetworkSettingsResponse,
     ExternalAccessNetworkSource, ExternalAccessPreflightCheck, ExternalAccessPreflightResponse,
-    InstancePreferences, InstancePreferencesResponse, KeyStorageMode, OidcConfigRecord,
-    OidcSecretRecord, RemoteAuthMode, RuntimeMode, SetupState, TrustedProxySettingsPublic,
+    GetExternalAccessOidcResponse, InstancePreferences, InstancePreferencesResponse,
+    KeyStorageMode, OidcConfigRecord, OidcSecretRecord, RemoteAuthMode, RuntimeMode, SetupState,
+    TestOidcConnectionRequest, TestOidcConnectionResponse, TrustedProxySettingsPublic,
     TrustedProxySettingsResponse, UpdateArtifactStorageSettingsRequest,
     UpdateExternalAccessNetworkSettingsRequest, UpdateInstancePreferencesRequest,
     UpdateTrustedProxySettingsRequest,
@@ -1407,6 +1408,137 @@ pub async fn get_external_access_preflight(
     Ok(Json(result))
 }
 
+pub async fn get_external_access_oidc(
+    State(state): State<Arc<AppState>>,
+    auth: AuthUser,
+) -> ApiResult<GetExternalAccessOidcResponse> {
+    check_permission(&state.enforcer, &auth.0.role, "instance_settings", "read").await?;
+
+    let store = state.store.lock().await;
+    let sf = store.load().await.map_err(|e| {
+        error!(error = %e, "failed to load setup state for External Access OIDC read");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to load setup state",
+        )
+    })?;
+
+    if sf.setup_state != SetupState::Ready {
+        return Err(api_err(
+            StatusCode::CONFLICT,
+            "invalid_state",
+            "External Access OIDC settings are only available after setup is ready",
+        ));
+    }
+
+    let oidc = sf.oidc_config.ok_or_else(|| {
+        api_err(
+            StatusCode::NOT_FOUND,
+            "oidc_not_configured",
+            "No OIDC provider is configured",
+        )
+    })?;
+
+    Ok(Json(GetExternalAccessOidcResponse {
+        issuer_url: oidc.issuer_url,
+        client_id: oidc.client_id,
+        has_client_secret: oidc.has_client_secret,
+        authorization_endpoint: oidc.authorization_endpoint,
+        token_endpoint: oidc.token_endpoint,
+        userinfo_endpoint: oidc.userinfo_endpoint,
+        jwks_uri: oidc.jwks_uri,
+        configured_at: oidc.configured_at,
+    }))
+}
+
+pub async fn test_oidc_connection(
+    State(state): State<Arc<AppState>>,
+    auth: AuthUser,
+    Json(req): Json<TestOidcConnectionRequest>,
+) -> ApiResult<TestOidcConnectionResponse> {
+    check_permission(&state.enforcer, &auth.0.role, "instance_settings", "write").await?;
+
+    if auth.0.role != "owner" {
+        return Err(api_err(
+            StatusCode::FORBIDDEN,
+            "external_access_owner_required",
+            "Only the owner can test OIDC connections",
+        ));
+    }
+
+    let issuer_url = req.issuer_url.trim();
+    if issuer_url.is_empty() || issuer_url.len() > 2048 {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "invalid_input",
+            "issuer_url must be between 1 and 2048 characters",
+        ));
+    }
+    if url::Url::parse(issuer_url).is_err() {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "invalid_input",
+            "issuer_url is not a valid URL",
+        ));
+    }
+
+    let discovered = {
+        #[cfg(any(test, feature = "test-support"))]
+        {
+            if state.skip_oidc_discovery {
+                let base = issuer_url.trim_end_matches('/').to_string();
+                crate::oidc::DiscoveredProvider {
+                    issuer: issuer_url.to_string(),
+                    authorization_endpoint: format!("{base}/o/oauth2/v2/auth"),
+                    token_endpoint: format!("{base}/token"),
+                    userinfo_endpoint: Some(format!("{base}/userinfo")),
+                    jwks_uri: format!("{base}/jwks"),
+                    scopes_supported: vec![
+                        "openid".to_string(),
+                        "email".to_string(),
+                        "profile".to_string(),
+                    ],
+                }
+            } else {
+                crate::oidc::discover_provider(issuer_url)
+                    .await
+                    .map_err(|e| {
+                        error!(error = %e, "OIDC test-connection discovery failed");
+                        api_err(
+                            StatusCode::BAD_REQUEST,
+                            "oidc_discovery_failed",
+                            "Failed to discover OIDC provider",
+                        )
+                    })?
+            }
+        }
+        #[cfg(not(any(test, feature = "test-support")))]
+        {
+            crate::oidc::discover_provider(issuer_url)
+                .await
+                .map_err(|e| {
+                    error!(error = %e, "OIDC test-connection discovery failed");
+                    api_err(
+                        StatusCode::BAD_REQUEST,
+                        "oidc_discovery_failed",
+                        "Failed to discover OIDC provider",
+                    )
+                })?
+        }
+    };
+
+    Ok(Json(TestOidcConnectionResponse {
+        success: true,
+        discovered_issuer: discovered.issuer,
+        authorization_endpoint: discovered.authorization_endpoint,
+        token_endpoint: discovered.token_endpoint,
+        userinfo_endpoint: discovered.userinfo_endpoint,
+        jwks_uri: discovered.jwks_uri,
+        scopes_supported: discovered.scopes_supported,
+    }))
+}
+
 pub async fn configure_external_access_oidc(
     State(state): State<Arc<AppState>>,
     auth: AuthUser,
@@ -1586,6 +1718,13 @@ pub async fn configure_external_access_oidc(
                 "Failed to update OIDC configuration",
             )
         })?;
+    }
+
+    // Clear pending OIDC auth entries — any in-flight auth flows are now invalid
+    // because the provider config just changed.
+    {
+        let mut pending = state.pending_auth.lock().await;
+        pending.clear();
     }
 
     let details = serde_json::json!({

--- a/crates/oored/src/instance_settings.rs
+++ b/crates/oored/src/instance_settings.rs
@@ -1591,7 +1591,6 @@ pub async fn configure_external_access_oidc(
     }
 
     let now = now_unix();
-    let has_client_secret = client_secret.is_some();
 
     #[derive(Debug)]
     struct OidcConfigFromDiscovery {
@@ -1661,6 +1660,7 @@ pub async fn configure_external_access_oidc(
         store.pool().clone()
     };
 
+    let has_client_secret;
     {
         let store = state.store.lock().await;
         let mut sf = store.load().await.map_err(|e| {
@@ -1680,6 +1680,25 @@ pub async fn configure_external_access_oidc(
             ));
         }
 
+        // Update secret: if provided, encrypt and store; if omitted, preserve existing
+        if let Some(secret) = client_secret {
+            let encrypted = crypto::encrypt(&secret, &state.encryption_key).map_err(|e| {
+                error!(error = %e, "failed to encrypt External Access OIDC client secret");
+                api_err(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "encryption_error",
+                    "Failed to encrypt OIDC client secret",
+                )
+            })?;
+            sf.oidc_secret = Some(OidcSecretRecord {
+                encrypted_client_secret: encrypted,
+                stored_at: now,
+            });
+        }
+        // When client_secret is None, sf.oidc_secret retains whatever was loaded
+
+        has_client_secret = sf.oidc_secret.is_some();
+
         sf.oidc_config = Some(OidcConfigRecord {
             issuer_url: discovered.issuer.clone(),
             client_id: client_id.to_string(),
@@ -1690,23 +1709,6 @@ pub async fn configure_external_access_oidc(
             jwks_uri: discovered.jwks_uri.clone(),
             configured_at: now,
         });
-
-        sf.oidc_secret = if let Some(secret) = client_secret {
-            let encrypted = crypto::encrypt(&secret, &state.encryption_key).map_err(|e| {
-                error!(error = %e, "failed to encrypt External Access OIDC client secret");
-                api_err(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "encryption_error",
-                    "Failed to encrypt OIDC client secret",
-                )
-            })?;
-            Some(OidcSecretRecord {
-                encrypted_client_secret: encrypted,
-                stored_at: now,
-            })
-        } else {
-            None
-        };
 
         sf.updated_at = now;
 

--- a/crates/oored/src/lib.rs
+++ b/crates/oored/src/lib.rs
@@ -2098,7 +2098,12 @@ async fn build_router_inner(
         )
         .route(
             "/v1/settings/external-access/oidc",
-            axum::routing::put(instance_settings::configure_external_access_oidc),
+            get(instance_settings::get_external_access_oidc)
+                .put(instance_settings::configure_external_access_oidc),
+        )
+        .route(
+            "/v1/settings/external-access/oidc/test-connection",
+            post(instance_settings::test_oidc_connection),
         )
         // Notification channel settings
         .route(

--- a/crates/oored/tests/external_access_oidc_integration.rs
+++ b/crates/oored/tests/external_access_oidc_integration.rs
@@ -1,0 +1,327 @@
+#![cfg(feature = "test-support")]
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{self, Request, StatusCode};
+use common::{body_json, connect_pool, create_test_app, now_unix, seed_test_user};
+use tower::ServiceExt;
+
+async fn create_session_token(pool: &sqlx::SqlitePool, user_id: &str) -> String {
+    let token = oored::token::generate_session_token();
+    let hashed = oored::token::hash_token(&token);
+    let now = now_unix();
+    let expires_at = now + 86400;
+
+    sqlx::query(
+        "INSERT INTO sessions (token_hash, user_id, created_at, expires_at) VALUES (?1, ?2, ?3, ?4)",
+    )
+    .bind(&hashed)
+    .bind(user_id)
+    .bind(now)
+    .bind(expires_at)
+    .execute(pool)
+    .await
+    .expect("failed to create test session");
+
+    token
+}
+
+/// Seed the setup_state row to `ready` with OIDC config and an encrypted secret.
+async fn seed_ready_with_oidc(pool: &sqlx::SqlitePool, has_secret: bool) {
+    let now = now_unix();
+    let encrypted_secret = if has_secret {
+        Some(
+            oored::crypto::encrypt("test-client-secret", &common::TEST_ENCRYPTION_KEY)
+                .expect("failed to encrypt test secret"),
+        )
+    } else {
+        None
+    };
+
+    sqlx::query(
+        r#"UPDATE setup_state SET
+            setup_state = 'ready',
+            oidc_issuer_url = 'https://accounts.google.com',
+            oidc_client_id = 'test-client-id',
+            oidc_has_client_secret = ?1,
+            oidc_authorization_endpoint = 'https://accounts.google.com/o/oauth2/v2/auth',
+            oidc_token_endpoint = 'https://oauth2.googleapis.com/token',
+            oidc_userinfo_endpoint = 'https://openidconnect.googleapis.com/v1/userinfo',
+            oidc_jwks_uri = 'https://www.googleapis.com/oauth2/v3/certs',
+            oidc_configured_at = ?2,
+            oidc_encrypted_client_secret = ?3,
+            oidc_secret_stored_at = ?4,
+            owner_email = 'owner@example.com',
+            owner_oidc_subject = 'owner-sub',
+            owner_created_at = ?2,
+            updated_at = ?2
+        WHERE id = 1"#,
+    )
+    .bind(has_secret as i32)
+    .bind(now)
+    .bind(&encrypted_secret)
+    .bind(if has_secret { Some(now) } else { None })
+    .execute(pool)
+    .await
+    .expect("failed to seed ready state with OIDC config");
+}
+
+/// Seed the setup_state row to `ready` without OIDC config.
+async fn seed_ready_without_oidc(pool: &sqlx::SqlitePool) {
+    let now = now_unix();
+    sqlx::query(
+        r#"UPDATE setup_state SET
+            setup_state = 'ready',
+            owner_email = 'owner@example.com',
+            owner_oidc_subject = 'owner-sub',
+            owner_created_at = ?1,
+            updated_at = ?1
+        WHERE id = 1"#,
+    )
+    .bind(now)
+    .execute(pool)
+    .await
+    .expect("failed to seed ready state without OIDC");
+}
+
+// ── GET /v1/settings/external-access/oidc ───────────────────────
+
+#[tokio::test]
+async fn test_get_oidc_returns_config_with_secret() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let db_path = tmp.path().join("test.db");
+    let app = create_test_app(&db_path).await;
+    let pool = connect_pool(&db_path).await;
+
+    let owner_id = seed_test_user(&pool).await;
+    let owner_session = create_session_token(&pool, &owner_id).await;
+    seed_ready_with_oidc(&pool, true).await;
+
+    let req = Request::builder()
+        .uri("/v1/settings/external-access/oidc")
+        .method("GET")
+        .header(
+            http::header::AUTHORIZATION,
+            format!("Bearer {owner_session}"),
+        )
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let json = body_json(resp.into_body()).await;
+    assert_eq!(
+        json["issuer_url"].as_str().unwrap(),
+        "https://accounts.google.com"
+    );
+    assert_eq!(json["client_id"].as_str().unwrap(), "test-client-id");
+    assert_eq!(json["has_client_secret"].as_bool(), Some(true));
+    assert_eq!(
+        json["authorization_endpoint"].as_str().unwrap(),
+        "https://accounts.google.com/o/oauth2/v2/auth"
+    );
+    assert_eq!(
+        json["token_endpoint"].as_str().unwrap(),
+        "https://oauth2.googleapis.com/token"
+    );
+    assert_eq!(
+        json["jwks_uri"].as_str().unwrap(),
+        "https://www.googleapis.com/oauth2/v3/certs"
+    );
+    assert!(json["configured_at"].as_i64().is_some());
+}
+
+#[tokio::test]
+async fn test_get_oidc_returns_config_without_secret() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let db_path = tmp.path().join("test.db");
+    let app = create_test_app(&db_path).await;
+    let pool = connect_pool(&db_path).await;
+
+    let owner_id = seed_test_user(&pool).await;
+    let owner_session = create_session_token(&pool, &owner_id).await;
+    seed_ready_with_oidc(&pool, false).await;
+
+    let req = Request::builder()
+        .uri("/v1/settings/external-access/oidc")
+        .method("GET")
+        .header(
+            http::header::AUTHORIZATION,
+            format!("Bearer {owner_session}"),
+        )
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let json = body_json(resp.into_body()).await;
+    assert_eq!(json["has_client_secret"].as_bool(), Some(false));
+}
+
+#[tokio::test]
+async fn test_get_oidc_returns_404_when_not_configured() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let db_path = tmp.path().join("test.db");
+    let app = create_test_app(&db_path).await;
+    let pool = connect_pool(&db_path).await;
+
+    let owner_id = seed_test_user(&pool).await;
+    let owner_session = create_session_token(&pool, &owner_id).await;
+    seed_ready_without_oidc(&pool).await;
+
+    let req = Request::builder()
+        .uri("/v1/settings/external-access/oidc")
+        .method("GET")
+        .header(
+            http::header::AUTHORIZATION,
+            format!("Bearer {owner_session}"),
+        )
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    let json = body_json(resp.into_body()).await;
+    assert_eq!(json["code"].as_str().unwrap(), "oidc_not_configured");
+}
+
+#[tokio::test]
+async fn test_get_oidc_returns_conflict_before_ready() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let db_path = tmp.path().join("test.db");
+    let app = create_test_app(&db_path).await;
+    let pool = connect_pool(&db_path).await;
+
+    // Default setup_state is bootstrap_pending — do NOT advance to ready
+    let owner_id = seed_test_user(&pool).await;
+    let owner_session = create_session_token(&pool, &owner_id).await;
+
+    let req = Request::builder()
+        .uri("/v1/settings/external-access/oidc")
+        .method("GET")
+        .header(
+            http::header::AUTHORIZATION,
+            format!("Bearer {owner_session}"),
+        )
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+
+    let json = body_json(resp.into_body()).await;
+    assert_eq!(json["code"].as_str().unwrap(), "invalid_state");
+}
+
+#[tokio::test]
+async fn test_developer_cannot_read_oidc_config() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let db_path = tmp.path().join("test.db");
+    let app = create_test_app(&db_path).await;
+    let pool = connect_pool(&db_path).await;
+
+    seed_ready_with_oidc(&pool, true).await;
+
+    let now = now_unix();
+    let user_id = uuid::Uuid::new_v4().to_string();
+    sqlx::query(
+        "INSERT INTO users (id, email, oidc_subject, display_name, role, status, created_at, updated_at) \
+         VALUES (?1, 'dev@example.com', 'dev-sub', 'Dev', 'developer', 'active', ?2, ?2)",
+    )
+    .bind(&user_id)
+    .bind(now)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let token = create_session_token(&pool, &user_id).await;
+
+    let req = Request::builder()
+        .uri("/v1/settings/external-access/oidc")
+        .method("GET")
+        .header(http::header::AUTHORIZATION, format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+// ── PUT /v1/settings/external-access/oidc (configure) ───────────
+
+#[tokio::test]
+async fn test_configure_oidc_rejects_before_ready() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let db_path = tmp.path().join("test.db");
+    let app = create_test_app(&db_path).await;
+    let pool = connect_pool(&db_path).await;
+
+    let owner_id = seed_test_user(&pool).await;
+    let owner_session = create_session_token(&pool, &owner_id).await;
+
+    let body = serde_json::json!({
+        "issuer_url": "https://accounts.google.com",
+        "client_id": "my-client-id",
+    });
+
+    let req = Request::builder()
+        .uri("/v1/settings/external-access/oidc")
+        .method("PUT")
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .header(
+            http::header::AUTHORIZATION,
+            format!("Bearer {owner_session}"),
+        )
+        .body(Body::from(serde_json::to_string(&body).unwrap()))
+        .unwrap();
+
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+
+    let json = body_json(resp.into_body()).await;
+    assert_eq!(json["code"].as_str().unwrap(), "invalid_state");
+}
+
+#[tokio::test]
+async fn test_developer_cannot_configure_oidc() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let db_path = tmp.path().join("test.db");
+    let app = create_test_app(&db_path).await;
+    let pool = connect_pool(&db_path).await;
+
+    seed_ready_with_oidc(&pool, false).await;
+
+    let now = now_unix();
+    let user_id = uuid::Uuid::new_v4().to_string();
+    sqlx::query(
+        "INSERT INTO users (id, email, oidc_subject, display_name, role, status, created_at, updated_at) \
+         VALUES (?1, 'dev@example.com', 'dev-sub', 'Dev', 'developer', 'active', ?2, ?2)",
+    )
+    .bind(&user_id)
+    .bind(now)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let token = create_session_token(&pool, &user_id).await;
+
+    let body = serde_json::json!({
+        "issuer_url": "https://accounts.google.com",
+        "client_id": "my-client-id",
+    });
+
+    let req = Request::builder()
+        .uri("/v1/settings/external-access/oidc")
+        .method("PUT")
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .header(http::header::AUTHORIZATION, format!("Bearer {token}"))
+        .body(Body::from(serde_json::to_string(&body).unwrap()))
+        .unwrap();
+
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -12,6 +12,14 @@ Rules:
 
 ## 2026-03-19
 
+- **SSO/OIDC provider management post-setup** ([OOR-141](https://linear.app/oorebuild/issue/OOR-141/ssooidc-provider-management-post-setup)):
+  - Added `GET /v1/settings/external-access/oidc` endpoint to read current OIDC provider config (issuer, client ID, endpoints, configured_at). Never exposes client secret.
+  - Added `POST /v1/settings/external-access/oidc/test-connection` endpoint for dry-run OIDC discovery validation without committing changes.
+  - Fixed bug: `PUT /v1/settings/external-access/oidc` now clears pending auth entries on reconfigure, invalidating stale in-flight OIDC flows.
+  - Frontend: OIDC identity card now displays current provider info (issuer, client ID, secret status).
+  - Frontend: OIDC reconfigure dialog pre-populates from current config and includes "Test Connection" button.
+  - Updated OpenAPI spec with new endpoints.
+
 - **Documentation & CI maintenance fixes**:
   - CI: Reverted `actions/checkout@v4` back to `v6` in `validate.yml` for latest performance/security.
   - Docs: Updated clean-reinstall guide to provide robust macOS paths as primary instruction (no `jq` dependency).


### PR DESCRIPTION
## What

Adds post-setup OIDC provider management: a GET endpoint to read current config, a test-connection endpoint for dry-run discovery, and an enhanced frontend UI. Also fixes a bug where reconfiguring the OIDC provider didn't clear stale in-flight auth flows.

## Why

From UX audit: after initial setup there was no way to view, validate, or rotate OIDC credentials without backend intervention. Closes [OOR-141](https://linear.app/oorebuild/issue/OOR-141/ssooidc-provider-management-post-setup).

## Testing

- `make validate` passes (cargo-check, lint-web, vitest, docs-check, builds)
- MSW handlers added for both new endpoints to support demo/test mode

## Docs

- `docs/changes.md` updated with OOR-141 entry
- OpenAPI spec regenerated (`make gen-openapi`)