### PR TITLE
Fix security scan findings

### DIFF
--- a/apps/docs-site/docs/concepts/security-model.md
+++ b/apps/docs-site/docs/concepts/security-model.md
@@ -25,6 +25,7 @@ The daemon also supports loopback-only local login (`POST /v1/auth/local/login`)
 In Trusted Proxy mode, Oore CI trusts identity headers from an upstream proxy and creates normal Oore sessions per user.
 
 - Default identity header: `x-warpgate-username` (expected to be an email)
+- Optional shared-secret header: `x-oore-trusted-proxy-secret`
 - Trust boundary: headers are accepted only when the immediate peer is trusted (loopback by default, optional CIDR allowlist for remote proxy peers)
 - Authorization stays in Oore RBAC (owner/admin/developer/qa_viewer) via Oore users and roles
 

--- a/apps/docs-site/docs/getting-started/first-instance.md
+++ b/apps/docs-site/docs/getting-started/first-instance.md
@@ -137,7 +137,7 @@ If you choose `Remote (Trusted Proxy / Warpgate)`, the web UI setup flow asks fo
 
 - trusted user email header (default: `x-warpgate-username`)
 - optional trusted proxy CIDRs
-- optional shared secret
+- optional shared secret sent by the proxy as `x-oore-trusted-proxy-secret`
 
 Then the owner is claimed from the trusted proxy-authenticated request instead of an OIDC redirect.
 

--- a/apps/docs-site/docs/operations/mac-studio-netbird-warpgate.md
+++ b/apps/docs-site/docs/operations/mac-studio-netbird-warpgate.md
@@ -78,6 +78,7 @@ ci.macstudio.internal {
             header_up X-Forwarded-Proto https
             header_up X-Forwarded-For {remote_host}
             header_up X-Warpgate-Username {header.X-Warpgate-Username}
+            header_up X-Oore-Trusted-Proxy-Secret {env.OORE_TRUSTED_PROXY_SHARED_SECRET}
         }
     }
 
@@ -95,6 +96,7 @@ Important details:
 
 - Serve `apps/web/dist` from the same HTTPS origin users open in the browser.
 - Preserve the Warpgate identity header when proxying `/v1/*`.
+- If you configure a trusted-proxy shared secret in Oore, forward the same value as `X-Oore-Trusted-Proxy-Secret` from the reverse proxy.
 - If Warpgate and the reverse proxy both run on the Mac Studio, `oored` will see the proxy peer as loopback, so `trusted_proxy_cidrs` can stay empty.
 - If `oored` sees a non-loopback proxy peer, add that proxy source CIDR during trusted-proxy setup.
 
@@ -127,9 +129,10 @@ In setup:
 1. Verify the bootstrap token.
 2. Choose `Remote (Trusted Proxy / Warpgate)`.
 3. Use `x-warpgate-username` as the user email header.
-4. Leave trusted proxy CIDRs empty if the reverse proxy talks to `oored` over loopback.
-5. Claim the owner account from the Warpgate-authenticated request.
-6. Finalize setup.
+4. Set a shared secret and configure the reverse proxy to send it as `X-Oore-Trusted-Proxy-Secret`.
+5. Leave trusted proxy CIDRs empty if the reverse proxy talks to `oored` over loopback.
+6. Claim the owner account from the Warpgate-authenticated request.
+7. Finalize setup.
 
 ## 6. Set External Access network settings after setup
 

--- a/apps/docs-site/docs/reference/api/auth.md
+++ b/apps/docs-site/docs/reference/api/auth.md
@@ -181,7 +181,12 @@ By default, Oore expects the user email in:
 X-Warpgate-Username
 ```
 
-The exact header name can be changed in trusted-proxy configuration.
+The exact identity header name can be changed in trusted-proxy configuration.
+If a shared secret is configured, the proxy must also send:
+
+```text
+X-Oore-Trusted-Proxy-Secret
+```
 
 ### Response `200 OK`
 
@@ -193,8 +198,10 @@ Returns `LocalLoginResponse`.
 |---|---|---|
 | 403 | `mode_restricted` | Instance is not in `runtime_mode=remote` with `remote_auth_mode=trusted_proxy` |
 | 403 | `trusted_proxy_peer_not_allowed` | Request did not come from a trusted proxy peer |
-| 403 | `trusted_proxy_identity_missing` | Trusted proxy identity header is missing |
-| 403 | `trusted_proxy_identity_invalid` | Trusted proxy identity header is not a valid email |
+| 401 | `trusted_proxy_shared_secret_missing` | Trusted proxy shared secret header is required but missing |
+| 401 | `trusted_proxy_shared_secret_invalid` | Trusted proxy shared secret header does not match |
+| 401 | `trusted_proxy_identity_missing` | Trusted proxy identity header is missing |
+| 401 | `trusted_proxy_identity_invalid` | Trusted proxy identity header is not a valid email |
 | 403 | `user_not_found` | No active user matched the forwarded email |
 
 ::: info

--- a/apps/docs-site/docs/reference/api/setup.md
+++ b/apps/docs-site/docs/reference/api/setup.md
@@ -243,7 +243,7 @@ POST /v1/setup/trusted-proxy/configure
 |---|---|---|---|
 | `user_email_header` | `string` | No | Header containing the authenticated user email. Defaults to `x-warpgate-username`. |
 | `trusted_proxy_cidrs` | `string[]` | No | Optional allowlist of proxy source CIDRs. |
-| `shared_secret` | `string` | No | Optional write-only shared secret for defense in depth. |
+| `shared_secret` | `string` | No | Optional write-only shared secret for defense in depth. When configured, the proxy must send it in `X-Oore-Trusted-Proxy-Secret`. |
 
 ### Response `200 OK`
 
@@ -356,6 +356,12 @@ By default, the request must include:
 X-Warpgate-Username: owner@example.com
 ```
 
+If a trusted-proxy shared secret is configured, the request must also include:
+
+```text
+X-Oore-Trusted-Proxy-Secret: configured-shared-secret
+```
+
 ### Response `200 OK`
 
 ```json
@@ -373,10 +379,12 @@ X-Warpgate-Username: owner@example.com
 | 401 | `missing_auth` | Authorization header not provided |
 | 401 | `invalid_session` | Setup session token is invalid |
 | 401 | `session_expired` | Setup session has expired |
+| 401 | `trusted_proxy_shared_secret_missing` | Trusted proxy shared secret header is required but missing |
+| 401 | `trusted_proxy_shared_secret_invalid` | Trusted proxy shared secret header does not match |
 | 403 | `mode_restricted` | Instance is not in trusted-proxy setup mode |
 | 403 | `trusted_proxy_peer_not_allowed` | Request did not come from a trusted proxy peer |
-| 403 | `trusted_proxy_identity_missing` | Trusted proxy identity header is missing |
-| 403 | `trusted_proxy_identity_invalid` | Trusted proxy identity header is not a valid email |
+| 401 | `trusted_proxy_identity_missing` | Trusted proxy identity header is missing |
+| 401 | `trusted_proxy_identity_invalid` | Trusted proxy identity header is not a valid email |
 | 409 | `trusted_proxy_not_configured` | Trusted proxy settings have not been configured yet |
 | 409 | `invalid_state` | Not in `idp_configured` state |
 

--- a/crates/oore-runner/src/lib.rs
+++ b/crates/oore-runner/src/lib.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -537,6 +537,28 @@ fn decode_runner_b64(value: &str, field_name: &str) -> anyhow::Result<Vec<u8>> {
         .map_err(|e| anyhow::anyhow!("invalid base64 value for {field_name}: {e}"))
 }
 
+fn safe_ios_signing_filename(
+    raw: &str,
+    fallback: &str,
+    field_name: &str,
+) -> anyhow::Result<String> {
+    let trimmed = raw.trim();
+    let candidate = if trimmed.is_empty() {
+        fallback
+    } else {
+        trimmed
+    };
+    let mut components = Path::new(candidate).components();
+    let is_single_normal_component =
+        matches!(components.next(), Some(Component::Normal(_))) && components.next().is_none();
+
+    if !is_single_normal_component || candidate.contains('/') || candidate.contains('\\') {
+        anyhow::bail!("{field_name} must be a filename, not a path");
+    }
+
+    Ok(candidate.to_string())
+}
+
 fn write_export_options_plist(
     output_path: &Path,
     team_id: &str,
@@ -611,11 +633,9 @@ fn install_ios_signing_bundle(
         )
     })?;
 
-    let p12_path = signing_dir.join(if bundle.p12_filename.trim().is_empty() {
-        "distribution.p12"
-    } else {
-        bundle.p12_filename.trim()
-    });
+    let p12_filename =
+        safe_ios_signing_filename(&bundle.p12_filename, "distribution.p12", "p12_filename")?;
+    let p12_path = signing_dir.join(p12_filename);
     let p12_bytes = decode_runner_b64(&bundle.p12_base64, "p12")?;
     if p12_bytes.is_empty() {
         anyhow::bail!("decoded iOS p12 is empty");
@@ -673,11 +693,12 @@ fn install_ios_signing_bundle(
                 );
             }
 
-            let work_file_name = if profile.profile_filename.trim().is_empty() {
-                format!("{}.mobileprovision", profile.bundle_id)
-            } else {
-                profile.profile_filename.trim().to_string()
-            };
+            let fallback_profile_name = format!("{}.mobileprovision", profile.bundle_id);
+            let work_file_name = safe_ios_signing_filename(
+                &profile.profile_filename,
+                &fallback_profile_name,
+                "profile_filename",
+            )?;
             let work_path = profile_work_dir.join(work_file_name);
             fs::write(&work_path, &profile_bytes).map_err(|e| {
                 anyhow::anyhow!("failed to write profile {}: {e}", work_path.display())
@@ -3801,6 +3822,34 @@ mod tests {
     fn chooses_release_testing_export_method_when_available() {
         let help = "Available options: app-store-connect, release-testing, enterprise";
         assert_eq!(choose_ios_export_method(help), "release-testing");
+    }
+
+    #[test]
+    fn ios_signing_filename_must_be_single_path_component() {
+        assert_eq!(
+            safe_ios_signing_filename(" dist.p12 ", "fallback.p12", "p12_filename")
+                .expect("valid filename"),
+            "dist.p12"
+        );
+        assert_eq!(
+            safe_ios_signing_filename("", "fallback.p12", "p12_filename")
+                .expect("fallback filename"),
+            "fallback.p12"
+        );
+
+        for unsafe_name in [
+            "../dist.p12",
+            "/tmp/dist.p12",
+            "profiles/dist.mobileprovision",
+            "profiles\\dist.mobileprovision",
+            ".",
+            "..",
+        ] {
+            assert!(
+                safe_ios_signing_filename(unsafe_name, "fallback.p12", "profile_filename").is_err(),
+                "{unsafe_name} should be rejected"
+            );
+        }
     }
 
     #[test]

--- a/crates/oored/src/artifacts.rs
+++ b/crates/oored/src/artifacts.rs
@@ -15,7 +15,9 @@ use uuid::Uuid;
 
 use crate::AppState;
 use crate::extractors::AuthUser;
-use crate::rbac::check_permission;
+use crate::project_rbac::{
+    ProjectPermission, require_project_permission, resolve_effective_project_role,
+};
 use crate::retention::load_effective_policy;
 use crate::runners::RunnerAuth;
 use crate::store::write_audit_log;
@@ -60,6 +62,22 @@ fn row_to_artifact(row: &sqlx::sqlite::SqliteRow) -> Artifact {
         created_at: row.get("created_at"),
         expires_at: row.get("expires_at"),
     }
+}
+
+async fn require_project_artifact_read(
+    pool: &sqlx::SqlitePool,
+    auth: &AuthUser,
+    project_id: &str,
+) -> Result<(), (StatusCode, Json<ApiError>)> {
+    let effective = resolve_effective_project_role(
+        pool,
+        &auth.0.user_id,
+        &auth.0.role,
+        project_id,
+        &auth.0.auth_source,
+    )
+    .await?;
+    require_project_permission(&effective, ProjectPermission::ReadArtifacts)
 }
 
 // ── Handlers ────────────────────────────────────────────────────
@@ -300,12 +318,25 @@ pub async fn list_artifacts(
     auth: AuthUser,
     Path(build_id): Path<String>,
 ) -> ApiResult<ListArtifactsResponse> {
-    check_permission(&state.enforcer, &auth.0.role, "builds", "read").await?;
-
     let pool = {
         let store = state.store.lock().await;
         store.pool().clone()
     };
+
+    let project_id: String = sqlx::query_scalar("SELECT project_id FROM builds WHERE id = ?1")
+        .bind(&build_id)
+        .fetch_optional(&pool)
+        .await
+        .map_err(|e| {
+            error!(error = %e, "failed to load build for artifact listing");
+            api_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "store_error",
+                "Failed to list artifacts",
+            )
+        })?
+        .ok_or_else(|| api_err(StatusCode::NOT_FOUND, "not_found", "Build not found"))?;
+    require_project_artifact_read(&pool, &auth, &project_id).await?;
 
     let rows = sqlx::query("SELECT * FROM artifacts WHERE build_id = ?1 ORDER BY created_at ASC")
         .bind(&build_id)
@@ -331,27 +362,33 @@ pub async fn generate_download_link(
     auth: AuthUser,
     Path(artifact_id): Path<String>,
 ) -> ApiResult<ArtifactDownloadLinkResponse> {
-    check_permission(&state.enforcer, &auth.0.role, "builds", "read").await?;
-
     let pool = {
         let store = state.store.lock().await;
         store.pool().clone()
     };
 
     // Look up artifact
-    let row = sqlx::query("SELECT * FROM artifacts WHERE id = ?1")
-        .bind(&artifact_id)
-        .fetch_optional(&pool)
-        .await
-        .map_err(|e| {
-            error!(error = %e, "failed to fetch artifact");
-            api_err(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "store_error",
-                "Failed to fetch artifact",
-            )
-        })?
-        .ok_or_else(|| api_err(StatusCode::NOT_FOUND, "not_found", "Artifact not found"))?;
+    let row = sqlx::query(
+        "SELECT a.*, b.project_id AS project_id \
+         FROM artifacts a \
+         JOIN builds b ON b.id = a.build_id \
+         WHERE a.id = ?1",
+    )
+    .bind(&artifact_id)
+    .fetch_optional(&pool)
+    .await
+    .map_err(|e| {
+        error!(error = %e, "failed to fetch artifact");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to fetch artifact",
+        )
+    })?
+    .ok_or_else(|| api_err(StatusCode::NOT_FOUND, "not_found", "Artifact not found"))?;
+
+    let project_id: String = row.get("project_id");
+    require_project_artifact_read(&pool, &auth, &project_id).await?;
 
     // Reject downloads of expired artifacts
     let artifact_expires_at: Option<i64> = row.get("expires_at");

--- a/crates/oored/src/auth.rs
+++ b/crates/oored/src/auth.rs
@@ -1029,6 +1029,12 @@ pub async fn trusted_proxy_login(
         ));
     }
 
+    crate::instance_settings::verify_trusted_proxy_shared_secret(
+        &headers,
+        &proxy_settings,
+        &state.encryption_key,
+    )?;
+
     let email = crate::instance_settings::extract_trusted_proxy_email(&headers, &proxy_settings)?;
     let subject = trusted_proxy_subject_for_email(&email);
 

--- a/crates/oored/src/builds.rs
+++ b/crates/oored/src/builds.rs
@@ -696,8 +696,6 @@ pub async fn list_builds(
     auth: AuthUser,
     Query(params): Query<ListBuildsQuery>,
 ) -> ApiResult<ListBuildsResponse> {
-    check_permission(&state.enforcer, &auth.0.role, "builds", "read").await?;
-
     let store = state.store.lock().await;
     let pool = store.pool();
 
@@ -708,6 +706,13 @@ pub async fn list_builds(
     let mut conditions = Vec::new();
     let mut bind_values: Vec<String> = Vec::new();
 
+    if auth.0.role != "owner" && auth.0.role != "admin" {
+        bind_values.push(auth.0.user_id.clone());
+        conditions.push(format!(
+            "EXISTS (SELECT 1 FROM project_members pm WHERE pm.project_id = builds.project_id AND pm.user_id = ?{})",
+            bind_values.len()
+        ));
+    }
     if let Some(ref project_id) = params.project_id {
         bind_values.push(project_id.clone());
         conditions.push(format!("project_id = ?{}", bind_values.len()));
@@ -772,8 +777,6 @@ pub async fn get_build(
     auth: AuthUser,
     Path(build_id): Path<String>,
 ) -> ApiResult<BuildDetailResponse> {
-    check_permission(&state.enforcer, &auth.0.role, "builds", "read").await?;
-
     let store = state.store.lock().await;
     let pool = store.pool();
 
@@ -790,6 +793,17 @@ pub async fn get_build(
             )
         })?
         .ok_or_else(|| api_err(StatusCode::NOT_FOUND, "not_found", "Build not found"))?;
+
+    let project_id: String = build_row.get("project_id");
+    let effective = resolve_effective_project_role(
+        pool,
+        &auth.0.user_id,
+        &auth.0.role,
+        &project_id,
+        &auth.0.auth_source,
+    )
+    .await?;
+    require_project_permission(&effective, ProjectPermission::Read)?;
 
     let build = row_to_build(&build_row);
 

--- a/crates/oored/src/instance_settings.rs
+++ b/crates/oored/src/instance_settings.rs
@@ -49,6 +49,7 @@ pub const DEFAULT_ALLOWED_ORIGINS: [&str; 4] = [
     "http://127.0.0.1:4173",
 ];
 pub const DEFAULT_TRUSTED_PROXY_EMAIL_HEADER: &str = "x-warpgate-username";
+pub const TRUSTED_PROXY_SHARED_SECRET_HEADER: &str = "x-oore-trusted-proxy-secret";
 
 #[derive(Debug, Clone)]
 pub struct EffectiveExternalAccessNetworkSettings {
@@ -64,6 +65,7 @@ pub struct EffectiveTrustedProxySettings {
     pub trusted_proxy_cidrs: Vec<String>,
     pub trusted_proxy_networks: Vec<IpNet>,
     pub has_shared_secret: bool,
+    pub encrypted_shared_secret: Option<String>,
     pub configured: bool,
     pub updated_at: Option<i64>,
 }
@@ -274,17 +276,18 @@ pub async fn load_effective_trusted_proxy_settings(
             .map(|value| parse_db_trusted_proxy_cidrs(&value))
             .unwrap_or_default();
         let trusted_proxy_networks = parse_cidr_list(&trusted_proxy_cidrs);
-        let has_shared_secret = row
+        let encrypted_shared_secret = row
             .try_get::<Option<String>, _>("encrypted_shared_secret")
             .ok()
-            .flatten()
-            .is_some();
+            .flatten();
+        let has_shared_secret = encrypted_shared_secret.is_some();
 
         return Ok(EffectiveTrustedProxySettings {
             user_email_header,
             trusted_proxy_cidrs,
             trusted_proxy_networks,
             has_shared_secret,
+            encrypted_shared_secret,
             configured: true,
             updated_at: row.try_get::<Option<i64>, _>("updated_at").ok().flatten(),
         });
@@ -296,6 +299,7 @@ pub async fn load_effective_trusted_proxy_settings(
         trusted_proxy_networks: parse_cidr_list(&trusted_proxy_cidrs),
         trusted_proxy_cidrs,
         has_shared_secret: false,
+        encrypted_shared_secret: None,
         configured: false,
         updated_at: None,
     })
@@ -431,12 +435,64 @@ fn trusted_proxy_settings_response(
     }
 }
 
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter()
+        .zip(b.iter())
+        .fold(0u8, |acc, (x, y)| acc | (x ^ y))
+        == 0
+}
+
 pub fn is_trusted_proxy_peer(peer_ip: IpAddr, settings: &EffectiveTrustedProxySettings) -> bool {
     peer_ip.is_loopback()
         || settings
             .trusted_proxy_networks
             .iter()
             .any(|cidr| cidr.contains(&peer_ip))
+}
+
+pub fn verify_trusted_proxy_shared_secret(
+    headers: &HeaderMap,
+    settings: &EffectiveTrustedProxySettings,
+    encryption_key: &[u8],
+) -> Result<(), (StatusCode, Json<ApiError>)> {
+    let Some(encrypted_shared_secret) = settings.encrypted_shared_secret.as_deref() else {
+        return Ok(());
+    };
+
+    let expected = crypto::decrypt(encrypted_shared_secret, encryption_key).map_err(|e| {
+        error!(error = %e, "failed to decrypt trusted proxy shared secret");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "decryption_error",
+            "Failed to verify trusted proxy shared secret",
+        )
+    })?;
+
+    let provided = headers
+        .get(TRUSTED_PROXY_SHARED_SECRET_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            api_err(
+                StatusCode::UNAUTHORIZED,
+                "trusted_proxy_shared_secret_missing",
+                "Trusted proxy shared secret header is missing",
+            )
+        })?;
+
+    if !constant_time_eq(provided.as_bytes(), expected.as_bytes()) {
+        return Err(api_err(
+            StatusCode::UNAUTHORIZED,
+            "trusted_proxy_shared_secret_invalid",
+            "Trusted proxy shared secret header is invalid",
+        ));
+    }
+
+    Ok(())
 }
 
 pub fn extract_trusted_proxy_email(
@@ -1220,6 +1276,7 @@ pub async fn update_external_access_trusted_proxy_settings(
             trusted_proxy_cidrs,
             trusted_proxy_networks,
             has_shared_secret: encrypted_shared_secret.is_some(),
+            encrypted_shared_secret,
             configured: true,
             updated_at: Some(now),
         },

--- a/crates/oored/src/lib.rs
+++ b/crates/oored/src/lib.rs
@@ -1084,6 +1084,11 @@ async fn setup_owner_claim_trusted_proxy(
             "Trusted proxy owner claim must come from an allowlisted proxy peer",
         ));
     }
+    crate::instance_settings::verify_trusted_proxy_shared_secret(
+        &headers,
+        &trusted_proxy_settings,
+        &state.encryption_key,
+    )?;
     let email =
         crate::instance_settings::extract_trusted_proxy_email(&headers, &trusted_proxy_settings)?;
 

--- a/crates/oored/src/logs.rs
+++ b/crates/oored/src/logs.rs
@@ -19,7 +19,9 @@ use uuid::Uuid;
 
 use crate::AppState;
 use crate::extractors::AuthUser;
-use crate::rbac::check_permission;
+use crate::project_rbac::{
+    ProjectPermission, require_project_permission, resolve_effective_project_role,
+};
 use crate::runners::RunnerAuth;
 use crate::session::SessionInfo;
 use crate::token::{generate_token, hash_token};
@@ -58,9 +60,12 @@ const STREAM_TOKEN_TTL_SECS: i64 = 300;
 // ── Stream token store ─────────────────────────────────────────
 
 /// Entry for a short-lived streaming token.
+#[derive(Clone)]
 struct StreamTokenEntry {
-    /// The user's role at the time the token was issued (for RBAC checks).
-    role: String,
+    /// The validated user session at the time the token was issued.
+    session: SessionInfo,
+    /// The build this token was minted for.
+    build_id: String,
     /// Unix timestamp when this token expires.
     expires_at: i64,
 }
@@ -83,13 +88,14 @@ impl StreamTokenStore {
 
     /// Create a short-lived streaming token derived from a validated session.
     /// Returns the plaintext token (the store keeps the hash).
-    pub async fn create(&self, session: &SessionInfo) -> String {
+    pub async fn create(&self, session: &SessionInfo, build_id: &str) -> String {
         let token = generate_token();
         let hashed = hash_token(&token);
         let now = now_unix();
 
         let entry = StreamTokenEntry {
-            role: session.role.clone(),
+            session: session.clone(),
+            build_id: build_id.to_string(),
             expires_at: now + STREAM_TOKEN_TTL_SECS,
         };
 
@@ -103,15 +109,13 @@ impl StreamTokenStore {
         token
     }
 
-    /// Validate a streaming token. Returns the associated role if valid.
-    pub async fn validate(&self, token: &str) -> Option<String> {
+    /// Validate a streaming token. Returns the associated session/build if valid.
+    async fn validate(&self, token: &str) -> Option<StreamTokenEntry> {
         let hashed = hash_token(token);
         let now = now_unix();
 
         let map = self.tokens.lock().await;
-        map.get(&hashed)
-            .filter(|e| e.expires_at > now)
-            .map(|e| e.role.clone())
+        map.get(&hashed).filter(|e| e.expires_at > now).cloned()
     }
 }
 
@@ -132,6 +136,42 @@ pub struct GetBuildLogsQuery {
 #[derive(Debug, Deserialize)]
 pub struct SseTokenQuery {
     pub token: Option<String>,
+}
+
+async fn load_build_project_id(
+    pool: &sqlx::SqlitePool,
+    build_id: &str,
+) -> Result<String, (StatusCode, Json<ApiError>)> {
+    sqlx::query_scalar("SELECT project_id FROM builds WHERE id = ?1")
+        .bind(build_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| {
+            error!(error = %e, "failed to load build project");
+            api_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "store_error",
+                "Failed to fetch build",
+            )
+        })?
+        .ok_or_else(|| api_err(StatusCode::NOT_FOUND, "not_found", "Build not found"))
+}
+
+async fn require_build_log_read(
+    pool: &sqlx::SqlitePool,
+    session: &SessionInfo,
+    build_id: &str,
+) -> Result<(), (StatusCode, Json<ApiError>)> {
+    let project_id = load_build_project_id(pool, build_id).await?;
+    let effective = resolve_effective_project_role(
+        pool,
+        &session.user_id,
+        &session.role,
+        &project_id,
+        &session.auth_source,
+    )
+    .await?;
+    require_project_permission(&effective, ProjectPermission::Read)
 }
 
 // ── Handlers ────────────────────────────────────────────────────
@@ -262,27 +302,11 @@ pub async fn get_build_logs(
     Path(build_id): Path<String>,
     Query(params): Query<GetBuildLogsQuery>,
 ) -> ApiResult<BuildLogsResponse> {
-    check_permission(&state.enforcer, &auth.0.role, "builds", "read").await?;
-
     let pool = {
         let store = state.store.lock().await;
         store.pool().clone()
     };
-
-    // Verify build exists
-    let exists: bool = sqlx::query_scalar("SELECT COUNT(*) > 0 FROM builds WHERE id = ?1")
-        .bind(&build_id)
-        .fetch_one(&pool)
-        .await
-        .unwrap_or(false);
-
-    if !exists {
-        return Err(api_err(
-            StatusCode::NOT_FOUND,
-            "not_found",
-            "Build not found",
-        ));
-    }
+    require_build_log_read(&pool, &auth.0, &build_id).await?;
 
     let after_seq = params.after_sequence.unwrap_or(-1);
     let limit = params.limit.unwrap_or(1000).min(5000);
@@ -330,28 +354,14 @@ pub async fn create_stream_token(
     auth: AuthUser,
     Path(build_id): Path<String>,
 ) -> ApiResult<serde_json::Value> {
-    check_permission(&state.enforcer, &auth.0.role, "builds", "read").await?;
-
     // Verify build exists
     let pool = {
         let store = state.store.lock().await;
         store.pool().clone()
     };
-    let exists: bool = sqlx::query_scalar("SELECT COUNT(*) > 0 FROM builds WHERE id = ?1")
-        .bind(&build_id)
-        .fetch_one(&pool)
-        .await
-        .unwrap_or(false);
+    require_build_log_read(&pool, &auth.0, &build_id).await?;
 
-    if !exists {
-        return Err(api_err(
-            StatusCode::NOT_FOUND,
-            "not_found",
-            "Build not found",
-        ));
-    }
-
-    let token = state.stream_tokens.create(&auth.0).await;
+    let token = state.stream_tokens.create(&auth.0, &build_id).await;
     let expires_at = now_unix() + STREAM_TOKEN_TTL_SECS;
 
     info!(
@@ -379,18 +389,26 @@ pub async fn stream_build_logs(
     let query_token = sse_query.token.as_deref();
     let header_token = crate::util::extract_bearer(&headers);
 
-    let role = if let Some(qt) = query_token {
+    let session = if let Some(qt) = query_token {
         // Query param: must be a valid stream token — reject if not
-        state.stream_tokens.validate(qt).await.ok_or_else(|| {
+        let entry = state.stream_tokens.validate(qt).await.ok_or_else(|| {
             api_err(
                 StatusCode::UNAUTHORIZED,
                 "invalid_stream_token",
                 "Invalid or expired stream token (obtain one via POST /v1/builds/{build_id}/stream-token)",
             )
-        })?
+        })?;
+        if entry.build_id != build_id {
+            return Err(api_err(
+                StatusCode::FORBIDDEN,
+                "stream_token_build_mismatch",
+                "Stream token is not valid for this build",
+            ));
+        }
+        entry.session
     } else if let Some(ht) = header_token {
         // Authorization header: accept full session token (non-browser clients)
-        let session = state
+        state
             .sessions
             .validate_session(ht)
             .await
@@ -408,8 +426,7 @@ pub async fn stream_build_logs(
                     "invalid_session",
                     "Invalid or expired session token",
                 )
-            })?;
-        session.role
+            })?
     } else {
         return Err(api_err(
             StatusCode::UNAUTHORIZED,
@@ -418,26 +435,11 @@ pub async fn stream_build_logs(
         ));
     };
 
-    // RBAC check
-    check_permission(&state.enforcer, &role, "builds", "read").await?;
-
-    // Verify build exists
     let pool = {
         let store = state.store.lock().await;
         store.pool().clone()
     };
-    let exists: bool = sqlx::query_scalar("SELECT COUNT(*) > 0 FROM builds WHERE id = ?1")
-        .bind(&build_id)
-        .fetch_one(&pool)
-        .await
-        .unwrap_or(false);
-    if !exists {
-        return Err(api_err(
-            StatusCode::NOT_FOUND,
-            "not_found",
-            "Build not found",
-        ));
-    }
+    require_build_log_read(&pool, &session, &build_id).await?;
 
     // Check for Last-Event-ID header for reconnection support
     let last_event_id: i64 = headers

--- a/crates/oored/src/pipeline_ios_signing.rs
+++ b/crates/oored/src/pipeline_ios_signing.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::io::Write;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
-use std::path::{Path as FsPath, PathBuf};
+use std::path::{Component, Path as FsPath, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::Arc;
 
@@ -29,7 +29,7 @@ use crate::AppState;
 use crate::apple_api::{self, AppleApiCredentials};
 use crate::crypto;
 use crate::extractors::AuthUser;
-use crate::rbac::check_permission;
+use crate::project_rbac::{ProjectPermission, require_pipeline_project_permission};
 use crate::runners::RunnerAuth;
 use crate::store::write_audit_log;
 use crate::util::{api_err, now_unix};
@@ -124,6 +124,25 @@ fn trim_opt(value: Option<String>) -> Option<String> {
             Some(trimmed.to_string())
         }
     })
+}
+
+fn validate_materialized_filename(
+    value: String,
+    field_name: &str,
+) -> Result<String, (StatusCode, Json<ApiError>)> {
+    let mut components = FsPath::new(&value).components();
+    let is_single_normal_component =
+        matches!(components.next(), Some(Component::Normal(_))) && components.next().is_none();
+
+    if !is_single_normal_component || value.contains('/') || value.contains('\\') {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "invalid_filename",
+            format!("{field_name} must be a filename, not a path"),
+        ));
+    }
+
+    Ok(value)
 }
 
 fn mode_str(mode: IosSigningMode) -> &'static str {
@@ -1921,12 +1940,19 @@ pub async fn get_pipeline_ios_signing(
     auth: AuthUser,
     Path(pipeline_id): Path<String>,
 ) -> ApiResult<PipelineIosSigningResponse> {
-    check_permission(&state.enforcer, &auth.0.role, "pipelines", "read").await?;
-
     let pool = {
         let store = state.store.lock().await;
         store.pool().clone()
     };
+    require_pipeline_project_permission(
+        &pool,
+        &auth.0.user_id,
+        &auth.0.role,
+        &auth.0.auth_source,
+        &pipeline_id,
+        ProjectPermission::Read,
+    )
+    .await?;
 
     if !ensure_pipeline_exists(&pool, &pipeline_id)
         .await
@@ -1965,12 +1991,19 @@ pub async fn update_pipeline_ios_signing(
     Path(pipeline_id): Path<String>,
     Json(req): Json<UpdatePipelineIosSigningRequest>,
 ) -> ApiResult<PipelineIosSigningResponse> {
-    check_permission(&state.enforcer, &auth.0.role, "pipelines", "write").await?;
-
     let pool = {
         let store = state.store.lock().await;
         store.pool().clone()
     };
+    require_pipeline_project_permission(
+        &pool,
+        &auth.0.user_id,
+        &auth.0.role,
+        &auth.0.auth_source,
+        &pipeline_id,
+        ProjectPermission::ManagePipelines,
+    )
+    .await?;
     if !ensure_pipeline_exists(&pool, &pipeline_id)
         .await
         .map_err(|e| {
@@ -2052,7 +2085,7 @@ pub async fn update_pipeline_ios_signing(
 
     if let Some(cert) = req.certificate.clone() {
         if let Some(filename) = trim_opt(cert.p12_filename) {
-            p12_filename = Some(filename);
+            p12_filename = Some(validate_materialized_filename(filename, "p12_filename")?);
         }
         if let Some(p12_payload) = trim_opt(cert.p12_base64) {
             let p12_bytes = decode_b64(&p12_payload).map_err(|_| {
@@ -2479,6 +2512,8 @@ async fn upsert_profile(
     })?;
     let checksum = Some(hex::encode(Sha256::digest(&profile_bytes)));
     let filename = trim_opt(input.profile_filename)
+        .map(|filename| validate_materialized_filename(filename, "profile_filename"))
+        .transpose()?
         .or_else(|| {
             parsed
                 .profile_uuid
@@ -2585,12 +2620,19 @@ pub async fn list_pipeline_ios_devices(
     auth: AuthUser,
     Path(pipeline_id): Path<String>,
 ) -> ApiResult<ListPipelineIosDevicesResponse> {
-    check_permission(&state.enforcer, &auth.0.role, "pipelines", "read").await?;
-
     let pool = {
         let store = state.store.lock().await;
         store.pool().clone()
     };
+    require_pipeline_project_permission(
+        &pool,
+        &auth.0.user_id,
+        &auth.0.role,
+        &auth.0.auth_source,
+        &pipeline_id,
+        ProjectPermission::Read,
+    )
+    .await?;
     if !ensure_pipeline_exists(&pool, &pipeline_id)
         .await
         .map_err(|e| {
@@ -2629,8 +2671,6 @@ pub async fn register_pipeline_ios_device(
     Path(pipeline_id): Path<String>,
     Json(req): Json<RegisterIosDeviceRequest>,
 ) -> ApiResult<RegisterIosDeviceResponse> {
-    check_permission(&state.enforcer, &auth.0.role, "pipelines", "write").await?;
-
     let udid = req.udid.trim().to_uppercase();
     let name = req.name.trim().to_string();
     let platform = req.platform.unwrap_or_else(|| "IOS".to_string());
@@ -2654,6 +2694,15 @@ pub async fn register_pipeline_ios_device(
         let store = state.store.lock().await;
         store.pool().clone()
     };
+    require_pipeline_project_permission(
+        &pool,
+        &auth.0.user_id,
+        &auth.0.role,
+        &auth.0.auth_source,
+        &pipeline_id,
+        ProjectPermission::ManagePipelines,
+    )
+    .await?;
     if !ensure_pipeline_exists(&pool, &pipeline_id)
         .await
         .map_err(|e| {
@@ -2868,12 +2917,19 @@ pub async fn sync_pipeline_ios_signing(
     auth: AuthUser,
     Path(pipeline_id): Path<String>,
 ) -> ApiResult<SyncPipelineIosSigningResponse> {
-    check_permission(&state.enforcer, &auth.0.role, "pipelines", "write").await?;
-
     let pool = {
         let store = state.store.lock().await;
         store.pool().clone()
     };
+    require_pipeline_project_permission(
+        &pool,
+        &auth.0.user_id,
+        &auth.0.role,
+        &auth.0.auth_source,
+        &pipeline_id,
+        ProjectPermission::ManagePipelines,
+    )
+    .await?;
     if !ensure_pipeline_exists(&pool, &pipeline_id)
         .await
         .map_err(|e| {
@@ -3154,4 +3210,32 @@ pub async fn get_job_ios_signing(
     Ok(Json(RunnerIosSigningResponse {
         bundle: Some(bundle),
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn materialized_ios_filenames_must_be_basenames() {
+        assert_eq!(
+            validate_materialized_filename("dist.p12".to_string(), "p12_filename")
+                .expect("valid p12 filename"),
+            "dist.p12"
+        );
+
+        for value in [
+            "../dist.p12",
+            "/tmp/dist.p12",
+            "profiles/dist.mobileprovision",
+            "profiles\\dist.mobileprovision",
+            ".",
+            "..",
+        ] {
+            assert!(
+                validate_materialized_filename(value.to_string(), "profile_filename").is_err(),
+                "{value} should be rejected"
+            );
+        }
+    }
 }

--- a/crates/oored/src/pipeline_signing.rs
+++ b/crates/oored/src/pipeline_signing.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 use crate::AppState;
 use crate::crypto;
 use crate::extractors::AuthUser;
-use crate::rbac::check_permission;
+use crate::project_rbac::{ProjectPermission, require_pipeline_project_permission};
 use crate::runners::RunnerAuth;
 use crate::store::write_audit_log;
 use crate::util::{api_err, now_unix};
@@ -409,12 +409,19 @@ pub async fn get_pipeline_android_signing(
     auth: AuthUser,
     Path(pipeline_id): Path<String>,
 ) -> ApiResult<PipelineAndroidSigningResponse> {
-    check_permission(&state.enforcer, &auth.0.role, "pipelines", "read").await?;
-
     let pool = {
         let store = state.store.lock().await;
         store.pool().clone()
     };
+    require_pipeline_project_permission(
+        &pool,
+        &auth.0.user_id,
+        &auth.0.role,
+        &auth.0.auth_source,
+        &pipeline_id,
+        ProjectPermission::Read,
+    )
+    .await?;
 
     if !ensure_pipeline_exists(&pool, &pipeline_id)
         .await
@@ -483,8 +490,6 @@ pub async fn update_pipeline_android_signing(
     Path(pipeline_id): Path<String>,
     Json(req): Json<UpdatePipelineAndroidSigningRequest>,
 ) -> ApiResult<PipelineAndroidSigningResponse> {
-    check_permission(&state.enforcer, &auth.0.role, "pipelines", "write").await?;
-
     if req.debug.is_none() && req.release.is_none() {
         return Err(api_err(
             StatusCode::BAD_REQUEST,
@@ -497,6 +502,15 @@ pub async fn update_pipeline_android_signing(
         let store = state.store.lock().await;
         store.pool().clone()
     };
+    require_pipeline_project_permission(
+        &pool,
+        &auth.0.user_id,
+        &auth.0.role,
+        &auth.0.auth_source,
+        &pipeline_id,
+        ProjectPermission::ManagePipelines,
+    )
+    .await?;
 
     if !ensure_pipeline_exists(&pool, &pipeline_id)
         .await

--- a/crates/oored/src/pipelines.rs
+++ b/crates/oored/src/pipelines.rs
@@ -17,7 +17,8 @@ use uuid::Uuid;
 use crate::AppState;
 use crate::extractors::AuthUser;
 use crate::project_rbac::{
-    ProjectPermission, require_project_permission, resolve_effective_project_role,
+    ProjectPermission, require_pipeline_project_permission, require_project_permission,
+    resolve_effective_project_role,
 };
 use crate::rbac::check_permission;
 use crate::store::write_audit_log;
@@ -606,10 +607,17 @@ pub async fn get_pipeline(
     auth: AuthUser,
     Path(pipeline_id): Path<String>,
 ) -> ApiResult<PipelineDetailResponse> {
-    check_permission(&state.enforcer, &auth.0.role, "pipelines", "read").await?;
-
     let store = state.store.lock().await;
     let pool = store.pool();
+    require_pipeline_project_permission(
+        pool,
+        &auth.0.user_id,
+        &auth.0.role,
+        &auth.0.auth_source,
+        &pipeline_id,
+        ProjectPermission::Read,
+    )
+    .await?;
 
     let pipeline_row = sqlx::query("SELECT * FROM pipelines WHERE id = ?1")
         .bind(&pipeline_id)
@@ -646,10 +654,17 @@ pub async fn update_pipeline(
     Path(pipeline_id): Path<String>,
     Json(req): Json<UpdatePipelineRequest>,
 ) -> ApiResult<CreatePipelineResponse> {
-    check_permission(&state.enforcer, &auth.0.role, "pipelines", "write").await?;
-
     let store = state.store.lock().await;
     let pool = store.pool();
+    require_pipeline_project_permission(
+        pool,
+        &auth.0.user_id,
+        &auth.0.role,
+        &auth.0.auth_source,
+        &pipeline_id,
+        ProjectPermission::ManagePipelines,
+    )
+    .await?;
 
     let row = sqlx::query("SELECT * FROM pipelines WHERE id = ?1")
         .bind(&pipeline_id)

--- a/crates/oored/src/project_rbac.rs
+++ b/crates/oored/src/project_rbac.rs
@@ -187,6 +187,37 @@ pub fn require_project_permission(
     }
 }
 
+/// Resolve project membership for a direct pipeline-id route and require the
+/// requested project permission. Returns the pipeline's project id.
+pub async fn require_pipeline_project_permission(
+    pool: &sqlx::SqlitePool,
+    user_id: &str,
+    instance_role: &str,
+    auth_source: &AuthSource,
+    pipeline_id: &str,
+    permission: ProjectPermission,
+) -> Result<String, (StatusCode, Json<ApiError>)> {
+    let project_id: String = sqlx::query_scalar("SELECT project_id FROM pipelines WHERE id = ?1")
+        .bind(pipeline_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| {
+            error!(error = %e, "failed to query pipeline project");
+            api_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "store_error",
+                "Failed to check pipeline access",
+            )
+        })?
+        .ok_or_else(|| api_err(StatusCode::NOT_FOUND, "not_found", "Pipeline not found"))?;
+
+    let effective =
+        resolve_effective_project_role(pool, user_id, instance_role, &project_id, auth_source)
+            .await?;
+    require_project_permission(&effective, permission)?;
+    Ok(project_id)
+}
+
 /// Return the project role string for inclusion in API responses.
 pub fn effective_role_string(effective_role: &EffectiveProjectRole) -> Option<String> {
     match effective_role {

--- a/crates/oored/tests/external_access_security_integration.rs
+++ b/crates/oored/tests/external_access_security_integration.rs
@@ -208,17 +208,38 @@ async fn upsert_trusted_proxy_settings(
     user_email_header: &str,
     trusted_proxy_cidrs_json: &str,
 ) {
+    upsert_trusted_proxy_settings_with_secret(
+        pool,
+        user_email_header,
+        trusted_proxy_cidrs_json,
+        None,
+    )
+    .await;
+}
+
+async fn upsert_trusted_proxy_settings_with_secret(
+    pool: &sqlx::SqlitePool,
+    user_email_header: &str,
+    trusted_proxy_cidrs_json: &str,
+    shared_secret: Option<&str>,
+) {
     let now = now_unix();
+    let encrypted_shared_secret = shared_secret.map(|secret| {
+        oored::crypto::encrypt(secret, &common::TEST_ENCRYPTION_KEY)
+            .expect("failed to encrypt trusted proxy shared secret")
+    });
     sqlx::query(
         "INSERT INTO trusted_proxy_settings (id, user_email_header, trusted_proxy_cidrs_json, encrypted_shared_secret, updated_by, created_at, updated_at)
-         VALUES (1, ?1, ?2, NULL, NULL, ?3, ?3)
+         VALUES (1, ?1, ?2, ?3, NULL, ?4, ?4)
          ON CONFLICT(id) DO UPDATE SET
             user_email_header = excluded.user_email_header,
             trusted_proxy_cidrs_json = excluded.trusted_proxy_cidrs_json,
+            encrypted_shared_secret = excluded.encrypted_shared_secret,
             updated_at = excluded.updated_at",
     )
     .bind(user_email_header)
     .bind(trusted_proxy_cidrs_json)
+    .bind(encrypted_shared_secret)
     .bind(now)
     .execute(pool)
     .await
@@ -872,6 +893,82 @@ async fn trusted_proxy_login_activates_invited_user() {
 
     assert_eq!(status, "active");
     assert_eq!(oidc_subject, "warpgate::invitee@example.com");
+}
+
+#[tokio::test]
+async fn trusted_proxy_login_requires_configured_shared_secret() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("test.db");
+    let app = create_test_app(&db_path).await;
+    let pool = connect_pool(&db_path).await;
+
+    mark_setup_ready(&pool).await;
+    set_runtime_and_remote_auth_mode(&pool, "remote", "trusted_proxy").await;
+    upsert_trusted_proxy_settings_with_secret(
+        &pool,
+        "x-warpgate-username",
+        "[]",
+        Some("proxy-secret"),
+    )
+    .await;
+    seed_user_with_role(&pool, "owner@example.com", "owner").await;
+
+    let missing_secret = Request::builder()
+        .uri("/v1/auth/trusted-proxy/login")
+        .method("POST")
+        .header("x-warpgate-username", "owner@example.com")
+        .extension(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 43104))))
+        .body(Body::empty())
+        .unwrap();
+    let resp = app
+        .clone()
+        .oneshot(missing_secret)
+        .await
+        .expect("missing secret response");
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    let body = body_json(resp.into_body()).await;
+    assert_eq!(body["code"], "trusted_proxy_shared_secret_missing");
+
+    let wrong_secret = Request::builder()
+        .uri("/v1/auth/trusted-proxy/login")
+        .method("POST")
+        .header("x-warpgate-username", "owner@example.com")
+        .header(
+            oored::instance_settings::TRUSTED_PROXY_SHARED_SECRET_HEADER,
+            "wrong-secret",
+        )
+        .extension(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 43105))))
+        .body(Body::empty())
+        .unwrap();
+    let resp = app
+        .clone()
+        .oneshot(wrong_secret)
+        .await
+        .expect("wrong secret response");
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    let body = body_json(resp.into_body()).await;
+    assert_eq!(body["code"], "trusted_proxy_shared_secret_invalid");
+
+    let valid_secret = Request::builder()
+        .uri("/v1/auth/trusted-proxy/login")
+        .method("POST")
+        .header("x-warpgate-username", "owner@example.com")
+        .header(
+            oored::instance_settings::TRUSTED_PROXY_SHARED_SECRET_HEADER,
+            "proxy-secret",
+        )
+        .extension(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 43106))))
+        .body(Body::empty())
+        .unwrap();
+    let resp = app
+        .clone()
+        .oneshot(valid_secret)
+        .await
+        .expect("valid secret response");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp.into_body()).await;
+    assert_eq!(body["user"]["email"], "owner@example.com");
+    assert!(body["session_token"].as_str().is_some());
 }
 
 #[tokio::test]

--- a/crates/oored/tests/logs_artifacts_integration.rs
+++ b/crates/oored/tests/logs_artifacts_integration.rs
@@ -35,6 +35,25 @@ async fn create_session_token(pool: &sqlx::SqlitePool, user_id: &str) -> String 
     token
 }
 
+async fn seed_user_with_role(pool: &sqlx::SqlitePool, email: &str, role: &str) -> String {
+    let user_id = uuid::Uuid::new_v4().to_string();
+    let now = common::now_unix();
+    sqlx::query(
+        "INSERT INTO users (id, email, oidc_subject, display_name, role, status, created_at, updated_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, 'active', ?6, ?6)",
+    )
+    .bind(&user_id)
+    .bind(email)
+    .bind(format!("{role}::{email}"))
+    .bind(email)
+    .bind(role)
+    .bind(now)
+    .execute(pool)
+    .await
+    .expect("failed to seed test user");
+    user_id
+}
+
 /// Register a runner and return (runner_id, runner_token).
 async fn register_runner(app: &axum::Router, session_token: &str, name: &str) -> (String, String) {
     let body = serde_json::json!({
@@ -399,6 +418,60 @@ async fn test_get_logs_build_not_found() {
 
     let resp = app.clone().oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_non_member_cannot_read_build_logs_or_artifacts() {
+    let (app, pool, _session_token, runner_id, runner_token, build_id) = full_scaffold().await;
+    let outsider_id = seed_user_with_role(&pool, "outsider@example.com", "developer").await;
+    let outsider_session = create_session_token(&pool, &outsider_id).await;
+
+    let artifact_body = serde_json::json!({
+        "name": "private.apk",
+        "artifact_type": "apk",
+    });
+    let req = Request::builder()
+        .uri(format!("/v1/runners/{runner_id}/jobs/{build_id}/artifacts"))
+        .method("POST")
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .header(
+            http::header::AUTHORIZATION,
+            format!("Bearer {runner_token}"),
+        )
+        .body(Body::from(serde_json::to_string(&artifact_body).unwrap()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let artifact_json = body_json(resp.into_body()).await;
+    let artifact_id = artifact_json["artifact"]["id"].as_str().unwrap();
+
+    for (method, uri) in [
+        ("GET", "/v1/builds".to_string()),
+        ("GET", format!("/v1/builds/{build_id}")),
+        ("GET", format!("/v1/builds/{build_id}/logs")),
+        ("POST", format!("/v1/builds/{build_id}/stream-token")),
+        ("GET", format!("/v1/builds/{build_id}/logs/stream")),
+        ("GET", format!("/v1/builds/{build_id}/artifacts")),
+        ("POST", format!("/v1/artifacts/{artifact_id}/download-link")),
+    ] {
+        let req = Request::builder()
+            .uri(uri)
+            .method(method)
+            .header(
+                http::header::AUTHORIZATION,
+                format!("Bearer {outsider_session}"),
+            )
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        if method == "GET" && resp.status() == StatusCode::OK {
+            let json = body_json(resp.into_body()).await;
+            assert_eq!(json["total"].as_i64(), Some(0));
+        } else {
+            assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        }
+    }
 }
 
 // ── Stream token tests ──────────────────────────────────────────

--- a/crates/oored/tests/project_pipeline_integration.rs
+++ b/crates/oored/tests/project_pipeline_integration.rs
@@ -58,6 +58,25 @@ async fn create_session_token(pool: &sqlx::SqlitePool, user_id: &str) -> String 
     token
 }
 
+async fn seed_user_with_role(pool: &sqlx::SqlitePool, email: &str, role: &str) -> String {
+    let user_id = uuid::Uuid::new_v4().to_string();
+    let now = common::now_unix();
+    sqlx::query(
+        "INSERT INTO users (id, email, oidc_subject, display_name, role, status, created_at, updated_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, 'active', ?6, ?6)",
+    )
+    .bind(&user_id)
+    .bind(email)
+    .bind(format!("{role}::{email}"))
+    .bind(email)
+    .bind(role)
+    .bind(now)
+    .execute(pool)
+    .await
+    .expect("failed to seed test user");
+    user_id
+}
+
 /// Helper to send a JSON request and return (status, body_json).
 async fn json_request(
     app: &axum::Router,
@@ -678,6 +697,144 @@ async fn test_update_pipeline() {
         "Renamed Pipeline"
     );
     assert!(!json["pipeline"]["enabled"].as_bool().unwrap());
+}
+
+#[tokio::test]
+async fn test_non_member_cannot_use_direct_pipeline_or_signing_routes() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let app = create_test_app(&db_path).await;
+    let pool = connect_pool(&db_path).await;
+    let owner_id = seed_test_user(&pool).await;
+    let integration_id = seed_github_integration(&pool, &owner_id, "secret").await;
+    let (_project_id, pipeline_id) =
+        seed_project_chain(&pool, &integration_id, &owner_id, "org/private-project").await;
+
+    let outsider_id = seed_user_with_role(&pool, "outsider@example.com", "developer").await;
+    let outsider_token = create_session_token(&pool, &outsider_id).await;
+
+    let denied_requests = [
+        ("GET", format!("/v1/pipelines/{pipeline_id}"), None),
+        (
+            "PATCH",
+            format!("/v1/pipelines/{pipeline_id}"),
+            Some(serde_json::json!({ "name": "Hijacked Pipeline" })),
+        ),
+        (
+            "GET",
+            format!("/v1/pipelines/{pipeline_id}/android-signing"),
+            None,
+        ),
+        (
+            "PUT",
+            format!("/v1/pipelines/{pipeline_id}/android-signing"),
+            Some(serde_json::json!({
+                "debug": {
+                    "enabled": true,
+                    "keystore_filename": "debug.jks",
+                    "keystore_base64": "ZmFrZQ==",
+                    "store_password": "store-pass",
+                    "key_alias": "debug",
+                    "key_password": "key-pass"
+                }
+            })),
+        ),
+        (
+            "GET",
+            format!("/v1/pipelines/{pipeline_id}/ios-signing"),
+            None,
+        ),
+        (
+            "PUT",
+            format!("/v1/pipelines/{pipeline_id}/ios-signing"),
+            Some(serde_json::json!({
+                "enabled": false,
+                "mode": "manual",
+                "bundle_ids": []
+            })),
+        ),
+        (
+            "GET",
+            format!("/v1/pipelines/{pipeline_id}/ios-signing/devices"),
+            None,
+        ),
+        (
+            "POST",
+            format!("/v1/pipelines/{pipeline_id}/ios-signing/devices/register"),
+            Some(serde_json::json!({
+                "name": "QA Device",
+                "udid": "00008110ABCDEF1234567890ABCDEF1234567890",
+                "platform": "IOS"
+            })),
+        ),
+        (
+            "POST",
+            format!("/v1/pipelines/{pipeline_id}/ios-signing/sync"),
+            None,
+        ),
+    ];
+
+    for (method, uri, body) in denied_requests {
+        let (status, json) = json_request(&app, method, &uri, &outsider_token, body).await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "{method} {uri}: {json}");
+    }
+}
+
+#[tokio::test]
+async fn test_ios_signing_rejects_path_filenames() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo_path = init_test_git_repo(dir.path());
+    let db_path = dir.path().join("test.db");
+    let app = create_test_app(&db_path).await;
+    let pool = connect_pool(&db_path).await;
+    let user_id = seed_test_user(&pool).await;
+    let token = create_session_token(&pool, &user_id).await;
+
+    let (_, json) = json_request(
+        &app,
+        "POST",
+        "/v1/projects",
+        &token,
+        Some(serde_json::json!({
+            "name": "iOS Filename Project",
+            "local_repository_path": repo_path.to_string_lossy().to_string(),
+        })),
+    )
+    .await;
+    let project_id = json["project"]["id"].as_str().unwrap();
+
+    let (_, json) = json_request(
+        &app,
+        "POST",
+        &format!("/v1/projects/{project_id}/pipelines"),
+        &token,
+        Some(serde_json::json!({ "name": "iOS Filename Pipeline" })),
+    )
+    .await;
+    let pipeline_id = json["pipeline"]["id"].as_str().unwrap().to_string();
+
+    let (status, json) = json_request(
+        &app,
+        "PUT",
+        &format!("/v1/pipelines/{pipeline_id}/ios-signing"),
+        &token,
+        Some(serde_json::json!({
+            "enabled": false,
+            "mode": "manual",
+            "bundle_ids": [],
+            "certificate": {
+                "p12_filename": "../dist.p12"
+            }
+        })),
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "invalid p12 filename: {json}"
+    );
+    assert_eq!(json["code"].as_str(), Some("invalid_filename"));
 }
 
 #[tokio::test]

--- a/crates/oored/tests/setup_integration.rs
+++ b/crates/oored/tests/setup_integration.rs
@@ -173,6 +173,30 @@ async fn set_runtime_and_remote_auth_mode(path: &Path, runtime_mode: &str, remot
     .expect("failed to set runtime/auth mode");
 }
 
+async fn upsert_trusted_proxy_settings(path: &Path, shared_secret: Option<&str>) {
+    let store = connect_store(path).await;
+    let now = now_unix();
+    let encrypted_shared_secret = shared_secret.map(|secret| {
+        oored::crypto::encrypt(secret, &TEST_ENCRYPTION_KEY)
+            .expect("failed to encrypt trusted proxy shared secret")
+    });
+
+    sqlx::query(
+        "INSERT INTO trusted_proxy_settings (id, user_email_header, trusted_proxy_cidrs_json, encrypted_shared_secret, updated_by, created_at, updated_at)
+         VALUES (1, 'x-warpgate-username', '[]', ?1, NULL, ?2, ?2)
+         ON CONFLICT(id) DO UPDATE SET
+            user_email_header = excluded.user_email_header,
+            trusted_proxy_cidrs_json = excluded.trusted_proxy_cidrs_json,
+            encrypted_shared_secret = excluded.encrypted_shared_secret,
+            updated_at = excluded.updated_at",
+    )
+    .bind(encrypted_shared_secret)
+    .bind(now)
+    .execute(store.pool())
+    .await
+    .expect("failed to upsert trusted proxy settings");
+}
+
 /// Extract the JSON body from a response.
 async fn body_json(response: axum::response::Response) -> Value {
     let body = response.into_body().collect().await.unwrap().to_bytes();
@@ -1023,6 +1047,80 @@ async fn test_setup_owner_claim_trusted_proxy_requires_configuration() {
     assert_eq!(resp.status(), 409);
     let body = body_json(resp).await;
     assert_eq!(body["code"], "trusted_proxy_not_configured");
+}
+
+#[tokio::test]
+async fn test_setup_owner_claim_trusted_proxy_requires_configured_shared_secret() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let db_path = tmp.path().join("oore.db");
+    let app = create_test_app(&db_path).await;
+    let session_token = seed_session_token(&db_path).await;
+
+    set_state(&db_path, SetupState::IdpConfigured).await;
+    set_runtime_and_remote_auth_mode(&db_path, "remote", "trusted_proxy").await;
+    upsert_trusted_proxy_settings(&db_path, Some("proxy-secret")).await;
+
+    let missing_secret = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/setup/owner/claim-trusted-proxy")
+                .header("Authorization", format!("Bearer {}", session_token))
+                .header("x-warpgate-username", "owner@example.com")
+                .extension(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 41235))))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(missing_secret.status(), 401);
+    let body = body_json(missing_secret).await;
+    assert_eq!(body["code"], "trusted_proxy_shared_secret_missing");
+
+    let wrong_secret = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/setup/owner/claim-trusted-proxy")
+                .header("Authorization", format!("Bearer {}", session_token))
+                .header("x-warpgate-username", "owner@example.com")
+                .header(
+                    oored::instance_settings::TRUSTED_PROXY_SHARED_SECRET_HEADER,
+                    "wrong-secret",
+                )
+                .extension(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 41236))))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(wrong_secret.status(), 401);
+    let body = body_json(wrong_secret).await;
+    assert_eq!(body["code"], "trusted_proxy_shared_secret_invalid");
+
+    let valid_secret = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/setup/owner/claim-trusted-proxy")
+                .header("Authorization", format!("Bearer {}", session_token))
+                .header("x-warpgate-username", "owner@example.com")
+                .header(
+                    oored::instance_settings::TRUSTED_PROXY_SHARED_SECRET_HEADER,
+                    "proxy-secret",
+                )
+                .extension(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 41237))))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(valid_secret.status(), 200);
+    let body = body_json(valid_secret).await;
+    assert_eq!(body["state"], "owner_created");
+    assert_eq!(body["owner_email"], "owner@example.com");
 }
 
 // ── Ready-locked tests ──────────────────────────────────────────

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -12,6 +12,13 @@ Rules:
 
 ## 2026-04-15
 
+- **Security fixes from Codex scan** ([GitHub #83](https://github.com/devaryakjha/oore.build/issues/83), [#84](https://github.com/devaryakjha/oore.build/issues/84), [#85](https://github.com/devaryakjha/oore.build/issues/85), [#86](https://github.com/devaryakjha/oore.build/issues/86)):
+  - Enforced configured trusted-proxy shared secrets with the `X-Oore-Trusted-Proxy-Secret` header for runtime trusted-proxy login and setup owner claim.
+  - Scoped direct build/log/artifact read routes to project RBAC, including stream-token issuance and artifact download links.
+  - Scoped direct pipeline and signing mutation routes to project RBAC before applying pipeline, Android signing, iOS signing, device registration, or sync changes.
+  - Rejected unsafe iOS signing filenames at API and runner materialization boundaries so signing assets cannot escape the runner workspace.
+  - Docs index: https://linear.app/oorebuild/document/docs-index-linear-first-457d9edc9cda
+
 - Deployment/auth docs now cover the internal-only Mac Studio rollout path behind NetBird + Warpgate instead of assuming remote setup is always OIDC-first.
   - Added an operations guide for serving the static web UI over internal HTTPS while keeping `oored` loopback-only, forwarding Warpgate identity headers, and completing setup in `Remote (Trusted Proxy / Warpgate)` mode.
   - Updated the deployment, hosted onboarding, first-instance, setup API, and auth API docs to document trusted-proxy setup/login and to correct loopback-vs-proxy guidance.


### PR DESCRIPTION
## Summary
- enforce configured trusted-proxy shared secrets for login and setup owner claim
- scope direct build, log, artifact, pipeline, and signing routes to project RBAC
- reject unsafe iOS signing filenames before persistence and runner materialization
- update docs and docs/changes.md with the security hardening notes

## Issues
Closes #83
Closes #84
Closes #85
Closes #86

## Validation
- make validate
- focused trusted-proxy, setup-owner-claim, build/log/artifact RBAC, pipeline/signing RBAC, and iOS signing filename tests passed before the full gate