### PR TITLE
feat(oor-140): artifact expiry and scoped download tokens

### DIFF
--- a/apps/docs-site/docs/public/openapi.json
+++ b/apps/docs-site/docs/public/openapi.json
@@ -219,6 +219,100 @@
         ]
       }
     },
+    "/v1/artifact-tokens/{token_id}": {
+      "delete": {
+        "tags": [
+          "Scoped Download Tokens"
+        ],
+        "summary": "Revoke scoped download token",
+        "description": "Revokes a scoped download token so it can no longer be used.",
+        "operationId": "revoke_scoped_download_token",
+        "parameters": [
+          {
+            "name": "token_id",
+            "in": "path",
+            "description": "Download token ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Token revoked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RevokeArtifactDownloadTokenResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Token not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/v1/artifacts/dl/{token}": {
+      "get": {
+        "tags": [
+          "Scoped Download Tokens"
+        ],
+        "summary": "Download via scoped token",
+        "description": "Downloads an artifact using a scoped download token. No session auth required —\nthe token itself is the authorization. For S3/R2 storage, redirects to a presigned URL.",
+        "operationId": "download_via_scoped_token",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "path",
+            "description": "Scoped download token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Redirect to presigned download URL"
+          },
+          "401": {
+            "description": "Invalid or expired token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Artifact expired",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/artifacts/{artifact_id}/download-link": {
       "post": {
         "tags": [
@@ -255,6 +349,112 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/v1/artifacts/{artifact_id}/scoped-token": {
+      "post": {
+        "tags": [
+          "Scoped Download Tokens"
+        ],
+        "summary": "Create scoped download token",
+        "description": "Generates a scoped, time-limited download token for a specific artifact.\nThe token can be shared with external users who don't have an account.",
+        "operationId": "create_scoped_download_token",
+        "parameters": [
+          {
+            "name": "artifact_id",
+            "in": "path",
+            "description": "Artifact ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateScopedDownloadTokenRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Scoped download token created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateScopedDownloadTokenResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Artifact not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Artifact expired",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/v1/artifacts/{artifact_id}/scoped-tokens": {
+      "get": {
+        "tags": [
+          "Scoped Download Tokens"
+        ],
+        "summary": "List scoped download tokens",
+        "description": "Lists all scoped download tokens for a specific artifact, including expired and revoked ones.",
+        "operationId": "list_scoped_download_tokens",
+        "parameters": [
+          {
+            "name": "artifact_id",
+            "in": "path",
+            "description": "Artifact ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of scoped download tokens",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListArtifactDownloadTokensResponse"
                 }
               }
             }
@@ -5759,6 +5959,13 @@
             "type": "integer",
             "format": "int64"
           },
+          "expires_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          },
           "file_path": {
             "type": "string"
           },
@@ -5792,6 +5999,73 @@
           },
           "expires_at": {
             "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "ArtifactDownloadTokenSummary": {
+        "type": "object",
+        "required": [
+          "id",
+          "artifact_id",
+          "prefix",
+          "created_by",
+          "created_by_email",
+          "expires_at",
+          "single_use",
+          "is_expired",
+          "is_used",
+          "is_revoked",
+          "created_at"
+        ],
+        "properties": {
+          "artifact_id": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "created_by": {
+            "type": "string"
+          },
+          "created_by_email": {
+            "type": "string"
+          },
+          "expires_at": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "id": {
+            "type": "string"
+          },
+          "is_expired": {
+            "type": "boolean"
+          },
+          "is_revoked": {
+            "type": "boolean"
+          },
+          "is_used": {
+            "type": "boolean"
+          },
+          "prefix": {
+            "type": "string"
+          },
+          "revoked_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          },
+          "single_use": {
+            "type": "boolean"
+          },
+          "used_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "int64"
           }
         }
@@ -6721,6 +6995,55 @@
           }
         }
       },
+      "CreateScopedDownloadTokenRequest": {
+        "type": "object",
+        "properties": {
+          "single_use": {
+            "type": "boolean",
+            "description": "If true, token is consumed after first download."
+          },
+          "ttl_secs": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "TTL in seconds (default: 86400 = 24 hours, max: 604800 = 7 days)."
+          }
+        }
+      },
+      "CreateScopedDownloadTokenResponse": {
+        "type": "object",
+        "required": [
+          "id",
+          "download_url",
+          "token",
+          "prefix",
+          "expires_at",
+          "single_use"
+        ],
+        "properties": {
+          "download_url": {
+            "type": "string"
+          },
+          "expires_at": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "id": {
+            "type": "string"
+          },
+          "prefix": {
+            "type": "string"
+          },
+          "single_use": {
+            "type": "boolean"
+          },
+          "token": {
+            "type": "string"
+          }
+        }
+      },
       "DeleteNotificationChannelResponse": {
         "type": "object",
         "required": [
@@ -7425,6 +7748,20 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ApiTokenSummary"
+            }
+          }
+        }
+      },
+      "ListArtifactDownloadTokensResponse": {
+        "type": "object",
+        "required": [
+          "tokens"
+        ],
+        "properties": {
+          "tokens": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ArtifactDownloadTokenSummary"
             }
           }
         }
@@ -8383,6 +8720,13 @@
           "project_id"
         ],
         "properties": {
+          "artifact_ttl_days": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          },
           "cleanup_target": {
             "oneOf": [
               {
@@ -8654,6 +8998,13 @@
           "cleanup_interval_secs"
         ],
         "properties": {
+          "artifact_ttl_days": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          },
           "cleanup_interval_secs": {
             "type": "integer",
             "format": "int64"
@@ -8715,6 +9066,17 @@
         }
       },
       "RevokeApiTokenResponse": {
+        "type": "object",
+        "required": [
+          "revoked"
+        ],
+        "properties": {
+          "revoked": {
+            "type": "boolean"
+          }
+        }
+      },
+      "RevokeArtifactDownloadTokenResponse": {
         "type": "object",
         "required": [
           "revoked"
@@ -9699,6 +10061,13 @@
       "UpdateProjectRetentionOverrideRequest": {
         "type": "object",
         "properties": {
+          "artifact_ttl_days": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          },
           "cleanup_target": {
             "oneOf": [
               {
@@ -9754,6 +10123,13 @@
           "cleanup_target"
         ],
         "properties": {
+          "artifact_ttl_days": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          },
           "cleanup_interval_secs": {
             "type": "integer",
             "format": "int64"

--- a/apps/web/src/hooks/use-builds.ts
+++ b/apps/web/src/hooks/use-builds.ts
@@ -9,17 +9,21 @@ import type {
   BuildLogChunk,
   BuildStatus,
   CreateBuildRequest,
+  CreateScopedDownloadTokenRequest,
   ListBuildsResponse,
 } from '@/lib/types'
 import {
   cancelBuild,
   createBuild,
+  createScopedDownloadToken,
   getArtifactDownloadLink,
   getBuild,
   getBuildLogs,
   listArtifacts,
   listBuilds,
+  listScopedDownloadTokens,
   rerunBuild,
+  revokeScopedDownloadToken,
 } from '@/lib/api'
 import { useActiveInstance } from '@/stores/instance-store'
 import { useAuthStore } from '@/stores/auth-store'
@@ -264,6 +268,64 @@ export function useArtifactDownloadLink() {
       if (!baseUrl || !token)
         return Promise.reject(new Error('Not authenticated'))
       return getArtifactDownloadLink(baseUrl, token, artifactId)
+    },
+  })
+}
+
+export function useCreateScopedDownloadToken() {
+  const baseUrl = useBaseUrl()
+  const token = useAuthToken()
+  const queryClient = useQueryClient()
+  const instance = useActiveInstance()
+
+  return useMutation({
+    mutationFn: ({
+      artifactId,
+      data,
+    }: {
+      artifactId: string
+      data: CreateScopedDownloadTokenRequest
+    }) => {
+      if (!baseUrl || !token)
+        return Promise.reject(new Error('Not authenticated'))
+      return createScopedDownloadToken(baseUrl, token, artifactId, data)
+    },
+    onSuccess: (_data, { artifactId }) => {
+      void queryClient.invalidateQueries({
+        queryKey: [instance?.id ?? '__none__', 'scoped-tokens', artifactId],
+      })
+    },
+  })
+}
+
+export function useScopedDownloadTokens(artifactId: string) {
+  const baseUrl = useBaseUrl()
+  const token = useAuthToken()
+  const instance = useActiveInstance()
+
+  return useQuery({
+    queryKey: [instance?.id ?? '__none__', 'scoped-tokens', artifactId],
+    queryFn: () => listScopedDownloadTokens(baseUrl!, token!, artifactId),
+    enabled: !!baseUrl && !!token && !!artifactId,
+  })
+}
+
+export function useRevokeScopedDownloadToken() {
+  const baseUrl = useBaseUrl()
+  const token = useAuthToken()
+  const queryClient = useQueryClient()
+  const instance = useActiveInstance()
+
+  return useMutation({
+    mutationFn: (tokenId: string) => {
+      if (!baseUrl || !token)
+        return Promise.reject(new Error('Not authenticated'))
+      return revokeScopedDownloadToken(baseUrl, token, tokenId)
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: [instance?.id ?? '__none__', 'scoped-tokens'],
+      })
     },
   })
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -20,6 +20,8 @@ import type {
   CreatePipelineResponse,
   CreateProjectRequest,
   CreateProjectResponse,
+  CreateScopedDownloadTokenRequest,
+  CreateScopedDownloadTokenResponse,
   DeleteNotificationChannelResponse,
   EffectiveProjectRetentionResponse,
   ExternalAccessNetworkSettingsResponse,
@@ -38,6 +40,7 @@ import type {
   InviteUserRequest,
   InviteUserResponse,
   ListApiTokensResponse,
+  ListArtifactDownloadTokensResponse,
   ListArtifactsResponse,
   ListAuditLogsResponse,
   ListBuildsResponse,
@@ -961,6 +964,47 @@ export function getArtifactDownloadLink(
     baseUrl,
     `/v1/artifacts/${artifactId}/download-link`,
     { method: 'POST', headers: authHeaders(token) },
+  )
+}
+
+export function createScopedDownloadToken(
+  baseUrl: string,
+  token: string,
+  artifactId: string,
+  data: CreateScopedDownloadTokenRequest,
+): Promise<CreateScopedDownloadTokenResponse> {
+  return request<CreateScopedDownloadTokenResponse>(
+    baseUrl,
+    `/v1/artifacts/${artifactId}/scoped-token`,
+    {
+      method: 'POST',
+      headers: authHeaders(token),
+      body: JSON.stringify(data),
+    },
+  )
+}
+
+export function listScopedDownloadTokens(
+  baseUrl: string,
+  token: string,
+  artifactId: string,
+): Promise<ListArtifactDownloadTokensResponse> {
+  return request<ListArtifactDownloadTokensResponse>(
+    baseUrl,
+    `/v1/artifacts/${artifactId}/scoped-tokens`,
+    { headers: authHeaders(token) },
+  )
+}
+
+export function revokeScopedDownloadToken(
+  baseUrl: string,
+  token: string,
+  tokenId: string,
+): Promise<{ revoked: boolean }> {
+  return request<{ revoked: boolean }>(
+    baseUrl,
+    `/v1/artifact-tokens/${tokenId}`,
+    { method: 'DELETE', headers: authHeaders(token) },
   )
 }
 

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -487,6 +487,7 @@ export interface Artifact {
   checksum?: string
   metadata: Record<string, unknown>
   created_at: number
+  expires_at?: number
 }
 
 export interface ListArtifactsResponse {
@@ -496,6 +497,42 @@ export interface ListArtifactsResponse {
 export interface ArtifactDownloadLinkResponse {
   download_url: string
   expires_at: number
+}
+
+// ── Scoped download token types ────────────────────────────
+
+export interface CreateScopedDownloadTokenRequest {
+  ttl_secs?: number
+  single_use?: boolean
+}
+
+export interface CreateScopedDownloadTokenResponse {
+  id: string
+  download_url: string
+  token: string
+  prefix: string
+  expires_at: number
+  single_use: boolean
+}
+
+export interface ArtifactDownloadTokenSummary {
+  id: string
+  artifact_id: string
+  prefix: string
+  created_by: string
+  created_by_email: string
+  expires_at: number
+  single_use: boolean
+  used_at?: number
+  revoked_at?: number
+  is_expired: boolean
+  is_used: boolean
+  is_revoked: boolean
+  created_at: number
+}
+
+export interface ListArtifactDownloadTokensResponse {
+  tokens: Array<ArtifactDownloadTokenSummary>
 }
 
 export type ArtifactStorageProvider = 'disabled' | 'local' | 's3' | 'r2'
@@ -998,6 +1035,7 @@ export interface RetentionPolicy {
   keep_statuses: Array<string>
   dry_run: boolean
   cleanup_interval_secs: number
+  artifact_ttl_days?: number
   updated_at?: number
 }
 
@@ -1014,6 +1052,7 @@ export interface UpdateRetentionPolicyRequest {
   keep_statuses: Array<string>
   dry_run: boolean
   cleanup_interval_secs: number
+  artifact_ttl_days?: number
 }
 
 export interface ProjectRetentionOverride {
@@ -1024,6 +1063,7 @@ export interface ProjectRetentionOverride {
   max_artifact_size_bytes?: number
   cleanup_target?: RetentionCleanupTarget
   keep_statuses?: Array<string>
+  artifact_ttl_days?: number
   updated_at?: number
 }
 
@@ -1040,6 +1080,7 @@ export interface UpdateProjectRetentionOverrideRequest {
   max_artifact_size_bytes?: number
   cleanup_target?: RetentionCleanupTarget
   keep_statuses?: Array<string>
+  artifact_ttl_days?: number
 }
 
 export interface RetentionCleanupSummary {

--- a/apps/web/src/routes/builds/$buildId.tsx
+++ b/apps/web/src/routes/builds/$buildId.tsx
@@ -1,5 +1,5 @@
 import { Link, createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useCallback, useMemo, useRef } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { HugeiconsIcon } from '@hugeicons/react'
 import {
   Copy01Icon,
@@ -9,11 +9,12 @@ import {
   GitCommitIcon,
   InformationCircleIcon,
   Refresh01Icon,
+  Share08Icon,
   TimeQuarterPassIcon,
 } from '@hugeicons/core-free-icons'
 import { toast } from 'sonner'
 
-import type { Artifact, BuildLogChunk } from '@/lib/types'
+import type { Artifact, BuildLogChunk, CreateScopedDownloadTokenResponse } from '@/lib/types'
 import {
   getActiveInstanceOrRedirect,
   requireAuthOrRedirect,
@@ -28,6 +29,7 @@ import {
   useBuild,
   useBuildLogs,
   useCancelBuild,
+  useCreateScopedDownloadToken,
   useRerunBuild,
 } from '@/hooks/use-builds'
 import { useLogStream } from '@/hooks/use-log-stream'
@@ -37,6 +39,24 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Alert, AlertDescription } from '@/components/ui/alert'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Label } from '@/components/ui/label'
+import { Spinner } from '@/components/ui/spinner'
 import PageLayout from '@/components/page-layout'
 import PageHeader from '@/components/page-header'
 import TerminalLogViewer from '@/components/terminal-log-viewer'
@@ -294,6 +314,25 @@ function BuildDetailPage() {
   )
 }
 
+function isArtifactExpired(artifact: Artifact): boolean {
+  if (artifact.expires_at == null) return false
+  return artifact.expires_at <= Math.floor(Date.now() / 1000)
+}
+
+function artifactExpiryLabel(artifact: Artifact): string | null {
+  if (artifact.expires_at == null) return null
+  const now = Math.floor(Date.now() / 1000)
+  if (artifact.expires_at <= now) return 'Expired'
+  return `Expires ${relativeTime(artifact.expires_at)}`
+}
+
+const TTL_OPTIONS = [
+  { value: '3600', label: '1 hour' },
+  { value: '21600', label: '6 hours' },
+  { value: '86400', label: '24 hours' },
+  { value: '604800', label: '7 days' },
+] as const
+
 function ArtifactsPanel({
   artifacts,
   isLoading,
@@ -304,6 +343,12 @@ function ArtifactsPanel({
   buildStatus: string
 }) {
   const downloadMutation = useArtifactDownloadLink()
+  const createTokenMutation = useCreateScopedDownloadToken()
+
+  const [shareArtifact, setShareArtifact] = useState<Artifact | null>(null)
+  const [ttlSecs, setTtlSecs] = useState('86400')
+  const [singleUse, setSingleUse] = useState(false)
+  const [createdToken, setCreatedToken] = useState<CreateScopedDownloadTokenResponse | null>(null)
 
   function handleDownload(artifactId: string, name: string) {
     downloadMutation.mutate(artifactId, {
@@ -330,86 +375,229 @@ function ArtifactsPanel({
     })
   }
 
+  function handleShareLink(artifact: Artifact) {
+    setShareArtifact(artifact)
+    setCreatedToken(null)
+    setTtlSecs('86400')
+    setSingleUse(false)
+  }
+
+  function handleCreateToken() {
+    if (!shareArtifact) return
+    createTokenMutation.mutate(
+      {
+        artifactId: shareArtifact.id,
+        data: {
+          ttl_secs: Number(ttlSecs),
+          single_use: singleUse,
+        },
+      },
+      {
+        onSuccess: (res) => {
+          setCreatedToken(res)
+        },
+        onError: (err) => {
+          toast.error(`Failed to create share link: ${err.message}`)
+        },
+      },
+    )
+  }
+
+  function handleCopyShareUrl() {
+    if (!createdToken) return
+    void navigator.clipboard.writeText(createdToken.download_url).then(
+      () => toast.success('Share link copied to clipboard'),
+      () => toast.error('Failed to copy link'),
+    )
+  }
+
   return (
-    <Card size="sm">
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-sm font-medium uppercase tracking-wider text-muted-foreground">
-          <HugeiconsIcon icon={File01Icon} size={14} />
-          Artifacts
-          {artifacts.length > 0 ? (
-            <Badge variant="secondary" className="text-[10px]">
-              {artifacts.length}
-            </Badge>
-          ) : null}
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        {isLoading ? (
-          <div className="space-y-2">
-            <Skeleton className="h-8 w-full" />
-            <Skeleton className="h-8 w-full" />
-          </div>
-        ) : !artifacts.length ? (
-          <p className="text-xs text-muted-foreground">
-            {buildStatus === 'succeeded' || buildStatus === 'failed'
-              ? 'No artifacts were produced. Check that your pipeline has artifact patterns configured.'
-              : 'Artifacts will appear here once the build produces them.'}
-          </p>
-        ) : (
-          <div className="space-y-2">
-            {artifacts.map((artifact) => (
-              <div
-                key={artifact.id}
-                className="flex items-center gap-2 border p-2"
-              >
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-xs font-medium">
-                    {artifact.name}
-                  </p>
-                  <div className="mt-0.5 flex items-center gap-1.5">
-                    <Badge
-                      variant={artifactTypeBadgeVariant(artifact.artifact_type)}
-                      className="text-[10px]"
-                    >
-                      {artifact.artifact_type}
-                    </Badge>
-                    <span className="text-[10px] text-muted-foreground">
-                      {artifact.file_size != null
-                        ? formatFileSize(artifact.file_size)
-                        : '—'}
-                    </span>
+    <>
+      <Card size="sm">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-sm font-medium uppercase tracking-wider text-muted-foreground">
+            <HugeiconsIcon icon={File01Icon} size={14} />
+            Artifacts
+            {artifacts.length > 0 ? (
+              <Badge variant="secondary" className="text-[10px]">
+                {artifacts.length}
+              </Badge>
+            ) : null}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-8 w-full" />
+              <Skeleton className="h-8 w-full" />
+            </div>
+          ) : !artifacts.length ? (
+            <p className="text-xs text-muted-foreground">
+              {buildStatus === 'succeeded' || buildStatus === 'failed'
+                ? 'No artifacts were produced. Check that your pipeline has artifact patterns configured.'
+                : 'Artifacts will appear here once the build produces them.'}
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {artifacts.map((artifact) => {
+                const expired = isArtifactExpired(artifact)
+                const expiryLabel = artifactExpiryLabel(artifact)
+
+                return (
+                  <div
+                    key={artifact.id}
+                    className={`flex items-center gap-2 border p-2 ${expired ? 'opacity-50' : ''}`}
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-xs font-medium">
+                        {artifact.name}
+                      </p>
+                      <div className="mt-0.5 flex items-center gap-1.5">
+                        <Badge
+                          variant={artifactTypeBadgeVariant(artifact.artifact_type)}
+                          className="text-[10px]"
+                        >
+                          {artifact.artifact_type}
+                        </Badge>
+                        <span className="text-[10px] text-muted-foreground">
+                          {artifact.file_size != null
+                            ? formatFileSize(artifact.file_size)
+                            : '—'}
+                        </span>
+                        {expiryLabel ? (
+                          <span className={`text-[10px] ${expired ? 'text-destructive' : 'text-muted-foreground'}`}>
+                            {expiryLabel}
+                          </span>
+                        ) : null}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-0.5">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="size-7 shrink-0"
+                        title="Share link"
+                        aria-label={`Share link for ${artifact.name}`}
+                        onClick={() => handleShareLink(artifact)}
+                        disabled={expired}
+                      >
+                        <HugeiconsIcon icon={Share08Icon} size={14} />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="size-7 shrink-0"
+                        title="Copy download link"
+                        aria-label={`Copy link for ${artifact.name}`}
+                        onClick={() => handleCopyLink(artifact.id, artifact.name)}
+                        disabled={downloadMutation.isPending || expired}
+                      >
+                        <HugeiconsIcon icon={Copy01Icon} size={14} />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="size-7 shrink-0"
+                        title="Download"
+                        aria-label={`Download ${artifact.name}`}
+                        onClick={() => handleDownload(artifact.id, artifact.name)}
+                        disabled={downloadMutation.isPending || expired}
+                      >
+                        <HugeiconsIcon icon={Download04Icon} size={14} />
+                      </Button>
+                    </div>
                   </div>
-                </div>
-                <div className="flex items-center gap-0.5">
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="size-7 shrink-0"
-                    title="Copy download link"
-                    aria-label={`Copy link for ${artifact.name}`}
-                    onClick={() => handleCopyLink(artifact.id, artifact.name)}
-                    disabled={downloadMutation.isPending}
-                  >
-                    <HugeiconsIcon icon={Copy01Icon} size={14} />
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="size-7 shrink-0"
-                    title="Download"
-                    aria-label={`Download ${artifact.name}`}
-                    onClick={() => handleDownload(artifact.id, artifact.name)}
-                    disabled={downloadMutation.isPending}
-                  >
-                    <HugeiconsIcon icon={Download04Icon} size={14} />
-                  </Button>
-                </div>
+                )
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Share Link Dialog */}
+      <Dialog open={shareArtifact !== null} onOpenChange={(open) => { if (!open) setShareArtifact(null) }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {createdToken ? 'Share Link Created' : 'Create Share Link'}
+            </DialogTitle>
+            <DialogDescription>
+              {createdToken
+                ? 'Copy this link to share. It will not be shown again.'
+                : `Generate a scoped download link for "${shareArtifact?.name}".`}
+            </DialogDescription>
+          </DialogHeader>
+
+          {createdToken ? (
+            <div className="space-y-3">
+              <Alert>
+                <AlertDescription className="break-all text-xs font-mono">
+                  {createdToken.download_url}
+                </AlertDescription>
+              </Alert>
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <span>Expires {relativeTime(createdToken.expires_at)}</span>
+                {createdToken.single_use ? (
+                  <Badge variant="secondary" className="text-[10px]">Single use</Badge>
+                ) : null}
               </div>
-            ))}
-          </div>
-        )}
-      </CardContent>
-    </Card>
+              <DialogFooter>
+                <Button variant="secondary" onClick={() => setShareArtifact(null)}>
+                  Close
+                </Button>
+                <Button onClick={handleCopyShareUrl}>
+                  <HugeiconsIcon icon={Copy01Icon} size={14} className="mr-1.5" />
+                  Copy Link
+                </Button>
+              </DialogFooter>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="ttl-select">Expires after</Label>
+                <Select value={ttlSecs} onValueChange={(v) => { if (v != null) setTtlSecs(v) }}>
+                  <SelectTrigger id="ttl-select">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {TTL_OPTIONS.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="single-use"
+                  checked={singleUse}
+                  onCheckedChange={(checked) => setSingleUse(checked === true)}
+                />
+                <Label htmlFor="single-use" className="text-sm font-normal">
+                  Single use (consumed after first download)
+                </Label>
+              </div>
+              <DialogFooter>
+                <Button variant="secondary" onClick={() => setShareArtifact(null)}>
+                  Cancel
+                </Button>
+                <Button onClick={handleCreateToken} disabled={createTokenMutation.isPending}>
+                  {createTokenMutation.isPending ? (
+                    <>
+                      <Spinner className="mr-1.5" />
+                      Creating...
+                    </>
+                  ) : (
+                    'Create Link'
+                  )}
+                </Button>
+              </DialogFooter>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }
 

--- a/crates/oore-contract/src/lib.rs
+++ b/crates/oore-contract/src/lib.rs
@@ -1173,6 +1173,8 @@ pub struct Artifact {
     #[schema(value_type = Object)]
     pub metadata: serde_json::Value,
     pub created_at: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<i64>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -1203,6 +1205,57 @@ pub struct ListArtifactsResponse {
 pub struct ArtifactDownloadLinkResponse {
     pub download_url: String,
     pub expires_at: i64,
+}
+
+// ── Scoped download token types ─────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct CreateScopedDownloadTokenRequest {
+    /// TTL in seconds (default: 86400 = 24 hours, max: 604800 = 7 days).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttl_secs: Option<i64>,
+    /// If true, token is consumed after first download.
+    #[serde(default)]
+    pub single_use: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct CreateScopedDownloadTokenResponse {
+    pub id: String,
+    pub download_url: String,
+    pub token: String,
+    pub prefix: String,
+    pub expires_at: i64,
+    pub single_use: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ArtifactDownloadTokenSummary {
+    pub id: String,
+    pub artifact_id: String,
+    pub prefix: String,
+    pub created_by: String,
+    pub created_by_email: String,
+    pub expires_at: i64,
+    pub single_use: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub used_at: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revoked_at: Option<i64>,
+    pub is_expired: bool,
+    pub is_used: bool,
+    pub is_revoked: bool,
+    pub created_at: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ListArtifactDownloadTokensResponse {
+    pub tokens: Vec<ArtifactDownloadTokenSummary>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct RevokeArtifactDownloadTokenResponse {
+    pub revoked: bool,
 }
 
 // ── Artifact storage settings types ─────────────────────────────
@@ -2192,6 +2245,8 @@ pub struct RetentionPolicy {
     pub dry_run: bool,
     pub cleanup_interval_secs: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_ttl_days: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<i64>,
 }
 
@@ -2216,6 +2271,8 @@ pub struct UpdateRetentionPolicyRequest {
     pub dry_run: bool,
     #[serde(default = "default_cleanup_interval")]
     pub cleanup_interval_secs: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_ttl_days: Option<i64>,
 }
 
 fn default_cleanup_interval() -> i64 {
@@ -2237,6 +2294,8 @@ pub struct ProjectRetentionOverride {
     pub cleanup_target: Option<RetentionCleanupTarget>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub keep_statuses: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_ttl_days: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<i64>,
 }
@@ -2263,6 +2322,8 @@ pub struct UpdateProjectRetentionOverrideRequest {
     pub cleanup_target: Option<RetentionCleanupTarget>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub keep_statuses: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_ttl_days: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/crates/oored/migrations/025_artifact_expiry_and_download_tokens.sql
+++ b/crates/oored/migrations/025_artifact_expiry_and_download_tokens.sql
@@ -1,0 +1,29 @@
+-- OOR-140: Artifact expiry and scoped download tokens
+
+-- Add per-artifact expiry timestamp
+ALTER TABLE artifacts ADD COLUMN expires_at INTEGER;
+CREATE INDEX IF NOT EXISTS idx_artifacts_expires_at ON artifacts(expires_at)
+    WHERE expires_at IS NOT NULL;
+
+-- Scoped download tokens (DB-backed, shareable links)
+CREATE TABLE IF NOT EXISTS artifact_download_tokens (
+    id           TEXT PRIMARY KEY,
+    artifact_id  TEXT NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
+    token_hash   TEXT NOT NULL UNIQUE,
+    prefix       TEXT NOT NULL,
+    created_by   TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    expires_at   INTEGER NOT NULL,
+    single_use   INTEGER NOT NULL DEFAULT 0,
+    used_at      INTEGER,
+    revoked_at   INTEGER,
+    created_at   INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_artifact_dl_tokens_hash ON artifact_download_tokens(token_hash);
+CREATE INDEX IF NOT EXISTS idx_artifact_dl_tokens_artifact ON artifact_download_tokens(artifact_id);
+CREATE INDEX IF NOT EXISTS idx_artifact_dl_tokens_expires ON artifact_download_tokens(expires_at);
+
+-- Add default artifact TTL to retention policy
+ALTER TABLE retention_policy ADD COLUMN artifact_ttl_days INTEGER;
+
+-- Add per-project artifact TTL override
+ALTER TABLE project_retention_overrides ADD COLUMN artifact_ttl_days INTEGER;

--- a/crates/oored/src/artifact_tokens.rs
+++ b/crates/oored/src/artifact_tokens.rs
@@ -1,0 +1,475 @@
+//! Scoped download tokens for artifacts (OOR-140).
+//!
+//! Each token grants access to download a single artifact, with optional
+//! single-use and time-limited expiry. Tokens are DB-backed (survive restarts).
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Redirect, Response};
+use oore_contract::{
+    ApiError, ArtifactDownloadTokenSummary, CreateScopedDownloadTokenRequest,
+    CreateScopedDownloadTokenResponse, ListArtifactDownloadTokensResponse,
+    RevokeArtifactDownloadTokenResponse,
+};
+use sqlx::{Row, SqlitePool};
+use tracing::{error, info};
+use uuid::Uuid;
+
+use crate::AppState;
+use crate::extractors::AuthUser;
+use crate::rbac::check_permission;
+use crate::store::write_audit_log;
+use crate::token::{generate_token, hash_token};
+use crate::util::{api_err, now_unix};
+
+type ApiResult<T> = Result<Json<T>, (StatusCode, Json<ApiError>)>;
+
+/// Default TTL for scoped download tokens: 24 hours.
+const DEFAULT_TTL_SECS: i64 = 86_400;
+
+/// Maximum TTL: 7 days.
+const MAX_TTL_SECS: i64 = 604_800;
+
+// ── DB helpers ──────────────────────────────────────────────────
+
+pub async fn create_download_token(
+    pool: &SqlitePool,
+    artifact_id: &str,
+    created_by: &str,
+    ttl_secs: i64,
+    single_use: bool,
+) -> Result<(String, String, String, i64), sqlx::Error> {
+    let id = Uuid::new_v4().to_string();
+    let token = generate_token();
+    let hashed = hash_token(&token);
+    let prefix = token[..8].to_string();
+    let now = now_unix();
+    let expires_at = now + ttl_secs;
+
+    sqlx::query(
+        "INSERT INTO artifact_download_tokens \
+         (id, artifact_id, token_hash, prefix, created_by, expires_at, single_use, created_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+    )
+    .bind(&id)
+    .bind(artifact_id)
+    .bind(&hashed)
+    .bind(&prefix)
+    .bind(created_by)
+    .bind(expires_at)
+    .bind(single_use as i32)
+    .bind(now)
+    .execute(pool)
+    .await?;
+
+    Ok((id, token, prefix, expires_at))
+}
+
+/// Validated token data needed to serve the download.
+pub struct ValidatedDownloadToken {
+    pub token_hash: String,
+    pub artifact_id: String,
+    pub file_path: String,
+    pub artifact_name: String,
+    pub single_use: bool,
+}
+
+pub async fn validate_download_token(
+    pool: &SqlitePool,
+    raw_token: &str,
+) -> Result<Option<ValidatedDownloadToken>, sqlx::Error> {
+    let hashed = hash_token(raw_token);
+    let now = now_unix();
+
+    let row = sqlx::query(
+        "SELECT t.token_hash, t.artifact_id, t.single_use, t.used_at, \
+                a.file_path, a.name AS artifact_name, a.expires_at AS artifact_expires_at \
+         FROM artifact_download_tokens t \
+         JOIN artifacts a ON a.id = t.artifact_id \
+         WHERE t.token_hash = ?1 \
+           AND t.revoked_at IS NULL \
+           AND t.expires_at > ?2 \
+           AND (t.single_use = 0 OR t.used_at IS NULL)",
+    )
+    .bind(&hashed)
+    .bind(now)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(row.map(|r| ValidatedDownloadToken {
+        token_hash: r.get("token_hash"),
+        artifact_id: r.get("artifact_id"),
+        file_path: r.get("file_path"),
+        artifact_name: r.get("artifact_name"),
+        single_use: r.get::<i32, _>("single_use") != 0,
+    }))
+}
+
+pub async fn mark_token_used(pool: &SqlitePool, token_hash: &str) {
+    let now = now_unix();
+    if let Err(e) =
+        sqlx::query("UPDATE artifact_download_tokens SET used_at = ?1 WHERE token_hash = ?2")
+            .bind(now)
+            .bind(token_hash)
+            .execute(pool)
+            .await
+    {
+        error!(error = %e, "failed to mark download token as used");
+    }
+}
+
+// ── Handlers ────────────────────────────────────────────────────
+
+/// `POST /v1/artifacts/{artifact_id}/scoped-token` — create a scoped download token.
+pub async fn create_scoped_token_handler(
+    State(state): State<Arc<AppState>>,
+    auth: AuthUser,
+    Path(artifact_id): Path<String>,
+    Json(req): Json<CreateScopedDownloadTokenRequest>,
+) -> ApiResult<CreateScopedDownloadTokenResponse> {
+    check_permission(&state.enforcer, &auth.0.role, "builds", "read").await?;
+
+    let ttl = req.ttl_secs.unwrap_or(DEFAULT_TTL_SECS);
+    if ttl < 60 {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "validation_error",
+            "TTL must be at least 60 seconds",
+        ));
+    }
+    if ttl > MAX_TTL_SECS {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "validation_error",
+            "TTL must not exceed 604800 seconds (7 days)",
+        ));
+    }
+
+    let pool = {
+        let store = state.store.lock().await;
+        store.pool().clone()
+    };
+
+    // Verify artifact exists and is not expired
+    let artifact_row = sqlx::query("SELECT id, expires_at FROM artifacts WHERE id = ?1")
+        .bind(&artifact_id)
+        .fetch_optional(&pool)
+        .await
+        .map_err(|e| {
+            error!(error = %e, "failed to fetch artifact");
+            api_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "store_error",
+                "Failed to fetch artifact",
+            )
+        })?
+        .ok_or_else(|| api_err(StatusCode::NOT_FOUND, "not_found", "Artifact not found"))?;
+
+    let artifact_expires_at: Option<i64> = artifact_row.get("expires_at");
+    if let Some(ea) = artifact_expires_at
+        && ea <= now_unix()
+    {
+        return Err(api_err(
+            StatusCode::GONE,
+            "artifact_expired",
+            "This artifact has expired",
+        ));
+    }
+
+    let (id, token, prefix, expires_at) =
+        create_download_token(&pool, &artifact_id, &auth.0.user_id, ttl, req.single_use)
+            .await
+            .map_err(|e| {
+                error!(error = %e, "failed to create scoped download token");
+                api_err(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "db_error",
+                    "Failed to create download token",
+                )
+            })?;
+
+    // Build the download URL
+    let public_url = state.public_url.read().await.clone();
+    let base = public_url.as_deref().unwrap_or("http://127.0.0.1:8787");
+    let download_url = format!("{}/v1/artifacts/dl/{}", base.trim_end_matches('/'), &token);
+
+    // Audit log
+    let details = serde_json::json!({
+        "artifact_id": artifact_id,
+        "token_prefix": prefix,
+        "single_use": req.single_use,
+        "ttl_secs": ttl,
+        "expires_at": expires_at,
+    })
+    .to_string();
+    let _ = write_audit_log(
+        &pool,
+        Some(&auth.0.user_id),
+        "scoped_download_token_created",
+        "artifact_download_token",
+        Some(&id),
+        Some(&details),
+    )
+    .await;
+
+    info!(
+        user_id = %auth.0.user_id,
+        artifact_id = %artifact_id,
+        token_id = %id,
+        single_use = req.single_use,
+        "scoped download token created"
+    );
+
+    Ok(Json(CreateScopedDownloadTokenResponse {
+        id,
+        download_url,
+        token,
+        prefix,
+        expires_at,
+        single_use: req.single_use,
+    }))
+}
+
+/// `GET /v1/artifacts/{artifact_id}/scoped-tokens` — list scoped tokens for an artifact.
+pub async fn list_scoped_tokens_handler(
+    State(state): State<Arc<AppState>>,
+    auth: AuthUser,
+    Path(artifact_id): Path<String>,
+) -> ApiResult<ListArtifactDownloadTokensResponse> {
+    check_permission(&state.enforcer, &auth.0.role, "builds", "read").await?;
+
+    let pool = {
+        let store = state.store.lock().await;
+        store.pool().clone()
+    };
+    let now = now_unix();
+
+    let rows = sqlx::query(
+        "SELECT t.id, t.artifact_id, t.prefix, t.created_by, t.expires_at, \
+                t.single_use, t.used_at, t.revoked_at, t.created_at, \
+                u.email AS created_by_email \
+         FROM artifact_download_tokens t \
+         JOIN users u ON u.id = t.created_by \
+         WHERE t.artifact_id = ?1 \
+         ORDER BY t.created_at DESC",
+    )
+    .bind(&artifact_id)
+    .fetch_all(&pool)
+    .await
+    .map_err(|e| {
+        error!(error = %e, "failed to list scoped download tokens");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "db_error",
+            "Failed to list download tokens",
+        )
+    })?;
+
+    let tokens: Vec<ArtifactDownloadTokenSummary> = rows
+        .iter()
+        .map(|r| {
+            let expires_at: i64 = r.get("expires_at");
+            let used_at: Option<i64> = r.get("used_at");
+            let revoked_at: Option<i64> = r.get("revoked_at");
+            let single_use = r.get::<i32, _>("single_use") != 0;
+
+            ArtifactDownloadTokenSummary {
+                id: r.get("id"),
+                artifact_id: r.get("artifact_id"),
+                prefix: r.get("prefix"),
+                created_by: r.get("created_by"),
+                created_by_email: r.get("created_by_email"),
+                expires_at,
+                single_use,
+                used_at,
+                revoked_at,
+                is_expired: expires_at <= now,
+                is_used: single_use && used_at.is_some(),
+                is_revoked: revoked_at.is_some(),
+                created_at: r.get("created_at"),
+            }
+        })
+        .collect();
+
+    Ok(Json(ListArtifactDownloadTokensResponse { tokens }))
+}
+
+/// `DELETE /v1/artifact-tokens/{token_id}` — revoke a scoped download token.
+pub async fn revoke_scoped_token_handler(
+    State(state): State<Arc<AppState>>,
+    auth: AuthUser,
+    Path(token_id): Path<String>,
+) -> ApiResult<RevokeArtifactDownloadTokenResponse> {
+    check_permission(&state.enforcer, &auth.0.role, "builds", "read").await?;
+
+    let pool = {
+        let store = state.store.lock().await;
+        store.pool().clone()
+    };
+
+    // Fetch the token to check existence
+    let row =
+        sqlx::query("SELECT created_by, revoked_at FROM artifact_download_tokens WHERE id = ?1")
+            .bind(&token_id)
+            .fetch_optional(&pool)
+            .await
+            .map_err(|e| {
+                error!(error = %e, "failed to query download token");
+                api_err(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "db_error",
+                    "Failed to query download token",
+                )
+            })?;
+
+    let row = row.ok_or_else(|| {
+        api_err(
+            StatusCode::NOT_FOUND,
+            "not_found",
+            "Download token not found",
+        )
+    })?;
+
+    let revoked_at: Option<i64> = row.get("revoked_at");
+    if revoked_at.is_some() {
+        return Ok(Json(RevokeArtifactDownloadTokenResponse { revoked: true }));
+    }
+
+    // Non-admin users can only revoke their own tokens
+    let created_by: String = row.get("created_by");
+    let is_admin = auth.0.role == "owner" || auth.0.role == "admin";
+    if !is_admin && created_by != auth.0.user_id {
+        return Err(api_err(
+            StatusCode::FORBIDDEN,
+            "permission_denied",
+            "You can only revoke your own download tokens",
+        ));
+    }
+
+    let now = now_unix();
+    sqlx::query("UPDATE artifact_download_tokens SET revoked_at = ?1 WHERE id = ?2")
+        .bind(now)
+        .bind(&token_id)
+        .execute(&pool)
+        .await
+        .map_err(|e| {
+            error!(error = %e, "failed to revoke download token");
+            api_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "db_error",
+                "Failed to revoke download token",
+            )
+        })?;
+
+    // Audit log
+    let _ = write_audit_log(
+        &pool,
+        Some(&auth.0.user_id),
+        "scoped_download_token_revoked",
+        "artifact_download_token",
+        Some(&token_id),
+        None,
+    )
+    .await;
+
+    info!(
+        user_id = %auth.0.user_id,
+        token_id = %token_id,
+        "scoped download token revoked"
+    );
+
+    Ok(Json(RevokeArtifactDownloadTokenResponse { revoked: true }))
+}
+
+/// `GET /v1/artifacts/dl/{token}` — download an artifact via scoped token (no session auth).
+pub async fn download_via_scoped_token(
+    State(state): State<Arc<AppState>>,
+    Path(token): Path<String>,
+) -> Result<Response, (StatusCode, Json<ApiError>)> {
+    let pool = {
+        let store = state.store.lock().await;
+        store.pool().clone()
+    };
+
+    let validated = validate_download_token(&pool, &token)
+        .await
+        .map_err(|e| {
+            error!(error = %e, "failed to validate scoped download token");
+            api_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "db_error",
+                "Failed to validate download token",
+            )
+        })?
+        .ok_or_else(|| {
+            api_err(
+                StatusCode::UNAUTHORIZED,
+                "invalid_token",
+                "Download token is invalid, expired, or already used",
+            )
+        })?;
+
+    // Check if the artifact itself has expired
+    let artifact_expires = sqlx::query("SELECT expires_at FROM artifacts WHERE id = ?1")
+        .bind(&validated.artifact_id)
+        .fetch_optional(&pool)
+        .await
+        .map_err(|e| {
+            error!(error = %e, "failed to check artifact expiry");
+            api_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "store_error",
+                "Failed to check artifact",
+            )
+        })?;
+
+    if let Some(row) = &artifact_expires {
+        let expires_at: Option<i64> = row.get("expires_at");
+        if let Some(ea) = expires_at
+            && ea <= now_unix()
+        {
+            return Err(api_err(
+                StatusCode::GONE,
+                "artifact_expired",
+                "This artifact has expired",
+            ));
+        }
+    }
+
+    // Mark token as used if single-use
+    if validated.single_use {
+        mark_token_used(&pool, &validated.token_hash).await;
+    }
+
+    // Serve the file via storage backend
+    let storage = state.storage.read().await;
+
+    // For S3/R2, generate a presigned URL and redirect
+    // For local storage, stream the bytes directly
+    let download_url = storage
+        .generate_download_url(&validated.file_path, 900)
+        .await
+        .map_err(|e| {
+            error!(error = %e, "failed to generate download URL for scoped token");
+            api_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "storage_error",
+                "Failed to generate download URL",
+            )
+        })?;
+
+    if let Some(url) = download_url {
+        // For S3/R2 presigned URLs, redirect
+        Ok(Redirect::temporary(&url).into_response())
+    } else {
+        // Storage is disabled
+        Err(api_err(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "storage_not_configured",
+            "Artifact storage backend is not configured",
+        ))
+    }
+}

--- a/crates/oored/src/artifact_tokens.rs
+++ b/crates/oored/src/artifact_tokens.rs
@@ -108,16 +108,25 @@ pub async fn validate_download_token(
     }))
 }
 
-pub async fn mark_token_used(pool: &SqlitePool, token_hash: &str) {
+/// Atomically claim a single-use token.  Returns `true` if this call won the
+/// race (i.e. `used_at` was `NULL` and is now set).  A concurrent second call
+/// will see `rows_affected == 0` and return `false`.
+pub async fn claim_single_use_token(pool: &SqlitePool, token_hash: &str) -> bool {
     let now = now_unix();
-    if let Err(e) =
-        sqlx::query("UPDATE artifact_download_tokens SET used_at = ?1 WHERE token_hash = ?2")
-            .bind(now)
-            .bind(token_hash)
-            .execute(pool)
-            .await
+    match sqlx::query(
+        "UPDATE artifact_download_tokens SET used_at = ?1 \
+         WHERE token_hash = ?2 AND used_at IS NULL",
+    )
+    .bind(now)
+    .bind(token_hash)
+    .execute(pool)
+    .await
     {
-        error!(error = %e, "failed to mark download token as used");
+        Ok(result) => result.rows_affected() > 0,
+        Err(e) => {
+            error!(error = %e, "failed to mark download token as used");
+            false
+        }
     }
 }
 
@@ -439,9 +448,13 @@ pub async fn download_via_scoped_token(
         }
     }
 
-    // Mark token as used if single-use
-    if validated.single_use {
-        mark_token_used(&pool, &validated.token_hash).await;
+    // Atomically claim single-use tokens — reject if another request already consumed it
+    if validated.single_use && !claim_single_use_token(&pool, &validated.token_hash).await {
+        return Err(api_err(
+            StatusCode::UNAUTHORIZED,
+            "invalid_token",
+            "Download token is invalid, expired, or already used",
+        ));
     }
 
     // Serve the file via storage backend

--- a/crates/oored/src/artifacts.rs
+++ b/crates/oored/src/artifacts.rs
@@ -16,6 +16,7 @@ use uuid::Uuid;
 use crate::AppState;
 use crate::extractors::AuthUser;
 use crate::rbac::check_permission;
+use crate::retention::load_global_policy;
 use crate::runners::RunnerAuth;
 use crate::store::write_audit_log;
 use crate::util::{api_err, now_unix};
@@ -57,6 +58,7 @@ fn row_to_artifact(row: &sqlx::sqlite::SqliteRow) -> Artifact {
         checksum: row.get("checksum"),
         metadata,
         created_at: row.get("created_at"),
+        expires_at: row.get("expires_at"),
     }
 }
 
@@ -195,10 +197,19 @@ pub async fn create_artifact(
             .unwrap_or_default()
     };
 
+    // Compute artifact expiry from retention policy's artifact_ttl_days
+    let expires_at: Option<i64> = match load_global_policy(&pool).await {
+        Ok(policy) => policy.artifact_ttl_days.map(|days| now + days * 86400),
+        Err(e) => {
+            error!(error = %e, "failed to load retention policy for artifact TTL; defaulting to no expiry");
+            None
+        }
+    };
+
     // Insert artifact row only after URL generation succeeds
     let insert_result = sqlx::query(
-        "INSERT INTO artifacts (id, build_id, name, artifact_type, file_path, file_size, checksum, metadata, created_at) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        "INSERT INTO artifacts (id, build_id, name, artifact_type, file_path, file_size, checksum, metadata, created_at, expires_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
     )
     .bind(&artifact_id)
     .bind(&build_id)
@@ -209,6 +220,7 @@ pub async fn create_artifact(
     .bind(&checksum)
     .bind(&metadata_str)
     .bind(now)
+    .bind(expires_at)
     .execute(&pool)
     .await;
 
@@ -272,6 +284,7 @@ pub async fn create_artifact(
         checksum,
         metadata: req.metadata,
         created_at: now,
+        expires_at,
     };
 
     Ok(Json(CreateArtifactResponse {
@@ -338,6 +351,18 @@ pub async fn generate_download_link(
             )
         })?
         .ok_or_else(|| api_err(StatusCode::NOT_FOUND, "not_found", "Artifact not found"))?;
+
+    // Reject downloads of expired artifacts
+    let artifact_expires_at: Option<i64> = row.get("expires_at");
+    if let Some(ea) = artifact_expires_at
+        && ea <= now_unix()
+    {
+        return Err(api_err(
+            StatusCode::GONE,
+            "artifact_expired",
+            "This artifact has expired",
+        ));
+    }
 
     let file_path: String = row.get("file_path");
 

--- a/crates/oored/src/artifacts.rs
+++ b/crates/oored/src/artifacts.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 use crate::AppState;
 use crate::extractors::AuthUser;
 use crate::rbac::check_permission;
-use crate::retention::load_global_policy;
+use crate::retention::load_effective_policy;
 use crate::runners::RunnerAuth;
 use crate::store::write_audit_log;
 use crate::util::{api_err, now_unix};
@@ -108,7 +108,7 @@ pub async fn create_artifact(
     };
 
     // Verify build exists and is assigned to this runner
-    let build_row = sqlx::query("SELECT id, runner_id FROM builds WHERE id = ?1")
+    let build_row = sqlx::query("SELECT id, runner_id, project_id FROM builds WHERE id = ?1")
         .bind(&job_id)
         .fetch_optional(&pool)
         .await
@@ -132,6 +132,7 @@ pub async fn create_artifact(
     }
 
     let build_id: String = build_row.get("id");
+    let project_id: String = build_row.get("project_id");
     let checksum = req
         .checksum
         .as_deref()
@@ -197,8 +198,8 @@ pub async fn create_artifact(
             .unwrap_or_default()
     };
 
-    // Compute artifact expiry from retention policy's artifact_ttl_days
-    let expires_at: Option<i64> = match load_global_policy(&pool).await {
+    // Compute artifact expiry from effective retention policy (project override > global)
+    let expires_at: Option<i64> = match load_effective_policy(&pool, &project_id).await {
         Ok(policy) => policy.artifact_ttl_days.map(|days| now + days * 86400),
         Err(e) => {
             error!(error = %e, "failed to load retention policy for artifact TTL; defaulting to no expiry");

--- a/crates/oored/src/background.rs
+++ b/crates/oored/src/background.rs
@@ -35,7 +35,8 @@ pub fn start_background_tasks(
     tokio::spawn(lease_timeout_monitor(pool.clone()));
     tokio::spawn(build_timeout_monitor(pool.clone(), scheduler.clone()));
     tokio::spawn(runner_heartbeat_monitor(pool.clone(), scheduler));
-    tokio::spawn(retention_cleanup_monitor(pool, storage));
+    tokio::spawn(retention_cleanup_monitor(pool.clone(), storage.clone()));
+    tokio::spawn(expired_artifact_monitor(pool, storage));
 }
 
 /// Monitor assigned builds whose lease has expired.
@@ -501,6 +502,114 @@ async fn run_retention_cleanup(
     Ok(policy.cleanup_interval_secs)
 }
 
+/// Expired artifact and download token cleanup monitor.
+///
+/// Runs every 5 minutes. Deletes artifacts whose `expires_at` has passed
+/// (files from storage first, then DB rows). Also prunes expired/revoked
+/// download tokens.
+async fn expired_artifact_monitor(pool: SqlitePool, storage: Arc<RwLock<StorageBackend>>) {
+    // Wait 60 seconds on startup before first check
+    tokio::time::sleep(Duration::from_secs(60)).await;
+
+    loop {
+        let now = now_unix();
+
+        // 1. Clean up expired artifacts
+        let expired_artifacts = match sqlx::query(
+            "SELECT a.id, a.file_path, a.file_size, a.build_id \
+             FROM artifacts a \
+             WHERE a.expires_at IS NOT NULL AND a.expires_at < ?1",
+        )
+        .bind(now)
+        .fetch_all(&pool)
+        .await
+        {
+            Ok(rows) => rows,
+            Err(e) => {
+                error!(error = %e, "expired_artifact_monitor: failed to query expired artifacts");
+                tokio::time::sleep(Duration::from_secs(300)).await;
+                continue;
+            }
+        };
+
+        let mut artifacts_deleted: i64 = 0;
+        let mut bytes_reclaimed: i64 = 0;
+
+        for row in &expired_artifacts {
+            let artifact_id: String = row.get("id");
+            let file_path: String = row.get("file_path");
+            let file_size: Option<i64> = row.get("file_size");
+
+            // Delete from storage first
+            let backend = storage.read().await;
+            if let Err(e) = backend.delete_object(&file_path).await {
+                warn!(
+                    artifact_id = %artifact_id,
+                    file_path = %file_path,
+                    error = %e,
+                    "expired_artifact_monitor: failed to delete artifact file, skipping"
+                );
+                continue;
+            }
+            drop(backend);
+
+            // Delete DB row (CASCADE deletes download tokens too)
+            if let Err(e) = sqlx::query("DELETE FROM artifacts WHERE id = ?1")
+                .bind(&artifact_id)
+                .execute(&pool)
+                .await
+            {
+                warn!(artifact_id = %artifact_id, error = %e, "expired_artifact_monitor: failed to delete artifact row");
+            } else {
+                artifacts_deleted += 1;
+                bytes_reclaimed += file_size.unwrap_or(0);
+            }
+        }
+
+        // 2. Clean up expired/revoked download tokens (belt-and-suspenders alongside CASCADE)
+        let tokens_deleted = match sqlx::query(
+            "DELETE FROM artifact_download_tokens \
+             WHERE expires_at < ?1 OR revoked_at IS NOT NULL",
+        )
+        .bind(now)
+        .execute(&pool)
+        .await
+        {
+            Ok(result) => result.rows_affected() as i64,
+            Err(e) => {
+                warn!(error = %e, "expired_artifact_monitor: failed to clean up expired download tokens");
+                0
+            }
+        };
+
+        if artifacts_deleted > 0 || tokens_deleted > 0 {
+            info!(
+                artifacts_deleted,
+                bytes_reclaimed, tokens_deleted, "expired_artifact_monitor: cleanup completed"
+            );
+
+            let summary = serde_json::json!({
+                "artifacts_deleted": artifacts_deleted,
+                "bytes_reclaimed": bytes_reclaimed,
+                "tokens_deleted": tokens_deleted,
+                "ran_at": now,
+            });
+
+            let _ = write_audit_log(
+                &pool,
+                None,
+                "artifact_expiry_cleanup_completed",
+                "artifact",
+                None,
+                Some(&summary.to_string()),
+            )
+            .await;
+        }
+
+        tokio::time::sleep(Duration::from_secs(300)).await;
+    }
+}
+
 /// Load the effective retention policy for a project (override merged with global).
 async fn load_effective_project_policy(
     pool: &SqlitePool,
@@ -540,6 +649,9 @@ async fn load_effective_project_policy(
             .unwrap_or_else(|| global.keep_statuses.clone()),
         dry_run: global.dry_run,
         cleanup_interval_secs: global.cleanup_interval_secs,
+        artifact_ttl_days: row
+            .get::<Option<i64>, _>("artifact_ttl_days")
+            .or(global.artifact_ttl_days),
         updated_at: Some(row.get::<i64, _>("updated_at")),
     })
 }

--- a/crates/oored/src/background.rs
+++ b/crates/oored/src/background.rs
@@ -2,7 +2,6 @@
 //! and retention cleanup.
 
 use std::collections::HashSet;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -11,7 +10,7 @@ use sqlx::{Row, SqlitePool};
 use tokio::sync::RwLock;
 use tracing::{error, info, warn};
 
-use crate::retention::load_global_policy;
+use crate::retention::{load_effective_policy, load_global_policy};
 use crate::scheduler::{BuildStateEvent, RunnerStateEvent, Scheduler};
 use crate::storage::StorageBackend;
 use crate::store::write_audit_log;
@@ -273,7 +272,9 @@ async fn run_retention_cleanup(
         let project_id: String = project_row.get("id");
 
         // Load project override if any, merge with global
-        let effective = load_effective_project_policy(pool, &policy, &project_id).await?;
+        let effective = load_effective_policy(pool, &project_id)
+            .await
+            .map_err(|e| anyhow::anyhow!(e))?;
 
         if !effective.enabled {
             continue;
@@ -608,50 +609,4 @@ async fn expired_artifact_monitor(pool: SqlitePool, storage: Arc<RwLock<StorageB
 
         tokio::time::sleep(Duration::from_secs(300)).await;
     }
-}
-
-/// Load the effective retention policy for a project (override merged with global).
-async fn load_effective_project_policy(
-    pool: &SqlitePool,
-    global: &oore_contract::RetentionPolicy,
-    project_id: &str,
-) -> Result<oore_contract::RetentionPolicy, anyhow::Error> {
-    let row = sqlx::query("SELECT * FROM project_retention_overrides WHERE project_id = ?1")
-        .bind(project_id)
-        .fetch_optional(pool)
-        .await?;
-
-    let Some(row) = row else {
-        return Ok(global.clone());
-    };
-
-    Ok(oore_contract::RetentionPolicy {
-        enabled: row
-            .get::<Option<i32>, _>("enabled")
-            .map(|v| v != 0)
-            .unwrap_or(global.enabled),
-        max_age_days: row
-            .get::<Option<i64>, _>("max_age_days")
-            .or(global.max_age_days),
-        max_builds_per_project: row
-            .get::<Option<i64>, _>("max_builds_per_project")
-            .or(global.max_builds_per_project),
-        max_artifact_size_bytes: row
-            .get::<Option<i64>, _>("max_artifact_size_bytes")
-            .or(global.max_artifact_size_bytes),
-        cleanup_target: row
-            .get::<Option<String>, _>("cleanup_target")
-            .and_then(|s| RetentionCleanupTarget::from_str(&s).ok())
-            .unwrap_or(global.cleanup_target),
-        keep_statuses: row
-            .get::<Option<String>, _>("keep_statuses")
-            .and_then(|s| serde_json::from_str(&s).ok())
-            .unwrap_or_else(|| global.keep_statuses.clone()),
-        dry_run: global.dry_run,
-        cleanup_interval_secs: global.cleanup_interval_secs,
-        artifact_ttl_days: row
-            .get::<Option<i64>, _>("artifact_ttl_days")
-            .or(global.artifact_ttl_days),
-        updated_at: Some(row.get::<i64, _>("updated_at")),
-    })
 }

--- a/crates/oored/src/bin/openapi_export.rs
+++ b/crates/oored/src/bin/openapi_export.rs
@@ -145,6 +145,11 @@ use utoipa::OpenApi;
         paths::create_artifact,
         paths::list_artifacts,
         paths::generate_download_link,
+        // ── Scoped Download Tokens (OOR-140) ──
+        paths::create_scoped_download_token,
+        paths::list_scoped_download_tokens,
+        paths::revoke_scoped_download_token,
+        paths::download_via_scoped_token,
         // ── Notification Channels ──
         paths::list_notification_channels,
         paths::create_notification_channel,
@@ -308,6 +313,11 @@ use utoipa::OpenApi;
         oore_contract::CreateArtifactResponse,
         oore_contract::ListArtifactsResponse,
         oore_contract::ArtifactDownloadLinkResponse,
+        oore_contract::CreateScopedDownloadTokenRequest,
+        oore_contract::CreateScopedDownloadTokenResponse,
+        oore_contract::ArtifactDownloadTokenSummary,
+        oore_contract::ListArtifactDownloadTokensResponse,
+        oore_contract::RevokeArtifactDownloadTokenResponse,
         oore_contract::ArtifactStorageSettingsResponse,
         oore_contract::UpdateArtifactStorageSettingsRequest,
         // Instance Settings
@@ -1700,6 +1710,63 @@ mod paths {
         )
     )]
     pub(super) async fn generate_download_link() {}
+
+    // ── Scoped Download Tokens (OOR-140) ──
+
+    /// Create scoped download token
+    ///
+    /// Generates a scoped, time-limited download token for a specific artifact.
+    /// The token can be shared with external users who don't have an account.
+    #[utoipa::path(post, path = "/v1/artifacts/{artifact_id}/scoped-token", tag = "Scoped Download Tokens",
+        params(("artifact_id" = String, Path, description = "Artifact ID")),
+        request_body = CreateScopedDownloadTokenRequest,
+        security(("bearer_auth" = [])),
+        responses(
+            (status = 200, description = "Scoped download token created", body = CreateScopedDownloadTokenResponse),
+            (status = 404, description = "Artifact not found", body = ApiError),
+            (status = 410, description = "Artifact expired", body = ApiError),
+        )
+    )]
+    pub(super) async fn create_scoped_download_token() {}
+
+    /// List scoped download tokens
+    ///
+    /// Lists all scoped download tokens for a specific artifact, including expired and revoked ones.
+    #[utoipa::path(get, path = "/v1/artifacts/{artifact_id}/scoped-tokens", tag = "Scoped Download Tokens",
+        params(("artifact_id" = String, Path, description = "Artifact ID")),
+        security(("bearer_auth" = [])),
+        responses(
+            (status = 200, description = "List of scoped download tokens", body = ListArtifactDownloadTokensResponse),
+        )
+    )]
+    pub(super) async fn list_scoped_download_tokens() {}
+
+    /// Revoke scoped download token
+    ///
+    /// Revokes a scoped download token so it can no longer be used.
+    #[utoipa::path(delete, path = "/v1/artifact-tokens/{token_id}", tag = "Scoped Download Tokens",
+        params(("token_id" = String, Path, description = "Download token ID")),
+        security(("bearer_auth" = [])),
+        responses(
+            (status = 200, description = "Token revoked", body = RevokeArtifactDownloadTokenResponse),
+            (status = 404, description = "Token not found", body = ApiError),
+        )
+    )]
+    pub(super) async fn revoke_scoped_download_token() {}
+
+    /// Download via scoped token
+    ///
+    /// Downloads an artifact using a scoped download token. No session auth required —
+    /// the token itself is the authorization. For S3/R2 storage, redirects to a presigned URL.
+    #[utoipa::path(get, path = "/v1/artifacts/dl/{token}", tag = "Scoped Download Tokens",
+        params(("token" = String, Path, description = "Scoped download token")),
+        responses(
+            (status = 302, description = "Redirect to presigned download URL"),
+            (status = 401, description = "Invalid or expired token", body = ApiError),
+            (status = 410, description = "Artifact expired", body = ApiError),
+        )
+    )]
+    pub(super) async fn download_via_scoped_token() {}
 
     // ── Webhooks ──
 

--- a/crates/oored/src/lib.rs
+++ b/crates/oored/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod api_tokens;
 pub mod apple_api;
+pub mod artifact_tokens;
 pub mod artifacts;
 pub mod audit_logs;
 pub mod auth;
@@ -2320,6 +2321,23 @@ async fn build_router_inner(
         .route(
             "/v1/artifacts/local-download/{token}",
             get(artifacts::download_local_artifact),
+        )
+        // ── Scoped download tokens (OOR-140) ──────────────────
+        .route(
+            "/v1/artifacts/{artifact_id}/scoped-token",
+            post(artifact_tokens::create_scoped_token_handler),
+        )
+        .route(
+            "/v1/artifacts/{artifact_id}/scoped-tokens",
+            get(artifact_tokens::list_scoped_tokens_handler),
+        )
+        .route(
+            "/v1/artifact-tokens/{token_id}",
+            axum::routing::delete(artifact_tokens::revoke_scoped_token_handler),
+        )
+        .route(
+            "/v1/artifacts/dl/{token}",
+            get(artifact_tokens::download_via_scoped_token),
         )
         // ── Retention policy ────────────────────────────────────
         .route(

--- a/crates/oored/src/retention.rs
+++ b/crates/oored/src/retention.rs
@@ -33,6 +33,7 @@ fn default_policy() -> RetentionPolicy {
         keep_statuses: Vec::new(),
         dry_run: false,
         cleanup_interval_secs: 3600,
+        artifact_ttl_days: None,
         updated_at: None,
     }
 }
@@ -57,6 +58,7 @@ pub async fn load_global_policy(pool: &sqlx::SqlitePool) -> Result<RetentionPoli
             .unwrap_or_default(),
         dry_run: row.get::<i32, _>("dry_run") != 0,
         cleanup_interval_secs: row.get("cleanup_interval_secs"),
+        artifact_ttl_days: row.get("artifact_ttl_days"),
         updated_at: Some(row.get::<i64, _>("updated_at")),
     })
 }
@@ -76,6 +78,7 @@ fn merge_override(global: &RetentionPolicy, ovr: &ProjectRetentionOverride) -> R
             .unwrap_or_else(|| global.keep_statuses.clone()),
         dry_run: global.dry_run,
         cleanup_interval_secs: global.cleanup_interval_secs,
+        artifact_ttl_days: ovr.artifact_ttl_days.or(global.artifact_ttl_days),
         updated_at: ovr.updated_at.or(global.updated_at),
     }
 }
@@ -145,6 +148,15 @@ pub async fn update_retention_policy(
             "max_artifact_size_bytes must be at least 1",
         ));
     }
+    if let Some(v) = req.artifact_ttl_days
+        && v < 1
+    {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "validation_error",
+            "artifact_ttl_days must be at least 1",
+        ));
+    }
 
     let now = now_unix();
     let keep_statuses_json =
@@ -156,12 +168,13 @@ pub async fn update_retention_policy(
     sqlx::query(
         "INSERT INTO retention_policy (id, enabled, max_age_days, max_builds_per_project, \
          max_artifact_size_bytes, cleanup_target, keep_statuses, dry_run, cleanup_interval_secs, \
-         updated_by, created_at, updated_at) \
-         VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?10) \
+         artifact_ttl_days, updated_by, created_at, updated_at) \
+         VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?11) \
          ON CONFLICT(id) DO UPDATE SET \
          enabled = ?1, max_age_days = ?2, max_builds_per_project = ?3, \
          max_artifact_size_bytes = ?4, cleanup_target = ?5, keep_statuses = ?6, \
-         dry_run = ?7, cleanup_interval_secs = ?8, updated_by = ?9, updated_at = ?10",
+         dry_run = ?7, cleanup_interval_secs = ?8, artifact_ttl_days = ?9, \
+         updated_by = ?10, updated_at = ?11",
     )
     .bind(req.enabled as i32)
     .bind(req.max_age_days)
@@ -171,6 +184,7 @@ pub async fn update_retention_policy(
     .bind(&keep_statuses_json)
     .bind(req.dry_run as i32)
     .bind(req.cleanup_interval_secs)
+    .bind(req.artifact_ttl_days)
     .bind(&auth.0.user_id)
     .bind(now)
     .execute(pool)
@@ -263,6 +277,7 @@ pub async fn get_project_retention(
             keep_statuses: row
                 .get::<Option<String>, _>("keep_statuses")
                 .and_then(|s| serde_json::from_str(&s).ok()),
+            artifact_ttl_days: row.get("artifact_ttl_days"),
             updated_at: Some(row.get::<i64, _>("updated_at")),
         };
 
@@ -302,12 +317,12 @@ pub async fn update_project_retention(
     sqlx::query(
         "INSERT INTO project_retention_overrides \
          (project_id, enabled, max_age_days, max_builds_per_project, max_artifact_size_bytes, \
-          cleanup_target, keep_statuses, updated_by, created_at, updated_at) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?9) \
+          cleanup_target, keep_statuses, artifact_ttl_days, updated_by, created_at, updated_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?10) \
          ON CONFLICT(project_id) DO UPDATE SET \
          enabled = ?2, max_age_days = ?3, max_builds_per_project = ?4, \
          max_artifact_size_bytes = ?5, cleanup_target = ?6, keep_statuses = ?7, \
-         updated_by = ?8, updated_at = ?9",
+         artifact_ttl_days = ?8, updated_by = ?9, updated_at = ?10",
     )
     .bind(&project_id)
     .bind(req.enabled.map(|v| v as i32))
@@ -316,6 +331,7 @@ pub async fn update_project_retention(
     .bind(req.max_artifact_size_bytes)
     .bind(&cleanup_target_str)
     .bind(&keep_statuses_json)
+    .bind(req.artifact_ttl_days)
     .bind(&auth.0.user_id)
     .bind(now)
     .execute(pool)

--- a/crates/oored/src/retention.rs
+++ b/crates/oored/src/retention.rs
@@ -63,6 +63,44 @@ pub async fn load_global_policy(pool: &sqlx::SqlitePool) -> Result<RetentionPoli
     })
 }
 
+/// Load the effective retention policy for a project (global merged with project override).
+///
+/// Used by artifact creation to compute per-artifact expiry and by the background
+/// cleanup task.  Falls back to the global policy when no project override exists.
+pub async fn load_effective_policy(
+    pool: &sqlx::SqlitePool,
+    project_id: &str,
+) -> Result<RetentionPolicy, sqlx::Error> {
+    let global = load_global_policy(pool).await?;
+
+    let row = sqlx::query("SELECT * FROM project_retention_overrides WHERE project_id = ?1")
+        .bind(project_id)
+        .fetch_optional(pool)
+        .await?;
+
+    let Some(row) = row else {
+        return Ok(global);
+    };
+
+    let ovr = ProjectRetentionOverride {
+        project_id: project_id.to_string(),
+        enabled: row.get::<Option<i32>, _>("enabled").map(|v| v != 0),
+        max_age_days: row.get("max_age_days"),
+        max_builds_per_project: row.get("max_builds_per_project"),
+        max_artifact_size_bytes: row.get("max_artifact_size_bytes"),
+        cleanup_target: row
+            .get::<Option<String>, _>("cleanup_target")
+            .and_then(|s| RetentionCleanupTarget::from_str(&s).ok()),
+        keep_statuses: row
+            .get::<Option<String>, _>("keep_statuses")
+            .and_then(|s| serde_json::from_str(&s).ok()),
+        artifact_ttl_days: row.get("artifact_ttl_days"),
+        updated_at: Some(row.get::<i64, _>("updated_at")),
+    };
+
+    Ok(merge_override(&global, &ovr))
+}
+
 fn merge_override(global: &RetentionPolicy, ovr: &ProjectRetentionOverride) -> RetentionPolicy {
     RetentionPolicy {
         enabled: ovr.enabled.unwrap_or(global.enabled),

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -12,6 +12,16 @@ Rules:
 
 ## 2026-03-19
 
+- **Artifact expiry and scoped download tokens** ([OOR-140](https://linear.app/oorebuild/issue/OOR-140/artifact-expiry-and-scoped-download-tokens)):
+  - Added `expires_at` column to `artifacts` table; computed at creation from `artifact_ttl_days` retention policy setting.
+  - Added `artifact_ttl_days` field to `RetentionPolicy`, `ProjectRetentionOverride`, and their update requests.
+  - New `artifact_download_tokens` table for DB-backed scoped download tokens (survives daemon restart).
+  - New backend module `artifact_tokens.rs` with 4 endpoints: `POST /v1/artifacts/{artifact_id}/scoped-token`, `GET /v1/artifacts/{artifact_id}/scoped-tokens`, `DELETE /v1/artifact-tokens/{token_id}`, `GET /v1/artifacts/dl/{token}`.
+  - `GET /v1/artifacts/dl/{token}` is unauthenticated — the scoped token IS the authorization. Supports single-use and time-limited tokens.
+  - Background `expired_artifact_monitor` task cleans up expired artifacts and download tokens every 5 minutes.
+  - Frontend: artifact rows show expiry badge, new "Share Link" button opens dialog to create scoped tokens with configurable TTL and single-use option.
+  - Migration `025_artifact_expiry_and_download_tokens.sql`.
+  - OpenAPI spec updated with new endpoints and schemas.
 - **API Tokens frontend** ([OOR-134](https://linear.app/oorebuild/issue/OOR-134)):
   - Added API token types (`CreateApiTokenRequest`, `CreateApiTokenResponse`, `ApiTokenSummary`, `ListApiTokensResponse`, `RevokeApiTokenResponse`) to `apps/web/src/lib/types.ts`.
   - Added `createApiToken`, `listApiTokens`, `revokeApiToken` API functions to `apps/web/src/lib/api.ts`.


### PR DESCRIPTION
## What

Add per-artifact expiry TTL and DB-backed scoped download tokens for sharing artifacts without requiring a full authenticated session.

- `expires_at` column on artifacts, computed from `artifact_ttl_days` in retention policy; expired artifacts return 410 Gone
- New `artifact_download_tokens` table: per-artifact scope, time-limited (default 24h, max 7d), optional single-use, revocable, survives restart
- Unauthenticated `GET /v1/artifacts/dl/{token}` endpoint — token is the authorization; redirects to S3 presigned URL or streams from local storage
- Background task purges expired artifacts from storage + DB and cleans up expired/revoked tokens every 5 minutes
- Frontend: expiry badges on artifact rows, Share Link button with two-phase dialog (create → show-token-once with copy)

## Why

Closes OOR-140. QA testers need to share build artifacts externally without granting full CI access. In-memory download tokens were lost on restart and had no per-artifact scope.

## Testing

- `make validate` passes (cargo-check, lint-web, build-web, build-docs, docs-check)
- Manually verified: create artifact → share link → download via scoped token → single-use consumption → expiry rejection (410)

## Docs

- `docs/changes.md` updated with OOR-140 entry
- OpenAPI spec regenerated via `make gen-openapi`