### PR TITLE
feat(runners): health monitoring, status endpoint, and offline alerts

### DIFF
--- a/apps/docs-site/docs/public/openapi.json
+++ b/apps/docs-site/docs/public/openapi.json
@@ -2827,6 +2827,52 @@
       }
     },
     "/v1/runners/{runner_id}": {
+      "get": {
+        "tags": [
+          "Runners"
+        ],
+        "summary": "Get runner",
+        "description": "Retrieves a single runner by ID, including its current status and health information.",
+        "operationId": "get_runner",
+        "parameters": [
+          {
+            "name": "runner_id",
+            "in": "path",
+            "description": "Runner ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Runner details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateRunnerResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Runner not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      },
       "patch": {
         "tags": [
           "Runners"

--- a/apps/docs-site/docs/public/openapi.json
+++ b/apps/docs-site/docs/public/openapi.json
@@ -7440,7 +7440,6 @@
         "required": [
           "id",
           "channel_id",
-          "build_id",
           "event_type",
           "status",
           "attempt_count",
@@ -7452,7 +7451,10 @@
             "format": "int64"
           },
           "build_id": {
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "channel_id": {
             "type": "string"

--- a/apps/web/src/hooks/use-runners.ts
+++ b/apps/web/src/hooks/use-runners.ts
@@ -27,6 +27,7 @@ export function useRunners() {
     queryKey: [instance?.id ?? '__none__', 'runners'],
     queryFn: () => listRunners(baseUrl!, token!),
     enabled: !!baseUrl && !!token,
+    refetchInterval: 15_000,
   })
 }
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -621,6 +621,16 @@ export function listRunners(
   })
 }
 
+export function getRunner(
+  baseUrl: string,
+  token: string,
+  runnerId: string,
+): Promise<UpdateRunnerResponse> {
+  return request<UpdateRunnerResponse>(baseUrl, `/v1/runners/${runnerId}`, {
+    headers: authHeaders(token),
+  })
+}
+
 export function updateRunner(
   baseUrl: string,
   token: string,

--- a/apps/web/src/routes/settings/runners.tsx
+++ b/apps/web/src/routes/settings/runners.tsx
@@ -76,6 +76,29 @@ function formatRelativeTime(epochSeconds?: number): string {
   return `${days}d ago`
 }
 
+function getHeartbeatStaleness(epochSeconds?: number): 'fresh' | 'stale' | 'none' {
+  if (!epochSeconds) return 'none'
+  const diffSecs = Math.floor(Date.now() / 1000) - epochSeconds
+  if (diffSecs > 60) return 'stale'
+  return 'fresh'
+}
+
+function StatusDot({ status }: { status: string }) {
+  if (status === 'online' || status === 'busy') {
+    return (
+      <span className="relative mr-2 inline-flex size-2">
+        <span className="bg-success absolute inline-flex size-full animate-ping rounded-full opacity-75" />
+        <span className="bg-success relative inline-flex size-2 rounded-full" />
+      </span>
+    )
+  }
+  if (status === 'offline') {
+    return <span className="bg-destructive mr-2 inline-flex size-2 rounded-full" />
+  }
+  // draining
+  return <span className="bg-warning mr-2 inline-flex size-2 rounded-full" />
+}
+
 function formatCapabilities(capabilities: Runner['capabilities']): string {
   const entries = Object.entries(capabilities)
   if (entries.length === 0) return 'none'
@@ -225,13 +248,17 @@ function RunnersSettingsPage() {
       ).length,
     [runners],
   )
+  const offlineCount = useMemo(
+    () => runners.filter((runner) => runner.status === 'offline').length,
+    [runners],
+  )
 
   return (
     <PageLayout width="wide">
       <PageMeta title="Runner Management" noindex />
       <PageHeader
         title="Runners"
-        description="Runner health and metadata management for this instance."
+        description="Runner health and metadata management. Auto-refreshes every 15s."
       />
 
       <section className="grid gap-4 md:grid-cols-3">
@@ -268,12 +295,19 @@ function RunnersSettingsPage() {
         </Card>
         <Card>
           <CardContent>
-            <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Rename policy
+            <div className="flex items-center justify-between">
+              <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Offline runners
+              </p>
+              {offlineCount > 0 ? (
+                <Badge variant="destructive">{offlineCount}</Badge>
+              ) : null}
+            </div>
+            <p className="mt-3 text-2xl font-bold tracking-tight">
+              {offlineCount}
             </p>
-            <p className="mt-3 text-sm font-bold">External only</p>
             <p className="mt-1 text-xs text-muted-foreground">
-              Embedded runners stay daemon-managed
+              Unreachable or stopped
             </p>
           </CardContent>
         </Card>
@@ -334,13 +368,23 @@ function RunnersSettingsPage() {
                           </p>
                         </TableCell>
                         <TableCell>
-                          <Badge
-                            variant={getRunnerStatusVariant(runner.status)}
-                          >
-                            {runner.status}
-                          </Badge>
+                          <div className="flex items-center">
+                            <StatusDot status={runner.status} />
+                            <Badge
+                              variant={getRunnerStatusVariant(runner.status)}
+                            >
+                              {runner.status}
+                            </Badge>
+                          </div>
                         </TableCell>
-                        <TableCell className="text-muted-foreground">
+                        <TableCell
+                          className={
+                            getHeartbeatStaleness(runner.last_heartbeat_at) ===
+                              'stale' && runner.status !== 'offline'
+                              ? 'text-warning'
+                              : 'text-muted-foreground'
+                          }
+                        >
                           {formatRelativeTime(runner.last_heartbeat_at)}
                         </TableCell>
                         <TableCell className="text-xs text-muted-foreground">

--- a/crates/oore-contract/src/lib.rs
+++ b/crates/oore-contract/src/lib.rs
@@ -2682,7 +2682,8 @@ pub struct TestNotificationChannelResponse {
 pub struct NotificationDelivery {
     pub id: String,
     pub channel_id: String,
-    pub build_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build_id: Option<String>,
     pub event_type: String,
     pub status: NotificationDeliveryStatus,
     pub attempt_count: i64,

--- a/crates/oored/migrations/022_runner_notification_deliveries.sql
+++ b/crates/oored/migrations/022_runner_notification_deliveries.sql
@@ -1,0 +1,35 @@
+-- Extend notification_deliveries to support runner events.
+-- Adds runner_id and event_category columns, and makes build_id nullable
+-- since runner events don't reference a build.
+
+-- SQLite doesn't support ALTER COLUMN, so we recreate the table.
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE notification_deliveries_new (
+    id TEXT PRIMARY KEY,
+    channel_id TEXT NOT NULL REFERENCES notification_channels(id) ON DELETE CASCADE,
+    build_id TEXT REFERENCES builds(id) ON DELETE CASCADE,
+    runner_id TEXT,
+    event_type TEXT NOT NULL,
+    event_category TEXT NOT NULL DEFAULT 'build',
+    status TEXT NOT NULL CHECK (status IN ('pending', 'delivered', 'failed')),
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+    created_at INTEGER NOT NULL,
+    delivered_at INTEGER
+);
+
+INSERT INTO notification_deliveries_new
+    (id, channel_id, build_id, event_type, event_category, status, attempt_count, last_error, created_at, delivered_at)
+SELECT id, channel_id, build_id, event_type, 'build', status, attempt_count, last_error, created_at, delivered_at
+FROM notification_deliveries;
+
+DROP TABLE notification_deliveries;
+ALTER TABLE notification_deliveries_new RENAME TO notification_deliveries;
+
+CREATE INDEX idx_notification_deliveries_channel ON notification_deliveries(channel_id);
+CREATE INDEX idx_notification_deliveries_build ON notification_deliveries(build_id);
+CREATE INDEX idx_notification_deliveries_status ON notification_deliveries(status);
+CREATE INDEX idx_notification_deliveries_runner ON notification_deliveries(runner_id);
+
+PRAGMA foreign_keys=ON;

--- a/crates/oored/src/background.rs
+++ b/crates/oored/src/background.rs
@@ -12,7 +12,7 @@ use tokio::sync::RwLock;
 use tracing::{error, info, warn};
 
 use crate::retention::load_global_policy;
-use crate::scheduler::{BuildStateEvent, Scheduler};
+use crate::scheduler::{BuildStateEvent, RunnerStateEvent, Scheduler};
 use crate::storage::StorageBackend;
 use crate::store::write_audit_log;
 use crate::util::now_unix;
@@ -33,8 +33,8 @@ pub fn start_background_tasks(
     storage: Arc<RwLock<StorageBackend>>,
 ) {
     tokio::spawn(lease_timeout_monitor(pool.clone()));
-    tokio::spawn(build_timeout_monitor(pool.clone(), scheduler));
-    tokio::spawn(runner_heartbeat_monitor(pool.clone()));
+    tokio::spawn(build_timeout_monitor(pool.clone(), scheduler.clone()));
+    tokio::spawn(runner_heartbeat_monitor(pool.clone(), scheduler));
     tokio::spawn(retention_cleanup_monitor(pool, storage));
 }
 
@@ -158,7 +158,7 @@ async fn build_timeout_monitor(pool: SqlitePool, scheduler: Arc<Scheduler>) {
 /// Runs every 60 seconds. Finds runners with status 'online', 'busy', or
 /// 'draining' whose last_heartbeat_at is older than HEARTBEAT_STALE_SECS
 /// and updates their status to 'offline'.
-async fn runner_heartbeat_monitor(pool: SqlitePool) {
+async fn runner_heartbeat_monitor(pool: SqlitePool, scheduler: Arc<Scheduler>) {
     loop {
         tokio::time::sleep(Duration::from_secs(60)).await;
 
@@ -200,6 +200,14 @@ async fn runner_heartbeat_monitor(pool: SqlitePool) {
                             prev_status = %prev_status,
                             "runner_heartbeat_monitor: marked runner as offline (stale heartbeat)"
                         );
+
+                        scheduler.publish_runner_event(RunnerStateEvent {
+                            runner_id: runner_id.clone(),
+                            runner_name: runner_name.clone(),
+                            from_status: prev_status.clone(),
+                            to_status: "offline".to_string(),
+                            timestamp: now,
+                        });
                     }
                 }
                 Err(e) => {

--- a/crates/oored/src/bin/openapi_export.rs
+++ b/crates/oored/src/bin/openapi_export.rs
@@ -123,6 +123,7 @@ use utoipa::OpenApi;
         // ── Runners ──
         paths::register_runner,
         paths::list_runners,
+        paths::get_runner,
         paths::update_runner,
         paths::runner_heartbeat,
         paths::claim_job,
@@ -1453,6 +1454,19 @@ mod paths {
         )
     )]
     pub(super) async fn list_runners() {}
+
+    /// Get runner
+    ///
+    /// Retrieves a single runner by ID, including its current status and health information.
+    #[utoipa::path(get, path = "/v1/runners/{runner_id}", tag = "Runners",
+        params(("runner_id" = String, Path, description = "Runner ID")),
+        security(("bearer_auth" = [])),
+        responses(
+            (status = 200, description = "Runner details", body = UpdateRunnerResponse),
+            (status = 404, description = "Runner not found", body = ApiError),
+        )
+    )]
+    pub(super) async fn get_runner() {}
 
     /// Update runner
     #[utoipa::path(patch, path = "/v1/runners/{runner_id}", tag = "Runners",

--- a/crates/oored/src/lib.rs
+++ b/crates/oored/src/lib.rs
@@ -2238,7 +2238,7 @@ async fn build_router_inner(
         .route("/v1/runners/register", post(runners::register_runner))
         .route(
             "/v1/runners/{runner_id}",
-            axum::routing::patch(runners::update_runner),
+            get(runners::get_runner).patch(runners::update_runner),
         )
         .route(
             "/v1/runners/{runner_id}/heartbeat",

--- a/crates/oored/src/notification_channels.rs
+++ b/crates/oored/src/notification_channels.rs
@@ -64,7 +64,7 @@ fn row_to_delivery(row: &sqlx::sqlite::SqliteRow) -> NotificationDelivery {
     NotificationDelivery {
         id: row.get("id"),
         channel_id: row.get("channel_id"),
-        build_id: row.get("build_id"),
+        build_id: row.try_get("build_id").ok().flatten(),
         event_type: row.get("event_type"),
         status,
         attempt_count: row.get("attempt_count"),
@@ -76,7 +76,7 @@ fn row_to_delivery(row: &sqlx::sqlite::SqliteRow) -> NotificationDelivery {
 
 // ── Validation ──────────────────────────────────────────────────
 
-const VALID_EVENTS: &[&str] = &["succeeded", "failed", "canceled", "timed_out", "expired"];
+const VALID_EVENTS: &[&str] = &["succeeded", "failed", "canceled", "timed_out", "expired", "runner_offline"];
 
 fn validate_events(events: &[String]) -> Result<(), (StatusCode, Json<ApiError>)> {
     for event in events {

--- a/crates/oored/src/notification_channels.rs
+++ b/crates/oored/src/notification_channels.rs
@@ -76,7 +76,14 @@ fn row_to_delivery(row: &sqlx::sqlite::SqliteRow) -> NotificationDelivery {
 
 // ── Validation ──────────────────────────────────────────────────
 
-const VALID_EVENTS: &[&str] = &["succeeded", "failed", "canceled", "timed_out", "expired", "runner_offline"];
+const VALID_EVENTS: &[&str] = &[
+    "succeeded",
+    "failed",
+    "canceled",
+    "timed_out",
+    "expired",
+    "runner_offline",
+];
 
 fn validate_events(events: &[String]) -> Result<(), (StatusCode, Json<ApiError>)> {
     for event in events {

--- a/crates/oored/src/notification_dispatch.rs
+++ b/crates/oored/src/notification_dispatch.rs
@@ -1,7 +1,8 @@
 //! Background notification dispatch worker.
 //!
-//! Subscribes to `BuildStateEvent` broadcast channel and dispatches notifications
-//! to configured channels when builds reach terminal states.
+//! Subscribes to `BuildStateEvent` and `RunnerStateEvent` broadcast channels and
+//! dispatches notifications to configured channels when builds reach terminal
+//! states or runners go offline.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -13,7 +14,7 @@ use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use crate::crypto;
-use crate::scheduler::{BuildStateEvent, Scheduler};
+use crate::scheduler::{BuildStateEvent, RunnerStateEvent, Scheduler};
 use crate::util::now_unix;
 
 /// Terminal build statuses that trigger notifications.
@@ -25,20 +26,23 @@ pub fn start_notification_dispatcher(
     scheduler: Arc<Scheduler>,
     encryption_key: Vec<u8>,
 ) {
+    // Build event dispatcher
+    let build_pool = pool.clone();
+    let build_key = encryption_key.clone();
+    let mut build_rx = scheduler.subscribe_events();
     tokio::spawn(async move {
-        let mut rx = scheduler.subscribe_events();
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(30))
             .build()
             .unwrap_or_else(|_| reqwest::Client::new());
 
         loop {
-            match rx.recv().await {
+            match build_rx.recv().await {
                 Ok(event) => {
                     if !TERMINAL_STATUSES.contains(&event.to_status.as_str()) {
                         continue;
                     }
-                    if let Err(e) = dispatch_event(&pool, &client, &encryption_key, &event).await {
+                    if let Err(e) = dispatch_event(&build_pool, &client, &build_key, &event).await {
                         error!(error = %e, build_id = %event.build_id, "notification dispatch error");
                     }
                 }
@@ -50,6 +54,44 @@ pub fn start_notification_dispatcher(
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                     info!("notification event bus closed, stopping dispatcher");
+                    break;
+                }
+            }
+        }
+    });
+
+    // Runner event dispatcher
+    let mut runner_rx = scheduler.subscribe_runner_events();
+    tokio::spawn(async move {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+
+        loop {
+            match runner_rx.recv().await {
+                Ok(event) => {
+                    if event.to_status != "offline" {
+                        continue;
+                    }
+                    if let Err(e) =
+                        dispatch_runner_event(&pool, &client, &encryption_key, &event).await
+                    {
+                        error!(
+                            error = %e,
+                            runner_id = %event.runner_id,
+                            "runner notification dispatch error"
+                        );
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    warn!(
+                        missed = n,
+                        "runner notification dispatcher lagged behind event bus"
+                    );
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    info!("runner event bus closed, stopping dispatcher");
                     break;
                 }
             }
@@ -210,6 +252,175 @@ async fn dispatch_event(
     Ok(())
 }
 
+/// Dispatch notifications for a runner state event (e.g. runner going offline).
+async fn dispatch_runner_event(
+    pool: &SqlitePool,
+    client: &reqwest::Client,
+    encryption_key: &[u8],
+    event: &RunnerStateEvent,
+) -> anyhow::Result<()> {
+    let channels = sqlx::query("SELECT * FROM notification_channels WHERE enabled = 1")
+        .fetch_all(pool)
+        .await?;
+
+    if channels.is_empty() {
+        return Ok(());
+    }
+
+    let payload = runner_notification_payload(event);
+    let event_type = "runner_offline";
+
+    for channel_row in &channels {
+        let channel_id: String = channel_row.get("id");
+        let channel_type_str: String = channel_row.get("channel_type");
+        let channel_name: String = channel_row.get("name");
+
+        // Check event filter — runner_offline must be in the filter list (or filter must be empty)
+        let event_filter_json: Option<String> = channel_row.get("event_filter_json");
+        if let Some(ref filter_json) = event_filter_json {
+            let filters: Vec<String> = serde_json::from_str(filter_json).unwrap_or_default();
+            if !filters.is_empty() && !filters.contains(&event_type.to_string()) {
+                continue;
+            }
+        }
+
+        let encrypted_url: Option<String> = channel_row.get("encrypted_url");
+        let encrypted_secret: Option<String> = channel_row.get("encrypted_secret");
+
+        let url = match encrypted_url
+            .as_deref()
+            .map(|eu| crypto::decrypt(eu, encryption_key))
+            .transpose()
+        {
+            Ok(Some(u)) => u,
+            Ok(None) => continue,
+            Err(e) => {
+                error!(channel_id = %channel_id, error = %e, "failed to decrypt channel URL");
+                continue;
+            }
+        };
+
+        let secret = match encrypted_secret
+            .as_deref()
+            .map(|es| crypto::decrypt(es, encryption_key))
+            .transpose()
+        {
+            Ok(s) => s,
+            Err(e) => {
+                error!(channel_id = %channel_id, error = %e, "failed to decrypt HMAC secret");
+                continue;
+            }
+        };
+
+        let channel_type = channel_type_str
+            .parse::<NotificationChannelType>()
+            .unwrap_or(NotificationChannelType::Webhook);
+
+        // Insert delivery record (build_id is NULL for runner events)
+        let delivery_id = Uuid::new_v4().to_string();
+        let now = now_unix();
+        let _ = sqlx::query(
+            "INSERT INTO notification_deliveries \
+             (id, channel_id, event_type, status, attempt_count, created_at, runner_id, event_category) \
+             VALUES (?1, ?2, ?3, 'pending', 0, ?4, ?5, 'runner')",
+        )
+        .bind(&delivery_id)
+        .bind(&channel_id)
+        .bind(event_type)
+        .bind(now)
+        .bind(&event.runner_id)
+        .execute(pool)
+        .await;
+
+        // For Mattermost channels, use the runner-specific message format
+        let effective_payload = match channel_type {
+            NotificationChannelType::Mattermost => runner_mattermost_payload(&payload),
+            NotificationChannelType::Webhook => payload.clone(),
+        };
+
+        let result = send_raw_payload(
+            client,
+            &url,
+            secret.as_deref(),
+            channel_type,
+            &effective_payload,
+        )
+        .await;
+
+        match result {
+            Ok(()) => {
+                let delivered_at = now_unix();
+                let _ = sqlx::query(
+                    "UPDATE notification_deliveries \
+                     SET status = 'delivered', attempt_count = 1, delivered_at = ?1 \
+                     WHERE id = ?2",
+                )
+                .bind(delivered_at)
+                .bind(&delivery_id)
+                .execute(pool)
+                .await;
+                info!(
+                    channel_id = %channel_id,
+                    channel_name = %channel_name,
+                    runner_id = %event.runner_id,
+                    "runner offline notification delivered"
+                );
+            }
+            Err(e) => {
+                let error_msg = e.to_string();
+                let _ = sqlx::query(
+                    "UPDATE notification_deliveries \
+                     SET status = 'failed', attempt_count = 1, last_error = ?1 \
+                     WHERE id = ?2",
+                )
+                .bind(&error_msg)
+                .bind(&delivery_id)
+                .execute(pool)
+                .await;
+                warn!(
+                    channel_id = %channel_id,
+                    channel_name = %channel_name,
+                    runner_id = %event.runner_id,
+                    error = %error_msg,
+                    "runner offline notification delivery failed"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Build the JSON notification payload for a runner state event.
+fn runner_notification_payload(event: &RunnerStateEvent) -> serde_json::Value {
+    serde_json::json!({
+        "event": format!("runner.{}", event.to_status),
+        "runner": {
+            "id": event.runner_id,
+            "name": event.runner_name,
+            "from_status": event.from_status,
+            "to_status": event.to_status,
+        },
+        "timestamp": event.timestamp,
+    })
+}
+
+/// Build a Mattermost/Slack-compatible message for a runner event.
+fn runner_mattermost_payload(payload: &serde_json::Value) -> serde_json::Value {
+    let runner_name = payload["runner"]["name"].as_str().unwrap_or("Unknown");
+    let from_status = payload["runner"]["from_status"]
+        .as_str()
+        .unwrap_or("unknown");
+
+    let text = format!(":warning: Runner **{runner_name}** went offline (was {from_status})");
+
+    serde_json::json!({
+        "text": text,
+        "username": "Oore CI",
+        "icon_url": "https://static.oore.build/logo-avatar-192.png",
+    })
+}
+
 /// Build the JSON notification payload from a build row.
 fn build_notification_payload(
     row: &sqlx::sqlite::SqliteRow,
@@ -305,7 +516,9 @@ pub async fn send_notification(
     send_notification_with_client(&client, url, secret, channel_type, payload).await
 }
 
-/// Send a notification using a provided reqwest client.
+/// Send a build notification using a provided reqwest client.
+///
+/// Transforms the payload for Mattermost channels automatically.
 async fn send_notification_with_client(
     client: &reqwest::Client,
     url: &str,
@@ -317,8 +530,18 @@ async fn send_notification_with_client(
         NotificationChannelType::Webhook => payload.clone(),
         NotificationChannelType::Mattermost => build_mattermost_payload(payload),
     };
+    send_raw_payload(client, url, secret, channel_type, &body).await
+}
 
-    let body_bytes = serde_json::to_vec(&body)?;
+/// Send a pre-formatted payload to a notification channel.
+async fn send_raw_payload(
+    client: &reqwest::Client,
+    url: &str,
+    secret: Option<&str>,
+    channel_type: NotificationChannelType,
+    body: &serde_json::Value,
+) -> anyhow::Result<()> {
+    let body_bytes = serde_json::to_vec(body)?;
 
     let mut request = client
         .post(url)

--- a/crates/oored/src/runners.rs
+++ b/crates/oored/src/runners.rs
@@ -576,6 +576,36 @@ pub async fn get_job_status(
     Ok(Json(JobStatusResponse { status }))
 }
 
+/// `GET /v1/runners/{runner_id}` — get a single runner (admin/owner only).
+pub async fn get_runner(
+    State(state): State<Arc<AppState>>,
+    auth: AuthUser,
+    Path(runner_id): Path<String>,
+) -> ApiResult<UpdateRunnerResponse> {
+    check_permission(&state.enforcer, &auth.0.role, "runners", "read").await?;
+
+    let store = state.store.lock().await;
+    let pool = store.pool();
+
+    let row = sqlx::query("SELECT * FROM runners WHERE id = ?1")
+        .bind(&runner_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| {
+            error!(error = %e, runner_id = %runner_id, "failed to fetch runner");
+            api_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "store_error",
+                "Failed to fetch runner",
+            )
+        })?
+        .ok_or_else(|| api_err(StatusCode::NOT_FOUND, "not_found", "Runner not found"))?;
+
+    Ok(Json(UpdateRunnerResponse {
+        runner: row_to_runner(&row),
+    }))
+}
+
 /// `GET /v1/runners` — list all runners (admin/owner only).
 pub async fn list_runners(
     State(state): State<Arc<AppState>>,

--- a/crates/oored/src/scheduler.rs
+++ b/crates/oored/src/scheduler.rs
@@ -35,20 +35,35 @@ pub struct BuildStateEvent {
     pub timestamp: i64,
 }
 
-/// Central scheduler managing the build event bus.
+/// A runner state change event broadcast to all subscribers.
+#[derive(Debug, Clone)]
+pub struct RunnerStateEvent {
+    pub runner_id: String,
+    pub runner_name: String,
+    pub from_status: String,
+    pub to_status: String,
+    pub timestamp: i64,
+}
+
+/// Central scheduler managing the build and runner event buses.
 ///
 /// Job dispatch uses SQLite directly (via `runners::claim_job`) with optimistic
-/// locking to prevent double-claims. The broadcast channel provides fan-out of
-/// build state change events for SSE subscribers (Phase 4).
+/// locking to prevent double-claims. The broadcast channels provide fan-out of
+/// state change events for SSE subscribers and notification dispatch.
 pub struct Scheduler {
     event_tx: broadcast::Sender<BuildStateEvent>,
+    runner_event_tx: broadcast::Sender<RunnerStateEvent>,
 }
 
 impl Scheduler {
     /// Create a new scheduler with the given event bus capacity.
     pub fn new(capacity: usize) -> Arc<Self> {
         let (event_tx, _) = broadcast::channel(capacity);
-        Arc::new(Self { event_tx })
+        let (runner_event_tx, _) = broadcast::channel(16);
+        Arc::new(Self {
+            event_tx,
+            runner_event_tx,
+        })
     }
 
     /// Subscribe to build state events.
@@ -60,6 +75,16 @@ impl Scheduler {
     pub fn publish_event(&self, event: BuildStateEvent) {
         // Ignore send errors (no active subscribers is OK)
         let _ = self.event_tx.send(event);
+    }
+
+    /// Subscribe to runner state events.
+    pub fn subscribe_runner_events(&self) -> broadcast::Receiver<RunnerStateEvent> {
+        self.runner_event_tx.subscribe()
+    }
+
+    /// Publish a runner state event to all subscribers.
+    pub fn publish_runner_event(&self, event: RunnerStateEvent) {
+        let _ = self.runner_event_tx.send(event);
     }
 
     /// Recover stale builds on daemon startup.

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -12,6 +12,17 @@ Rules:
 
 ## 2026-03-19
 
+- **Runner health monitoring and status endpoint (OOR-142)**:
+  - Backend: Added `GET /v1/runners/{runner_id}` endpoint for individual runner details.
+  - Backend: Added `RunnerStateEvent` broadcast channel to emit events when runners go offline.
+  - Backend: Notification dispatch now sends runner offline alerts to configured notification channels.
+  - Backend: DB migration `022` extends `notification_deliveries` for runner event tracking (`runner_id`, `event_category`).
+  - Frontend: Runner status dashboard now auto-refreshes every 15s via `refetchInterval`.
+  - Frontend: Replaced "Rename policy" stat card with "Offline runners" count card with destructive badge.
+  - Frontend: Added pulsing status dot indicators and stale heartbeat (>60s) warning highlighting.
+  - OpenAPI spec updated with new `GET /v1/runners/{runner_id}` endpoint.
+  - Linear: https://linear.app/oorebuild/issue/OOR-142/runner-health-monitoring-and-status-endpoint
+
 - **Documentation & CI maintenance fixes**:
   - CI: Reverted `actions/checkout@v4` back to `v6` in `validate.yml` for latest performance/security.
   - Docs: Updated clean-reinstall guide to provide robust macOS paths as primary instruction (no `jq` dependency).


### PR DESCRIPTION
## What

Implements OOR-142: runner health monitoring and status endpoint. Adds a `GET /v1/runners/{runner_id}` endpoint, runner offline event broadcasting with notification dispatch, a DB migration extending `notification_deliveries` for runner events, and a live-polling runner status dashboard on the frontend.

## Why

Admins had no way to see if a runner was offline or degraded — the heartbeat monitor silently updated the DB with no alerts or live UI feedback. Fixes [OOR-142](https://linear.app/oorebuild/issue/OOR-142/runner-health-monitoring-and-status-endpoint).

## Testing

- `make validate` passes (lint, build, cargo-check, docs-check)
- `make test-rust` — 18/18 tests pass
- `make test-web` — 91/91 tests pass
- `make clippy-rust` — clean
- `make gen-openapi` — spec regenerated and committed

## Docs

- `docs/changes.md` updated with OOR-142 entry
- OpenAPI spec regenerated at `apps/docs-site/docs/public/openapi.json`