### PR TITLE
fix: enforce project auth on artifact tokens and cancels

### DIFF
--- a/crates/oored/src/artifact_tokens.rs
+++ b/crates/oored/src/artifact_tokens.rs
@@ -20,7 +20,9 @@ use uuid::Uuid;
 
 use crate::AppState;
 use crate::extractors::AuthUser;
-use crate::rbac::check_permission;
+use crate::project_rbac::{
+    ProjectPermission, require_project_permission, resolve_effective_project_role,
+};
 use crate::store::write_audit_log;
 use crate::token::{generate_token, hash_token};
 use crate::util::{api_err, now_unix};
@@ -34,6 +36,48 @@ const DEFAULT_TTL_SECS: i64 = 86_400;
 const MAX_TTL_SECS: i64 = 604_800;
 
 // ── DB helpers ──────────────────────────────────────────────────
+
+async fn require_project_artifact_read(
+    pool: &SqlitePool,
+    auth: &AuthUser,
+    project_id: &str,
+) -> Result<(), (StatusCode, Json<ApiError>)> {
+    let effective = resolve_effective_project_role(
+        pool,
+        &auth.0.user_id,
+        &auth.0.role,
+        project_id,
+        &auth.0.auth_source,
+    )
+    .await?;
+    require_project_permission(&effective, ProjectPermission::ReadArtifacts)
+}
+
+async fn load_artifact_access(
+    pool: &SqlitePool,
+    artifact_id: &str,
+) -> Result<(Option<i64>, String), (StatusCode, Json<ApiError>)> {
+    let row = sqlx::query(
+        "SELECT a.expires_at, b.project_id \
+         FROM artifacts a \
+         JOIN builds b ON b.id = a.build_id \
+         WHERE a.id = ?1",
+    )
+    .bind(artifact_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| {
+        error!(error = %e, "failed to fetch artifact project");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to fetch artifact",
+        )
+    })?
+    .ok_or_else(|| api_err(StatusCode::NOT_FOUND, "not_found", "Artifact not found"))?;
+
+    Ok((row.get("expires_at"), row.get("project_id")))
+}
 
 pub async fn create_download_token(
     pool: &SqlitePool,
@@ -139,8 +183,6 @@ pub async fn create_scoped_token_handler(
     Path(artifact_id): Path<String>,
     Json(req): Json<CreateScopedDownloadTokenRequest>,
 ) -> ApiResult<CreateScopedDownloadTokenResponse> {
-    check_permission(&state.enforcer, &auth.0.role, "builds", "read").await?;
-
     let ttl = req.ttl_secs.unwrap_or(DEFAULT_TTL_SECS);
     if ttl < 60 {
         return Err(api_err(
@@ -162,22 +204,8 @@ pub async fn create_scoped_token_handler(
         store.pool().clone()
     };
 
-    // Verify artifact exists and is not expired
-    let artifact_row = sqlx::query("SELECT id, expires_at FROM artifacts WHERE id = ?1")
-        .bind(&artifact_id)
-        .fetch_optional(&pool)
-        .await
-        .map_err(|e| {
-            error!(error = %e, "failed to fetch artifact");
-            api_err(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "store_error",
-                "Failed to fetch artifact",
-            )
-        })?
-        .ok_or_else(|| api_err(StatusCode::NOT_FOUND, "not_found", "Artifact not found"))?;
-
-    let artifact_expires_at: Option<i64> = artifact_row.get("expires_at");
+    let (artifact_expires_at, project_id) = load_artifact_access(&pool, &artifact_id).await?;
+    require_project_artifact_read(&pool, &auth, &project_id).await?;
     if let Some(ea) = artifact_expires_at
         && ea <= now_unix()
     {
@@ -248,12 +276,12 @@ pub async fn list_scoped_tokens_handler(
     auth: AuthUser,
     Path(artifact_id): Path<String>,
 ) -> ApiResult<ListArtifactDownloadTokensResponse> {
-    check_permission(&state.enforcer, &auth.0.role, "builds", "read").await?;
-
     let pool = {
         let store = state.store.lock().await;
         store.pool().clone()
     };
+    let (_, project_id) = load_artifact_access(&pool, &artifact_id).await?;
+    require_project_artifact_read(&pool, &auth, &project_id).await?;
     let now = now_unix();
 
     let rows = sqlx::query(
@@ -312,27 +340,30 @@ pub async fn revoke_scoped_token_handler(
     auth: AuthUser,
     Path(token_id): Path<String>,
 ) -> ApiResult<RevokeArtifactDownloadTokenResponse> {
-    check_permission(&state.enforcer, &auth.0.role, "builds", "read").await?;
-
     let pool = {
         let store = state.store.lock().await;
         store.pool().clone()
     };
 
     // Fetch the token to check existence
-    let row =
-        sqlx::query("SELECT created_by, revoked_at FROM artifact_download_tokens WHERE id = ?1")
-            .bind(&token_id)
-            .fetch_optional(&pool)
-            .await
-            .map_err(|e| {
-                error!(error = %e, "failed to query download token");
-                api_err(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "db_error",
-                    "Failed to query download token",
-                )
-            })?;
+    let row = sqlx::query(
+        "SELECT t.created_by, t.revoked_at, b.project_id \
+         FROM artifact_download_tokens t \
+         JOIN artifacts a ON a.id = t.artifact_id \
+         JOIN builds b ON b.id = a.build_id \
+         WHERE t.id = ?1",
+    )
+    .bind(&token_id)
+    .fetch_optional(&pool)
+    .await
+    .map_err(|e| {
+        error!(error = %e, "failed to query download token");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "db_error",
+            "Failed to query download token",
+        )
+    })?;
 
     let row = row.ok_or_else(|| {
         api_err(
@@ -341,6 +372,9 @@ pub async fn revoke_scoped_token_handler(
             "Download token not found",
         )
     })?;
+
+    let project_id: String = row.get("project_id");
+    require_project_artifact_read(&pool, &auth, &project_id).await?;
 
     let revoked_at: Option<i64> = row.get("revoked_at");
     if revoked_at.is_some() {

--- a/crates/oored/src/builds.rs
+++ b/crates/oored/src/builds.rs
@@ -18,7 +18,6 @@ use crate::extractors::AuthUser;
 use crate::project_rbac::{
     ProjectPermission, require_project_permission, resolve_effective_project_role,
 };
-use crate::rbac::check_permission;
 use crate::store::write_audit_log;
 use crate::util::{api_err, now_unix};
 
@@ -832,10 +831,32 @@ pub async fn cancel_build(
     auth: AuthUser,
     Path(build_id): Path<String>,
 ) -> ApiResult<CancelBuildResponse> {
-    check_permission(&state.enforcer, &auth.0.role, "builds", "cancel").await?;
-
     let store = state.store.lock().await;
     let pool = store.pool();
+
+    let project_id: String = sqlx::query_scalar("SELECT project_id FROM builds WHERE id = ?1")
+        .bind(&build_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| {
+            error!(error = %e, "failed to fetch build project for cancel");
+            api_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "store_error",
+                "Failed to fetch build",
+            )
+        })?
+        .ok_or_else(|| api_err(StatusCode::NOT_FOUND, "not_found", "Build not found"))?;
+
+    let effective = resolve_effective_project_role(
+        pool,
+        &auth.0.user_id,
+        &auth.0.role,
+        &project_id,
+        &auth.0.auth_source,
+    )
+    .await?;
+    require_project_permission(&effective, ProjectPermission::CancelBuild)?;
 
     let build = transition_build(
         pool,

--- a/crates/oored/tests/logs_artifacts_integration.rs
+++ b/crates/oored/tests/logs_artifacts_integration.rs
@@ -54,6 +54,32 @@ async fn seed_user_with_role(pool: &sqlx::SqlitePool, email: &str, role: &str) -
     user_id
 }
 
+async fn json_request(
+    app: &axum::Router,
+    method: &str,
+    uri: &str,
+    token: &str,
+    body: Option<serde_json::Value>,
+) -> (StatusCode, serde_json::Value) {
+    let mut builder = Request::builder()
+        .uri(uri)
+        .method(method)
+        .header(http::header::AUTHORIZATION, format!("Bearer {token}"));
+
+    let req_body = if let Some(json) = body {
+        builder = builder.header(http::header::CONTENT_TYPE, "application/json");
+        Body::from(serde_json::to_string(&json).unwrap())
+    } else {
+        Body::empty()
+    };
+
+    let req = builder.body(req_body).unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let json = body_json(resp.into_body()).await;
+    (status, json)
+}
+
 /// Register a runner and return (runner_id, runner_token).
 async fn register_runner(app: &axum::Router, session_token: &str, name: &str) -> (String, String) {
     let body = serde_json::json!({
@@ -422,7 +448,7 @@ async fn test_get_logs_build_not_found() {
 
 #[tokio::test]
 async fn test_non_member_cannot_read_build_logs_or_artifacts() {
-    let (app, pool, _session_token, runner_id, runner_token, build_id) = full_scaffold().await;
+    let (app, pool, session_token, runner_id, runner_token, build_id) = full_scaffold().await;
     let outsider_id = seed_user_with_role(&pool, "outsider@example.com", "developer").await;
     let outsider_session = create_session_token(&pool, &outsider_id).await;
 
@@ -445,31 +471,56 @@ async fn test_non_member_cannot_read_build_logs_or_artifacts() {
     let artifact_json = body_json(resp.into_body()).await;
     let artifact_id = artifact_json["artifact"]["id"].as_str().unwrap();
 
-    for (method, uri) in [
-        ("GET", "/v1/builds".to_string()),
-        ("GET", format!("/v1/builds/{build_id}")),
-        ("GET", format!("/v1/builds/{build_id}/logs")),
-        ("POST", format!("/v1/builds/{build_id}/stream-token")),
-        ("GET", format!("/v1/builds/{build_id}/logs/stream")),
-        ("GET", format!("/v1/builds/{build_id}/artifacts")),
-        ("POST", format!("/v1/artifacts/{artifact_id}/download-link")),
-    ] {
-        let req = Request::builder()
-            .uri(uri)
-            .method(method)
-            .header(
-                http::header::AUTHORIZATION,
-                format!("Bearer {outsider_session}"),
-            )
-            .body(Body::empty())
-            .unwrap();
+    let (status, owner_token_json) = json_request(
+        &app,
+        "POST",
+        &format!("/v1/artifacts/{artifact_id}/scoped-token"),
+        &session_token,
+        Some(serde_json::json!({
+            "ttl_secs": 3600,
+            "single_use": true
+        })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "owner scoped token create: {owner_token_json}"
+    );
+    let token_id = owner_token_json["id"].as_str().unwrap().to_string();
 
-        let resp = app.clone().oneshot(req).await.unwrap();
-        if method == "GET" && resp.status() == StatusCode::OK {
-            let json = body_json(resp.into_body()).await;
+    for (method, uri, body) in [
+        ("GET", "/v1/builds".to_string(), None),
+        ("GET", format!("/v1/builds/{build_id}"), None),
+        ("GET", format!("/v1/builds/{build_id}/logs"), None),
+        ("POST", format!("/v1/builds/{build_id}/stream-token"), None),
+        ("GET", format!("/v1/builds/{build_id}/logs/stream"), None),
+        ("GET", format!("/v1/builds/{build_id}/artifacts"), None),
+        (
+            "POST",
+            format!("/v1/artifacts/{artifact_id}/download-link"),
+            None,
+        ),
+        (
+            "POST",
+            format!("/v1/artifacts/{artifact_id}/scoped-token"),
+            Some(serde_json::json!({
+                "ttl_secs": 3600,
+                "single_use": true
+            })),
+        ),
+        (
+            "GET",
+            format!("/v1/artifacts/{artifact_id}/scoped-tokens"),
+            None,
+        ),
+        ("DELETE", format!("/v1/artifact-tokens/{token_id}"), None),
+    ] {
+        let (status, json) = json_request(&app, method, &uri, &outsider_session, body).await;
+        if method == "GET" && status == StatusCode::OK {
             assert_eq!(json["total"].as_i64(), Some(0));
         } else {
-            assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+            assert_eq!(status, StatusCode::NOT_FOUND, "{method} {uri}: {json}");
         }
     }
 }

--- a/crates/oored/tests/project_pipeline_integration.rs
+++ b/crates/oored/tests/project_pipeline_integration.rs
@@ -77,6 +77,54 @@ async fn seed_user_with_role(pool: &sqlx::SqlitePool, email: &str, role: &str) -
     user_id
 }
 
+async fn seed_project_member(
+    pool: &sqlx::SqlitePool,
+    project_id: &str,
+    user_id: &str,
+    created_by: &str,
+    role: &str,
+) {
+    let now = common::now_unix();
+    sqlx::query(
+        "INSERT INTO project_members (id, project_id, user_id, role, created_by, created_at, updated_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6)",
+    )
+    .bind(uuid::Uuid::new_v4().to_string())
+    .bind(project_id)
+    .bind(user_id)
+    .bind(role)
+    .bind(created_by)
+    .bind(now)
+    .execute(pool)
+    .await
+    .expect("failed to seed project member");
+}
+
+async fn seed_running_build_without_runner(
+    pool: &sqlx::SqlitePool,
+    project_id: &str,
+    pipeline_id: &str,
+) -> String {
+    let build_id = uuid::Uuid::new_v4().to_string();
+    let now = common::now_unix();
+    sqlx::query(
+        "INSERT INTO builds (id, project_id, pipeline_id, build_number, status, runner_id, \
+         trigger_type, config_snapshot, queued_at, started_at, created_at, updated_at) \
+         VALUES (?1, ?2, ?3, \
+                 (SELECT COALESCE(MAX(build_number), 0) + 1 FROM builds WHERE project_id = ?2), \
+                 'running', NULL, 'manual', '{}', ?4, ?4, ?4, ?4)",
+    )
+    .bind(&build_id)
+    .bind(project_id)
+    .bind(pipeline_id)
+    .bind(now)
+    .execute(pool)
+    .await
+    .expect("failed to seed running build");
+
+    build_id
+}
+
 /// Helper to send a JSON request and return (status, body_json).
 async fn json_request(
     app: &axum::Router,
@@ -778,6 +826,65 @@ async fn test_non_member_cannot_use_direct_pipeline_or_signing_routes() {
         let (status, json) = json_request(&app, method, &uri, &outsider_token, body).await;
         assert_eq!(status, StatusCode::NOT_FOUND, "{method} {uri}: {json}");
     }
+}
+
+#[tokio::test]
+async fn test_developer_cannot_cancel_build_outside_project() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let app = create_test_app(&db_path).await;
+    let pool = connect_pool(&db_path).await;
+    let owner_id = seed_test_user(&pool).await;
+    let integration_id = seed_github_integration(&pool, &owner_id, "secret").await;
+
+    let (allowed_project_id, allowed_pipeline_id) =
+        seed_project_chain(&pool, &integration_id, &owner_id, "org/allowed-project").await;
+    let (private_project_id, private_pipeline_id) =
+        seed_project_chain(&pool, &integration_id, &owner_id, "org/private-project").await;
+
+    let developer_id = seed_user_with_role(&pool, "developer@example.com", "developer").await;
+    seed_project_member(
+        &pool,
+        &allowed_project_id,
+        &developer_id,
+        &owner_id,
+        "developer",
+    )
+    .await;
+    let developer_token = create_session_token(&pool, &developer_id).await;
+
+    let allowed_build_id =
+        seed_running_build_without_runner(&pool, &allowed_project_id, &allowed_pipeline_id).await;
+    let private_build_id =
+        seed_running_build_without_runner(&pool, &private_project_id, &private_pipeline_id).await;
+
+    let (status, json) = json_request(
+        &app,
+        "POST",
+        &format!("/v1/builds/{private_build_id}/cancel"),
+        &developer_token,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "private cancel: {json}");
+
+    let private_status: String = sqlx::query_scalar("SELECT status FROM builds WHERE id = ?1")
+        .bind(&private_build_id)
+        .fetch_one(&pool)
+        .await
+        .expect("failed to fetch private build status");
+    assert_eq!(private_status, "running");
+
+    let (status, json) = json_request(
+        &app,
+        "POST",
+        &format!("/v1/builds/{allowed_build_id}/cancel"),
+        &developer_token,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "allowed cancel: {json}");
+    assert_eq!(json["build"]["status"].as_str(), Some("canceled"));
 }
 
 #[tokio::test]

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -10,6 +10,13 @@ Rules:
 - Any code change under `apps/`, `crates/`, `tools/`, etc. must add an entry here.
 - Include a Linear issue/doc link for each entry.
 
+## 2026-05-05
+
+- **Project RBAC hardening from Codex scan** ([GitHub #88](https://github.com/devaryakjha/oore.build/issues/88), [#89](https://github.com/devaryakjha/oore.build/issues/89)):
+  - `POST /v1/builds/{build_id}/cancel` now resolves the build project and requires `ProjectPermission::CancelBuild` before transitioning build state.
+  - Scoped artifact token create/list/revoke routes now resolve artifact -> build -> project and require `ProjectPermission::ReadArtifacts` before minting or managing bearer download URLs.
+  - Docs index: https://linear.app/oorebuild/document/docs-index-linear-first-457d9edc9cda
+
 ## 2026-04-15
 
 - **Security fixes from Codex scan** ([GitHub #83](https://github.com/devaryakjha/oore.build/issues/83), [#84](https://github.com/devaryakjha/oore.build/issues/84), [#85](https://github.com/devaryakjha/oore.build/issues/85), [#86](https://github.com/devaryakjha/oore.build/issues/86)):


### PR DESCRIPTION
## Summary
- require project-level `CancelBuild` before `POST /v1/builds/{build_id}/cancel` transitions build state
- require project-level `ReadArtifacts` before scoped artifact token create/list/revoke routes touch bearer download URLs
- add focused integration coverage for cross-project cancel denial and scoped-token non-member denial
- update `docs/changes.md` with the security hardening entry

## Issues
Fixes #88
Fixes #89

## Validation
- `cargo test -p oored --features test-support test_developer_cannot_cancel_build_outside_project`
- `cargo test -p oored --features test-support test_non_member_cannot_read_build_logs_or_artifacts`
- `make validate`

Note: `make validate` required `bun install` first because the fresh worktree did not have local web/docs dependencies installed. The final `make validate` run passed; Vite emitted the existing chunk-size and missing `%VITE_CF_WEB_ANALYTICS_TOKEN%` warnings during production builds.