### PR TITLE
feat: harden product trust and release safety

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -1,7 +1,9 @@
 name: Autotag
 
 on:
-  push:
+  workflow_run:
+    workflows: [Validate]
+    types: [completed]
     branches: [stable, alpha, beta]
 
 concurrency:
@@ -11,6 +13,10 @@ concurrency:
 jobs:
   autotag:
     name: Cut release tag
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      contains(fromJSON('["stable","alpha","beta"]'), github.event.workflow_run.head_branch)
     runs-on: [self-hosted, jarvis]
     # Only run after validate completes — but since validate is a separate workflow,
     # we rely on branch protection rules to enforce this ordering.
@@ -19,10 +25,12 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PAT }}
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Autotag
         env:
-          AUTOTAG_CHANNEL: ${{ github.ref_name }}
-          AUTOTAG_BRANCH: ${{ github.ref_name }}
+          AUTOTAG_CHANNEL: ${{ github.event.workflow_run.head_branch }}
+          AUTOTAG_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          AUTOTAG_SHA: ${{ github.event.workflow_run.head_sha }}
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: bash tools/autotag.sh

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,9 +2,9 @@ name: Validate
 
 on:
   pull_request:
-    branches: [master]
+    branches: [master, alpha, beta, stable]
   push:
-    branches: [master]
+    branches: [master, alpha, beta, stable]
   workflow_dispatch:
 
 concurrency:
@@ -32,11 +32,18 @@ jobs:
             docs:
               - 'apps/docs-site/**'
               - 'docs/**'
+              - 'scripts/**'
               - 'tools/docs-check.sh'
+              - 'tools/release-smoke.sh'
+              - 'tools/autotag.sh'
+              - '.github/workflows/**'
             rust:
               - 'crates/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
+              - 'tools/release-smoke.sh'
+              - 'tools/autotag.sh'
+              - '.github/workflows/**'
 
   frontend:
     name: Frontend

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2670,6 +2670,7 @@ version = "0.1.10"
 dependencies = [
  "serde",
  "serde_json",
+ "serde_yaml",
  "utoipa",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: dev-web dev-docs dev-site build-web build-demo deploy-demo deploy-web build-site deploy-site build-docs deploy-docs build check \
 		       test-web lint-web fix-web \
-		       test-docs lint-docs fix-docs test-rust \
+		       test-docs lint-docs fix-docs test-rust test-install \
 		       fmt-rust fmt-rust-check clippy-rust test-rust-workspace lint test \
 		       cargo-check run-daemon run-daemon-debug run-daemon-release \
 		       run-runner register-runner run-cli doctor clean-dev-state dev-fresh-setup \
@@ -140,6 +140,9 @@ install-local:
 
 test-rust:
 	cargo test -p oored --features test-support
+
+test-install:
+	bash scripts/install-acceptance.sh
 
 # ── Rust: Lint/Fmt/Clippy/Test ───────────────────────────────────
 fmt-rust:

--- a/apps/docs-site/docs/concepts/artifact-access.md
+++ b/apps/docs-site/docs/concepts/artifact-access.md
@@ -35,7 +35,12 @@ When a runner produces a build artifact:
    - Maximum file size: 512 MiB
    - The upload URL is single-use and time-limited
 
-4. **Daemon records the artifact** with its storage location and metadata
+4. **Runner finalizes the reservation**
+   - `POST .../artifacts/{artifact_id}/complete` makes the artifact available
+   - `POST .../artifacts/{artifact_id}/abort` records a failed upload
+   - Pending and failed artifacts are not listed or downloadable
+
+Declared artifact patterns are part of build success: an empty pattern list requires no artifact, while a non-empty list must produce at least one finalized artifact. Missing matches and upload/finalization failures fail the build.
 
 ## Download flow
 

--- a/apps/docs-site/docs/concepts/runner-protocol.md
+++ b/apps/docs-site/docs/concepts/runner-protocol.md
@@ -42,7 +42,7 @@ The daemon uses heartbeat data to track which runners are available.
 
 ### 3. Job claim
 
-The runner calls `POST /v1/runners/{runner_id}/claim` to request work. The daemon:
+The runner calls `POST /v1/runners/{runner_id}/claim` with `{"protocol_version": 2}` to request work. The daemon rejects incompatible runners before assigning work.
 
 1. Finds the oldest build with `status = queued`
 2. Transitions the build: `queued` → `scheduled` → `assigned`
@@ -97,6 +97,7 @@ After a successful build, the runner uploads artifacts:
 1. **Create artifact record**: `POST /v1/runners/{runner_id}/jobs/{job_id}/artifacts` with the artifact name, type (`apk`, `ipa`, `app`, `generic`), and checksum
 2. **Receive upload URL**: The daemon returns a presigned upload URL (S3/R2) or a local upload token
 3. **Upload the file**: The runner PUTs the file to the upload URL (max 512 MiB)
+4. **Finalize or abort**: The runner calls the artifact `complete` endpoint after a successful upload, or `abort` after a failed upload. Pending artifacts are not visible or downloadable.
 
 See [Artifact Access Model](/concepts/artifact-access) for details on how uploads and downloads are secured.
 

--- a/apps/docs-site/docs/getting-started/install.md
+++ b/apps/docs-site/docs/getting-started/install.md
@@ -16,11 +16,16 @@ Installation puts the daemon, CLI, and/or frontend launcher on disk. First-run s
 - Internet access to GitHub (`github.com`) and the installer endpoint for your channel
 - Access to `ci.oore.build` only if you plan to use the hosted UI
 
-## Install (latest release)
+## Install on one Mac (default)
 
 ```bash
 curl -fsSL https://oore.build/install | bash
 ```
+
+On macOS, this is the local-first path: it installs the daemon, CLI, embedded runner, and local web UI; keeps both services on loopback; enables launch-at-login; starts them; and opens `http://127.0.0.1:4173`.
+It uses loopback local login, so it does not generate a bootstrap token or send you to `/setup`.
+
+Use `--no-open` to suppress the browser. Non-interactive installs do not open a browser unless you explicitly set `OORE_OPEN_BROWSER=true`.
 
 ## Install by channel (stable/beta/alpha)
 
@@ -43,9 +48,15 @@ curl -fsSL https://alpha.oore.pages.dev/install | OORE_CHANNEL=alpha bash
 
 `OORE_VERSION` (pinned tag/version) always overrides channel selection. Use the matching channel installer endpoint when testing prerelease installer behavior; `https://oore.build/install` is the stable production installer.
 
-## Install modes
+## Advanced topology install modes
 
-The installer is role-based:
+For split, remote, or frontend-only deployments, keep the existing topology wizard behind `--advanced`:
+
+```bash
+curl -fsSL https://oore.build/install | bash -s -- --advanced
+```
+
+The advanced installer is role-based:
 
 - `auto`: macOS prompts for a role in interactive shells; Linux defaults to frontend-only mode.
 - `all`: installs the daemon, CLI, embedded runner, `oore-web`, and local web assets on one macOS host.
@@ -66,7 +77,7 @@ Install roles describe where binaries run. Setup modes describe how the backend 
 | Split frontend/backend | `backend` on macOS plus `frontend` on Linux/macOS | Usually `Remote Trusted Proxy` or `Remote OIDC` | A browser-facing `oore-web` host proxies API calls to the macOS backend over a controlled network path. |
 | Hosted UI | `backend` on macOS | `Remote OIDC` or `Remote Trusted Proxy` | `ci.oore.build` serves only the frontend app; your macOS backend still owns setup, auth, data, builds, and signing keys. |
 
-The installer:
+The advanced installer:
 
 - Detects your architecture (`arm64` or `x86_64`)
 - Prompts for the macOS role and chooses frontend-only mode on Linux when `OORE_INSTALL_MODE=auto`
@@ -243,13 +254,14 @@ Continue with [Set Up Your Instance](/getting-started/first-instance). If you pl
 |---|---|---|
 | `OORE_VERSION` | `latest` | Release selector (`latest` or tag like `v0.2.0`) |
 | `OORE_CHANNEL` | `stable` | Channel selector when `OORE_VERSION=latest`: `stable`, `beta`, or `alpha` |
-| `OORE_INSTALL_MODE` | `auto` | Install mode: `auto`, `all`, `backend`, or `frontend`; `full` is accepted as a legacy alias for `all` |
+| `OORE_INSTALL_MODE` | `auto` | Advanced install mode: `auto`, `all`, `backend`, or `frontend`; use it with `--advanced`; `full` is accepted as a legacy alias for `all` |
 | `OORE_INSTALL_ROOT` | `~/.oore` | Installation directory |
 | `OORE_GITHUB_REPO` | `devaryakjha/oore.build` | GitHub repository used to resolve `latest` and download assets |
 | `OORE_RELEASE_BASE_URL` | `https://github.com/<repo>/releases/download` | Base URL that contains `<tag>/` release assets |
 | `OORE_RELEASE_MANIFEST_URL` | `https://api.github.com/repos/<repo>/releases/latest` | Metadata URL used when `OORE_VERSION=latest` |
 | `OORE_RELEASES_LIST_URL` | `https://api.github.com/repos/<repo>/releases?per_page=100` | Release list URL used when `OORE_VERSION=latest` and `OORE_CHANNEL` is `alpha` or `beta` |
 | `OORE_NONINTERACTIVE` | `0` | Disable prompts when set to `1` |
+| `OORE_OPEN_BROWSER` | interactive local install only | Open the local web root after a default macOS install; set `true` to opt in for non-interactive installs |
 | `OORE_DAEMON_LISTEN` | from `OORE_DAEMON_URL` | Daemon listen address for `all` and `backend` installs, for example `127.0.0.1:8787` for same-host reverse proxy or `10.0.0.20:8787` for a private frontend host |
 | `OORE_START_DAEMON` | unset | Non-interactive daemon startup behavior (`true` or `false`) |
 | `OORE_INSTALL_DAEMON_SERVICE` | unset | Non-interactive launchd service install/start behavior for `all` and `backend` macOS installs (`true` or `false`) |

--- a/apps/docs-site/docs/getting-started/prerequisites.md
+++ b/apps/docs-site/docs/getting-started/prerequisites.md
@@ -76,7 +76,7 @@ Run diagnostics after installation:
 oore doctor
 ```
 
-`oore doctor` currently checks a broad toolchain set (including Rust and Bun). Missing Rust/Bun does not block release-binary installation, but it does block source-development workflows.
+`oore doctor` checks the runner runtime by default. Add `--platform android`, `--platform ios`, or `--platform macos` (repeatable), or use `--all`, for target-specific requirements. Rust and Bun are source-development tools and are not release-runner requirements.
 
 ## Next step
 

--- a/apps/docs-site/docs/getting-started/public-alpha.md
+++ b/apps/docs-site/docs/getting-started/public-alpha.md
@@ -60,6 +60,8 @@ Choosing the right path depends on how your browser reaches the backend. The bac
 
 ![Oore CI Dashboard screenshot](/demo-dashboard.webp)
 
+> The public demo uses fixed sample data. It is read-only and does not create projects, pipelines, builds, or settings changes.
+
 ### Path A: Local-first (no HTTPS required)
 
 Best when you want to try it on a single Mac first.

--- a/apps/docs-site/docs/guides/projects/pipeline-config.md
+++ b/apps/docs-site/docs/guides/projects/pipeline-config.md
@@ -27,7 +27,7 @@ commands:
   post_build: []
 artifacts:
   patterns:
-    - "**/*.apk"
+    - "build/app/outputs/flutter-apk/*.apk"
 ```
 
 ## Full schema
@@ -61,9 +61,9 @@ Each stage is a list of shell commands executed sequentially. If any command ret
 ```yaml
 platform_build_args:
   android:
-    extra_args: "--split-per-abi"
+    - "--split-per-abi"
   ios:
-    export_method: "ad-hoc"
+    - "--flavor=staging"
 ```
 
 ### Platform-specific commands
@@ -72,12 +72,8 @@ Override the default build command per platform:
 
 ```yaml
 platform_commands:
-  android:
-    build:
-      - flutter build apk --release --split-per-abi
-  ios:
-    build:
-      - flutter build ipa --release --export-method ad-hoc
+  android: flutter build apk --release --split-per-abi
+  ios: flutter build ipa --release
 ```
 
 ### Environment variables
@@ -95,32 +91,12 @@ env:
 ```yaml
 artifacts:
   patterns:
-    - "**/*.apk"
-    - "**/*.ipa"
-    - "**/*.app.zip"
+    - "build/app/outputs/flutter-apk/*.apk"
+    - "build/ios/ipa/*.ipa"
+    - "build/macos/Build/Products/Release/*.app"
 ```
 
-Glob patterns are matched against the build output directory.
-
-### Trigger configuration
-
-```yaml
-triggers:
-  events:
-    - push
-    - pull_request
-  branches:
-    - main
-    - "release/*"
-```
-
-### Concurrency
-
-```yaml
-concurrency:
-  max_concurrent: 1
-  cancel_in_progress: true
-```
+Glob patterns are matched against workspace-relative paths. Filename-only patterns such as `*.apk` still match anywhere. Configure triggers and concurrency in the pipeline UI/API, not in repository YAML.
 
 ## Multi-platform example
 
@@ -143,13 +119,8 @@ platform_build_args:
     extra_args: "--split-per-abi"
 artifacts:
   patterns:
-    - "**/*.apk"
-    - "**/*.ipa"
-triggers:
-  events:
-    - push
-  branches:
-    - main
+    - "build/app/outputs/flutter-apk/*.apk"
+    - "build/ios/ipa/*.ipa"
 ```
 
 ## Config resolution
@@ -169,11 +140,8 @@ For Flutter version resolution:
 
 ## Validation
 
-Validate a pipeline config before creating a build:
+Validate a pipeline config locally with the same parser used by the runner:
 
 ```bash
-curl -X POST http://127.0.0.1:8787/v1/pipelines/validate \
-  -H "Authorization: Bearer <session_token>" \
-  -H "Content-Type: application/json" \
-  -d '{"config": "<yaml content>"}'
+oore pipeline validate .oore.yaml
 ```

--- a/apps/docs-site/docs/operations/backup-restore.md
+++ b/apps/docs-site/docs/operations/backup-restore.md
@@ -1,86 +1,41 @@
 ---
 status: implemented
-description: "Back up and restore Oore CI data including SQLite database and configuration."
+description: "Create, verify, and restore Oore CI backups."
 ---
 
 # Backup and Restore
 
-Oore CI stores all state in two files: the SQLite database and the encryption key. Regular backups of both are essential.
+`oore backup` packages a consistent SQLite snapshot, the matching encryption key, and a checksum manifest into one owner-readable archive. Both database and key are required to recover encrypted credentials.
 
-## What to back up
-
-| File | Default location | Contains |
-|---|---|---|
-| **Database** | `~/Library/Application Support/oore/oore.db` | All instance state, users, projects, builds, configs |
-| **Encryption key** | `~/Library/Application Support/oore/encryption.key` | AES-256-GCM key for encrypted secrets |
-
-::: danger
-Both files are required for a successful restore. The database contains encrypted secrets that can only be decrypted with the corresponding encryption key. If you lose the encryption key, encrypted data (OIDC client secrets, signing credentials) is unrecoverable.
-:::
-
-## Backup
-
-### Manual backup
+## Create and verify
 
 ```bash
-# Stop the daemon first for a consistent snapshot
-# Or use SQLite's backup API for online backups
-
-# Copy database
-cp ~/Library/Application\ Support/oore/oore.db /backups/oore-$(date +%Y%m%d).db
-
-# Copy encryption key
-cp ~/Library/Application\ Support/oore/encryption.key /backups/encryption-$(date +%Y%m%d).key
+oore backup create --output /Volumes/backups/oore-$(date +%F).tar.gz
+oore backup verify --input /Volumes/backups/oore-$(date +%F).tar.gz
 ```
 
-### SQLite online backup
+The snapshot uses SQLite's online backup operation, so creating it does not require stopping `oored`. The archive and copied key are written with restrictive owner-only permissions. Keep archives on separate encrypted storage.
 
-For zero-downtime backups, use SQLite's `.backup` command:
-
-```bash
-sqlite3 ~/Library/Application\ Support/oore/oore.db ".backup /backups/oore-$(date +%Y%m%d).db"
-```
-
-### Automated backups
-
-Schedule backups with cron or launchd:
+For a non-default database, use the same state-file path as the daemon:
 
 ```bash
-# crontab -e
-0 2 * * * sqlite3 ~/Library/Application\ Support/oore/oore.db ".backup /backups/oore-$(date +\%Y\%m\%d).db" && cp ~/Library/Application\ Support/oore/encryption.key /backups/encryption-$(date +\%Y\%m\%d).key
+oore backup create --state-file "$HOME/Library/Application Support/oore-prod/oore.db" --output /Volumes/backups/oore-prod.tar.gz
 ```
 
 ## Restore
 
-### 1. Stop the daemon
+Stop the daemon first. Restore refuses to run while the default managed daemon is reachable, preventing a live process from writing over restored state.
 
 ```bash
-# Stop oored process
+launchctl bootout gui/$(id -u)/build.oore.oored
+oore backup restore --input /Volumes/backups/oore-2026-07-12.tar.gz
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/build.oore.oored.plist
 ```
 
-### 2. Restore files
+The command verifies the manifest, both SHA-256 checksums, key length, and SQLite integrity before replacing files. It swaps database and key atomically and restores the previous pair if replacement fails.
 
-```bash
-cp /backups/oore-20260210.db ~/Library/Application\ Support/oore/oore.db
-cp /backups/encryption-20260210.key ~/Library/Application\ Support/oore/encryption.key
-```
+## Storage guidance
 
-### 3. Start the daemon
-
-```bash
-oored run
-```
-
-### 4. Verify
-
-```bash
-curl http://127.0.0.1:8787/v1/public/setup-status
-curl http://127.0.0.1:8787/healthz
-```
-
-## Backup storage recommendations
-
-- Store backups on a separate volume or remote storage
-- Encrypt backups at rest (the encryption key file is especially sensitive)
-- Retain at least 7 daily backups
-- Test restores periodically
+- Keep at least one verified copy outside the daemon host.
+- Treat the archive as sensitive: it contains the encryption key.
+- Test `oore backup verify` after copying an archive and rehearse a restore before relying on it.

--- a/apps/docs-site/docs/operations/upgrade.md
+++ b/apps/docs-site/docs/operations/upgrade.md
@@ -10,12 +10,24 @@ How to upgrade your Oore CI instance to a new version.
 ## Before upgrading
 
 1. **Read the release notes** for the target version
-2. **Back up your database and encryption key** (see [Backup and Restore](/operations/backup-restore))
+2. **Create and verify a backup** (see [Backup and Restore](/operations/backup-restore))
 3. **Check for breaking changes** in the changelog
 
 ## Upgrade steps
 
-### 1. Pull the latest code
+### Installed release update
+
+```bash
+oore update
+```
+
+The updater creates a pre-update backup, stages the verified release inside the install root, atomically replaces release files, reloads active launchd daemon/local-web services, and rolls back the release if readiness fails. Use `/healthz` for liveness and `/readyz` for database, migration, and encryption-runtime readiness.
+
+::: warning
+This hardening release must be installed with the current installer. An already-installed older updater cannot be made retroactively atomic or rollback-safe.
+:::
+
+### Source checkout update
 
 ```bash
 cd /path/to/Oore CI
@@ -48,6 +60,7 @@ The daemon handles any necessary database migrations automatically on startup.
 
 ```bash
 curl http://127.0.0.1:8787/healthz
+curl http://127.0.0.1:8787/readyz
 curl http://127.0.0.1:8787/v1/public/setup-status
 ```
 

--- a/apps/docs-site/docs/public/openapi.json
+++ b/apps/docs-site/docs/public/openapi.json
@@ -3376,6 +3376,16 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ClaimJobRequest"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "Job claimed (or null)",
@@ -3528,6 +3538,128 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CreateArtifactResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/v1/runners/{runner_id}/jobs/{job_id}/artifacts/{artifact_id}/abort": {
+      "post": {
+        "tags": [
+          "Artifacts"
+        ],
+        "operationId": "abort_artifact",
+        "parameters": [
+          {
+            "name": "runner_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "artifact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompleteArtifactRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompleteArtifactResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/v1/runners/{runner_id}/jobs/{job_id}/artifacts/{artifact_id}/complete": {
+      "post": {
+        "tags": [
+          "Artifacts"
+        ],
+        "operationId": "complete_artifact",
+        "parameters": [
+          {
+            "name": "runner_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "artifact_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompleteArtifactRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompleteArtifactResponse"
                 }
               }
             }
@@ -5940,7 +6072,8 @@
           "artifact_type",
           "file_path",
           "metadata",
-          "created_at"
+          "created_at",
+          "state"
         ],
         "properties": {
           "artifact_type": {
@@ -5983,6 +6116,9 @@
             "type": "object"
           },
           "name": {
+            "type": "string"
+          },
+          "state": {
             "type": "string"
           }
         }
@@ -6551,6 +6687,19 @@
           }
         }
       },
+      "ClaimJobRequest": {
+        "type": "object",
+        "required": [
+          "protocol_version"
+        ],
+        "properties": {
+          "protocol_version": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          }
+        }
+      },
       "ClaimJobResponse": {
         "type": "object",
         "properties": {
@@ -6608,6 +6757,28 @@
           },
           "project_id": {
             "type": "string"
+          }
+        }
+      },
+      "CompleteArtifactRequest": {
+        "type": "object",
+        "properties": {
+          "error_message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "CompleteArtifactResponse": {
+        "type": "object",
+        "required": [
+          "artifact"
+        ],
+        "properties": {
+          "artifact": {
+            "$ref": "#/components/schemas/Artifact"
           }
         }
       },
@@ -8398,7 +8569,8 @@
               "type": "string"
             }
           }
-        }
+        },
+        "additionalProperties": false
       },
       "PipelineDetailResponse": {
         "type": "object",
@@ -8429,7 +8601,8 @@
           "value": {
             "type": "string"
           }
-        }
+        },
+        "additionalProperties": false
       },
       "PipelineExecutionConfig": {
         "type": "object",
@@ -8581,7 +8754,8 @@
               "type": "string"
             }
           }
-        }
+        },
+        "additionalProperties": false
       },
       "PlatformBuildCommands": {
         "type": "object",
@@ -8604,7 +8778,8 @@
               "null"
             ]
           }
-        }
+        },
+        "additionalProperties": false
       },
       "Project": {
         "type": "object",
@@ -10491,6 +10666,12 @@
               {
                 "$ref": "#/components/schemas/PipelineExecutionConfig"
               }
+            ]
+          },
+          "repository_yaml": {
+            "type": [
+              "string",
+              "null"
             ]
           },
           "trigger_config": {

--- a/apps/docs-site/docs/public/openapi.json
+++ b/apps/docs-site/docs/public/openapi.json
@@ -6466,6 +6466,16 @@
           "config_snapshot": {
             "type": "object"
           },
+          "context": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/BuildContext"
+              }
+            ]
+          },
           "created_at": {
             "type": "integer",
             "format": "int64"
@@ -6552,6 +6562,29 @@
           "updated_at": {
             "type": "integer",
             "format": "int64"
+          }
+        }
+      },
+      "BuildContext": {
+        "type": "object",
+        "properties": {
+          "pipeline_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "project_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "runner_name": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },

--- a/apps/docs-site/docs/reference/api/artifacts.md
+++ b/apps/docs-site/docs/reference/api/artifacts.md
@@ -85,6 +85,14 @@ POST /v1/runners/{runner_id}/jobs/{job_id}/artifacts
 
 This endpoint is called by the runner process, not by end users.
 
+The returned artifact is `pending`. After uploading, the runner must call:
+
+```
+POST /v1/runners/{runner_id}/jobs/{job_id}/artifacts/{artifact_id}/complete
+```
+
+If upload fails, it calls the corresponding `/abort` endpoint. Only completed (`available`) artifacts appear in list and download APIs.
+
 ---
 
 ## Local Upload (Runner) {#local-upload}

--- a/apps/docs-site/docs/reference/cli/index.md
+++ b/apps/docs-site/docs/reference/cli/index.md
@@ -110,6 +110,8 @@ The operator CLI handles setup, authentication, and administration.
 | [`oore config set <key> <value>`](/reference/cli/oore-config) | Set CLI configuration values | Implemented |
 | [`oore config get <key>`](/reference/cli/oore-config) | Get CLI configuration values | Implemented |
 | [`oore doctor`](/reference/cli/oore-doctor) | Run environment/signing diagnostics | Implemented |
+| `oore backup create|verify|restore` | Create and recover verified SQLite/key backups | Implemented |
+| `oore update` | Safely install a verified release update | Implemented |
 
 ### Global behavior
 

--- a/apps/docs-site/docs/reference/cli/index.md
+++ b/apps/docs-site/docs/reference/cli/index.md
@@ -10,6 +10,12 @@ Oore CI provides two command-line tools:
 - **`oored`** — the daemon (control plane and API server)
 - **`oore`** — the operator CLI for setup, administration, and daily use
 
+Validate repository pipeline YAML locally with the exact parser used by the daemon and runner:
+
+```bash
+oore pipeline validate .oore.yaml
+```
+
 ## oored (Daemon)
 
 The daemon serves the HTTP API and manages instance state.

--- a/apps/docs-site/docs/reference/cli/oore-doctor.md
+++ b/apps/docs-site/docs/reference/cli/oore-doctor.md
@@ -10,7 +10,7 @@ Run environment diagnostics for build/signing readiness.
 ## Synopsis
 
 ```bash
-oore doctor [--json]
+oore doctor [--json] [--platform android|ios|macos]... [--all]
 ```
 
 ## Flags
@@ -18,25 +18,25 @@ oore doctor [--json]
 | Flag | Description |
 |------|-------------|
 | `--json` | Print machine-readable diagnostic report |
+| `--platform <platform>` | Add Android, iOS, or macOS target checks; repeat the flag for multiple targets |
+| `--all` | Run all platform checks |
 
 ## Checks
 
 `oore doctor` reports status for:
 
-- Core tooling: `git`, `rustc`, `cargo`, `bun`, `fvm`, `flutter`
-- Xcode CLI readiness:
-  - `xcodebuild -version`
-  - `xcode-select -p`
-- Code signing identities:
-  - `security find-identity -v -p codesigning`
-- Notarization tooling:
-  - `xcrun notarytool --version`
+- Core runner tools: `git`, `fvm`, and `flutter`
+- Android (with `--platform android`): Java and an `ANDROID_HOME` / `ANDROID_SDK_ROOT` SDK with Platform-Tools
+- iOS/macOS (with `--platform ios` or `--platform macos`): `xcode-select -p` and `xcodebuild -version`
+- Optional Apple signing and notarization readiness: signing identities and `xcrun notarytool`
+
+Every check is `ok`, `warning`, `missing`, or `skipped`. Warnings cover optional signing/notarization setup and do not fail the command.
 
 ## Exit codes
 
 | Code | Meaning |
 |------|---------|
-| `0` | All required checks passed |
+| `0` | All selected required checks passed (warnings are allowed) |
 | `1` | One or more required checks missing |
 
 ## Example output
@@ -44,10 +44,10 @@ oore doctor [--json]
 ```text
 oore doctor -- environment checks
   [ok] git                git version 2.49.0
-  [ok] rustc              rustc 1.86.0
-  [ok] xcode_cli          xcodebuild + xcode-select configured
-  [missing] codesign_identity install: import a Developer/Application certificate into Keychain Access
-1 issue(s) found.
+  [ok] flutter            Flutter 3.29.0
+  [ok] xcode              Xcode 16.2 (/Applications/Xcode.app/Contents/Developer)
+  [warning] codesign_identity import an Apple development or distribution certificate before signing
+1 required issue(s) found.
 ```
 
 ## JSON output example
@@ -62,6 +62,7 @@ oore doctor -- environment checks
       "install_hint": null
     }
   ],
-  "missing_count": 0
+  "missing_count": 0,
+  "warning_count": 0
 }
 ```

--- a/apps/docs-site/docs/reference/config/oore-yaml.md
+++ b/apps/docs-site/docs/reference/config/oore-yaml.md
@@ -31,17 +31,13 @@ commands:                            # Required. Build command stages.
 
 platform_build_args:                 # Optional. Per-platform build arguments.
   android:
-    extra_args: "--split-per-abi"
+    - "--split-per-abi"
   ios:
-    export_method: "ad-hoc"          # Options: ad-hoc, app-store, development, enterprise
+    - "--flavor=staging"
 
 platform_commands:                   # Optional. Override commands per platform.
-  android:
-    build:
-      - flutter build apk --release --split-per-abi
-  ios:
-    build:
-      - flutter build ipa --release --export-method ad-hoc
+  android: flutter build apk --release --split-per-abi
+  ios: flutter build ipa --release
 
 env:                                 # Optional. Environment variables for builds.
   - key: JAVA_HOME
@@ -49,20 +45,8 @@ env:                                 # Optional. Environment variables for build
 
 artifacts:                           # Optional. Artifact collection patterns.
   patterns:
-    - "**/*.apk"
-    - "**/*.ipa"
-
-triggers:                            # Optional. Webhook trigger configuration.
-  events:
-    - push                           # Options: push, pull_request
-    - pull_request
-  branches:
-    - main
-    - "release/*"                    # Supports glob patterns
-
-concurrency:                         # Optional. Concurrency controls.
-  max_concurrent: 1                  # Max simultaneous builds for this pipeline.
-  cancel_in_progress: true           # Cancel older builds when a new one starts.
+    - "build/app/outputs/flutter-apk/*.apk"
+    - "build/ios/ipa/*.ipa"
 ```
 
 ## Field reference
@@ -79,8 +63,6 @@ concurrency:                         # Optional. Concurrency controls.
 | `platform_commands` | `object` | No | — | Per-platform command overrides. |
 | `env` | `object[]` | No | `[]` | Environment variables. |
 | `artifacts` | `object` | No | — | Artifact collection config. |
-| `triggers` | `object` | No | — | Webhook trigger rules. |
-| `concurrency` | `object` | No | — | Concurrency controls. |
 
 ### commands
 
@@ -94,10 +76,7 @@ Commands are executed sequentially. If any command returns a non-zero exit code,
 
 ### platform_build_args
 
-| Platform | Field | Type | Description |
-|---|---|---|---|
-| `android` | `extra_args` | `string` | Extra arguments passed to the Android build command |
-| `ios` | `export_method` | `string` | IPA export method: `ad-hoc`, `app-store`, `development`, `enterprise` |
+Each platform value is a string array appended to its default build command.
 
 ### env
 
@@ -109,20 +88,7 @@ Commands are executed sequentially. If any command returns a non-zero exit code,
 ### artifacts.patterns
 
 An array of glob patterns matched against the build workspace. Matched files are collected as build artifacts.
-
-### triggers
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `events` | `string[]` | No | Trigger events: `push`, `pull_request` |
-| `branches` | `string[]` | No | Branch filters (supports glob patterns) |
-
-### concurrency
-
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `max_concurrent` | `integer` | No | `1` | Maximum simultaneous builds |
-| `cancel_in_progress` | `boolean` | No | `false` | Cancel running builds when a new one is triggered |
+Patterns are workspace-relative. Absolute paths, parent traversal, and symlink traversal are rejected. Filename-only patterns such as `*.apk` match anywhere in the workspace. Trigger and concurrency policy are configured on the pipeline through the UI/API; they are not repository YAML fields.
 
 ## Config resolution order
 

--- a/apps/web/src/components/pipeline-card.tsx
+++ b/apps/web/src/components/pipeline-card.tsx
@@ -23,6 +23,7 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
 import TriggerBuildDialog from '@/components/trigger-build-dialog'
+import { READ_ONLY_REASON, isDemoMode } from '@/lib/demo-mode'
 
 interface PipelineCardProps {
   pipeline: Pipeline
@@ -115,7 +116,12 @@ export default function PipelineCard({
           {/* Actions */}
           <div className="mt-4 flex flex-wrap items-center gap-2 border-t pt-4">
             {canTriggerBuild ? (
-              <Button size="sm" onClick={() => setTriggerOpen(true)}>
+              <Button
+                size="sm"
+                onClick={() => setTriggerOpen(true)}
+                disabled={isDemoMode}
+                title={isDemoMode ? READ_ONLY_REASON : undefined}
+              >
                 <HugeiconsIcon icon={PlayIcon} size={14} />
                 Run
               </Button>
@@ -128,6 +134,7 @@ export default function PipelineCard({
                   <Link
                     to="/projects/$projectId/pipelines/$pipelineId/edit"
                     params={{ projectId, pipelineId: pipeline.id }}
+                    search={{}}
                   />
                 }
                 nativeButton={false}
@@ -141,7 +148,8 @@ export default function PipelineCard({
                 size="sm"
                 variant="outline"
                 onClick={handleToggle}
-                disabled={updateMutation.isPending}
+                disabled={updateMutation.isPending || isDemoMode}
+                title={isDemoMode ? READ_ONLY_REASON : undefined}
               >
                 {pipeline.enabled ? 'Disable' : 'Enable'}
               </Button>

--- a/apps/web/src/components/pipeline-form.tsx
+++ b/apps/web/src/components/pipeline-form.tsx
@@ -78,6 +78,10 @@ interface PipelineFormProps {
   children?: React.ReactNode
   /** Local-mode repositories only support manual/API build triggers for now. */
   manualOnlyTriggers?: boolean
+  readOnly?: boolean
+  readOnlyReason?: string
+  retrySigning?: 'android' | 'ios'
+  signingError?: string
   signingData?: {
     release: {
       has_keystore: boolean
@@ -203,6 +207,10 @@ export default function PipelineForm({
   validationErrors = [],
   children,
   manualOnlyTriggers = false,
+  readOnly = false,
+  readOnlyReason,
+  retrySigning,
+  signingError,
   signingData,
   iosSigningData,
 }: PipelineFormProps) {
@@ -233,15 +241,16 @@ export default function PipelineForm({
   const [platformArgsOpen, setPlatformArgsOpen] = useState(false)
   const [envOpen, setEnvOpen] = useState(false)
   const [artifactsOpen, setArtifactsOpen] = useState(false)
+  const [iosSigningOpen, setIosSigningOpen] = useState(
+    () => !!initialValues.ios_signing_enabled || retrySigning === 'ios',
+  )
   const [signingOpen, setSigningOpen] = useState(
     () =>
+      retrySigning === 'android' ||
       !!(
         initialValues.android_signing_release_enabled ||
         initialValues.android_signing_debug_enabled
       ),
-  )
-  const [iosSigningOpen, setIosSigningOpen] = useState(
-    () => !!initialValues.ios_signing_enabled,
   )
 
   useMountEffect(() => {
@@ -919,8 +928,8 @@ export default function PipelineForm({
                             Oore also injects <code>PROJECT_ID</code>,{' '}
                             <code>PIPELINE_ID</code>, <code>BUILD_ID</code>,{' '}
                             <code>PROJECT_BUILD_NUMBER</code>,{' '}
-                            <code>BUILD_NUMBER</code>, <code>CI=true</code>,
-                            and branch/commit values when present.
+                            <code>BUILD_NUMBER</code>, <code>CI=true</code>, and
+                            branch/commit values when present.
                           </span>,
                           'Use this section for app-specific values such as API_BASE_URL, APP_FLAVOR, SENTRY_DSN, or feature flags.',
                         ]}
@@ -1575,6 +1584,17 @@ export default function PipelineForm({
           </div>
         ) : null}
 
+        {signingError ? (
+          <Alert variant="destructive">
+            <HugeiconsIcon icon={AlertCircleIcon} size={16} />
+            <AlertDescription>
+              Pipeline creation completed, but {retrySigning} signing failed:{' '}
+              {signingError}. Fix the signing fields below and retry only
+              signing.
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
         {values.ios_signing_enabled &&
           (values.ios_signing_mode === 'api' ||
             values.ios_signing_mode === 'hybrid') &&
@@ -1591,7 +1611,8 @@ export default function PipelineForm({
             </Button>
             <Button
               type="button"
-              disabled={isPending}
+              disabled={isPending || readOnly}
+              title={readOnly ? readOnlyReason : undefined}
               onClick={() => {
                 void form.handleSubmit(handleFormSubmit)()
               }}
@@ -1601,6 +1622,8 @@ export default function PipelineForm({
                   <Spinner className="size-4" />
                   Saving...
                 </>
+              ) : readOnly ? (
+                'Demo is read-only'
               ) : (
                 submitLabel
               )}

--- a/apps/web/src/components/terminal-log-viewer.tsx
+++ b/apps/web/src/components/terminal-log-viewer.tsx
@@ -28,6 +28,8 @@ export interface TerminalLogViewerProps {
   stepResults: Array<StepResult>
   isStreaming: boolean
   streamError?: string
+  logsUnavailable?: boolean
+  isTerminal?: boolean
 }
 
 interface StepGroup {
@@ -143,6 +145,8 @@ export default function TerminalLogViewer({
   stepResults,
   isStreaming,
   streamError,
+  logsUnavailable = false,
+  isTerminal = false,
 }: TerminalLogViewerProps) {
   const [userSelectedStep, setUserSelectedStep] = useState<string | null>(null)
   const [autoScroll, setAutoScroll] = useState(true)
@@ -222,7 +226,12 @@ export default function TerminalLogViewer({
         userSelectedStep === 'all' || stepGroupsByName.has(userSelectedStep)
       if (valid) return userSelectedStep
     }
-    return runningStepName ?? stepGroups.at(0)?.name ?? 'all'
+    return (
+      runningStepName ??
+      stepGroups.find((group) => group.status === 'failed')?.name ??
+      stepGroups.at(0)?.name ??
+      'all'
+    )
   }, [userSelectedStep, stepGroups, stepGroupsByName, runningStepName])
 
   // ── Filtered logs ──────────────────────────────────────────
@@ -556,7 +565,13 @@ export default function TerminalLogViewer({
           {filteredLogs.length === 0 ? (
             <div className="flex h-48 items-center justify-center">
               <span className="text-xs text-[oklch(0.52_0_0)]">
-                {searchQuery ? 'No matching lines' : 'No logs yet'}
+                {searchQuery
+                  ? 'No matching lines'
+                  : logsUnavailable
+                    ? 'Logs are unavailable for this build.'
+                    : isTerminal
+                      ? 'This build completed without recorded logs.'
+                      : 'No logs yet'}
               </span>
             </div>
           ) : (

--- a/apps/web/src/components/trigger-build-dialog.tsx
+++ b/apps/web/src/components/trigger-build-dialog.tsx
@@ -36,6 +36,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Spinner } from '@/components/ui/spinner'
+import { READ_ONLY_REASON, isDemoMode } from '@/lib/demo-mode'
 
 const triggerBuildSchema = z
   .object({
@@ -220,7 +221,9 @@ export default function TriggerBuildDialog({
     pipelines.length === 0
 
   return (
-    <Dialog open={open} onOpenChange={(nextOpen) => {
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
         if (nextOpen) {
           form.reset(
             defaults(
@@ -233,7 +236,8 @@ export default function TriggerBuildDialog({
           )
         }
         onOpenChange(nextOpen)
-      }}>
+      }}
+    >
       <DialogContent>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
@@ -411,6 +415,7 @@ export default function TriggerBuildDialog({
                 type="button"
                 disabled={
                   createBuildMutation.isPending ||
+                  isDemoMode ||
                   noProjects ||
                   noPipelines ||
                   sourceMissing ||
@@ -419,6 +424,7 @@ export default function TriggerBuildDialog({
                 onClick={() => {
                   void form.handleSubmit(onSubmit)()
                 }}
+                title={isDemoMode ? READ_ONLY_REASON : undefined}
               >
                 {createBuildMutation.isPending ? (
                   <>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -107,6 +107,7 @@ import type {
   ValidatePipelineRequest,
   ValidatePipelineResponse,
 } from '@/lib/types'
+import { READ_ONLY_REASON, isDemoMutationBlocked } from '@/lib/demo-mode'
 
 // ── Error class ─────────────────────────────────────────────────
 
@@ -132,6 +133,12 @@ async function request<T>(
   options: RequestInit = {},
 ): Promise<T> {
   const method = (options.method ?? 'GET').toUpperCase()
+  if (isDemoMutationBlocked(method, path)) {
+    throw new ApiClientError(403, {
+      error: READ_ONLY_REASON,
+      code: 'demo_read_only',
+    })
+  }
   // Only set Content-Type on requests with a body. GET/HEAD without it
   // avoids triggering CORS preflight (important for tunneled backends).
   const headers: Record<string, string> = {
@@ -1067,6 +1074,12 @@ export async function deleteProject(
   token: string,
   projectId: string,
 ): Promise<void> {
+  if (isDemoMutationBlocked('DELETE', `/v1/projects/${projectId}`)) {
+    throw new ApiClientError(403, {
+      error: READ_ONLY_REASON,
+      code: 'demo_read_only',
+    })
+  }
   const res = await fetch(`${baseUrl}/v1/projects/${projectId}`, {
     method: 'DELETE',
     headers: {
@@ -1158,6 +1171,12 @@ export async function deletePipeline(
   token: string,
   pipelineId: string,
 ): Promise<void> {
+  if (isDemoMutationBlocked('DELETE', `/v1/pipelines/${pipelineId}`)) {
+    throw new ApiClientError(403, {
+      error: READ_ONLY_REASON,
+      code: 'demo_read_only',
+    })
+  }
   const res = await fetch(`${baseUrl}/v1/pipelines/${pipelineId}`, {
     method: 'DELETE',
     headers: {

--- a/apps/web/src/lib/demo-mode.ts
+++ b/apps/web/src/lib/demo-mode.ts
@@ -1,0 +1,18 @@
+const READ_ONLY_REASON = 'This demo uses sample data and is read-only.'
+
+export const isDemoMode = import.meta.env.VITE_DEMO_MODE === 'true'
+
+export function isDemoMutationAllowed(method: string, path: string): boolean {
+  if (method === 'GET' || method === 'HEAD') return true
+  return (
+    path.startsWith('/v1/auth/') ||
+    path.includes('/validate') ||
+    path.endsWith('/download-link')
+  )
+}
+
+export function isDemoMutationBlocked(method: string, path: string): boolean {
+  return isDemoMode && !isDemoMutationAllowed(method, path)
+}
+
+export { READ_ONLY_REASON }

--- a/apps/web/src/lib/pipeline-form-utils.test.ts
+++ b/apps/web/src/lib/pipeline-form-utils.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+
+import type { PipelineFormValues } from '@/lib/pipeline-schema'
+import {
+  defaultArtifactPatterns,
+  previewPlatformCommands,
+} from '@/lib/pipeline-form-utils'
+
+const defaults: PipelineFormValues = {
+  name: 'Debug APK',
+  config_mode: 'auto',
+  config_path: '.oore.yaml',
+  platform_android: true,
+  platform_ios: false,
+  platform_macos: false,
+  android_signing_release_enabled: false,
+  android_signing_release_store_password: '',
+  android_signing_release_key_alias: '',
+  android_signing_release_key_password: '',
+  android_signing_debug_enabled: false,
+  android_signing_debug_store_password: '',
+  android_signing_debug_key_alias: '',
+  android_signing_debug_key_password: '',
+  ios_signing_enabled: false,
+  ios_signing_mode: 'manual',
+  ios_signing_team_id: '',
+  ios_signing_bundle_ids: '',
+  ios_signing_p12_password: '',
+  ios_signing_api_key_id: '',
+  ios_signing_api_issuer_id: '',
+  flutter_version: '',
+  enable_customization: true,
+  pre_build_commands: '',
+  build_commands: '',
+  post_build_commands: '',
+  android_build_args: '',
+  ios_build_args: '',
+  macos_build_args: '',
+  android_command_override: 'flutter build apk --debug',
+  ios_command_override: '',
+  macos_command_override: '',
+  env_vars: '',
+  artifact_patterns: '',
+  branches: '',
+  max_concurrent: undefined,
+}
+
+describe('pipeline form defaults', () => {
+  it('uses Flutter output paths for default artifacts', () => {
+    expect(defaultArtifactPatterns(['android', 'ios', 'macos'])).toEqual([
+      'build/app/outputs/flutter-apk/*.apk',
+      'build/ios/ipa/*.ipa',
+      'build/macos/Build/Products/Release/*.app',
+    ])
+  })
+
+  it('keeps the Quick Debug APK command in the pipeline payload preview', () => {
+    expect(previewPlatformCommands(defaults)).toEqual([
+      'flutter build apk --debug',
+    ])
+  })
+})

--- a/apps/web/src/lib/pipeline-form-utils.ts
+++ b/apps/web/src/lib/pipeline-form-utils.ts
@@ -93,10 +93,12 @@ export function defaultArtifactPatterns(
   platforms: Array<BuildPlatform>,
 ): Array<string> {
   const patterns = new Set<string>()
-  if (platforms.includes('android')) patterns.add('*.apk')
-  if (platforms.includes('ios')) patterns.add('*.ipa')
-  if (platforms.includes('macos')) patterns.add('*.app')
-  if (patterns.size === 0) patterns.add('*.apk')
+  if (platforms.includes('android'))
+    patterns.add('build/app/outputs/flutter-apk/*.apk')
+  if (platforms.includes('ios')) patterns.add('build/ios/ipa/*.ipa')
+  if (platforms.includes('macos'))
+    patterns.add('build/macos/Build/Products/Release/*.app')
+  if (patterns.size === 0) patterns.add('build/app/outputs/flutter-apk/*.apk')
   return [...patterns]
 }
 

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -410,6 +410,8 @@ export interface Build {
   source_build_id?: string
   config_snapshot: Record<string, unknown>
   runner_id?: string
+  /** Optional display context supplied by newer backend responses. */
+  context?: BuildContext
   step_results?: Array<StepResult>
   exit_code?: number
   queued_at: number
@@ -417,6 +419,12 @@ export interface Build {
   finished_at?: number
   created_at: number
   updated_at: number
+}
+
+export interface BuildContext {
+  project_name?: string
+  pipeline_name?: string
+  runner_name?: string
 }
 
 export interface BuildEvent {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -14,6 +14,7 @@ import {
   AlertCircleIcon,
   ArrowLeft02Icon,
   Home01Icon,
+  InformationCircleIcon,
   RotateClockwiseIcon,
   Search01Icon,
 } from '@hugeicons/core-free-icons'
@@ -37,6 +38,8 @@ import { queryClient } from '@/lib/query-client'
 import { useAuthStore } from '@/stores/auth-store'
 import { useInstanceStore } from '@/stores/instance-store'
 import { useSetupStore } from '@/stores/setup-store'
+import { READ_ONLY_REASON, isDemoMode } from '@/lib/demo-mode'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 
 const CommandPalette = lazy(() => import('@/components/command-palette'))
 
@@ -237,6 +240,15 @@ function RootLayout() {
                   </button>
                 </div>
               </header>
+              {isDemoMode ? (
+                <div className="border-b bg-background px-4 py-2">
+                  <Alert>
+                    <HugeiconsIcon icon={InformationCircleIcon} size={16} />
+                    <AlertTitle>Sample demo</AlertTitle>
+                    <AlertDescription>{READ_ONLY_REASON}</AlertDescription>
+                  </Alert>
+                </div>
+              ) : null}
               <ConnectivityBanner />
               <div className="flex flex-1 flex-col bg-surface">
                 <Outlet />
@@ -257,7 +269,7 @@ function RootLayout() {
             <CommandPalette />
           </Suspense>
         ) : null}
-        {import.meta.env.VITE_DEMO_MODE === 'true' && (
+        {isDemoMode && (
           <div className="fixed bottom-4 right-4 z-50 flex items-center gap-2 border bg-background px-3 py-1.5 text-xs text-muted-foreground shadow-md">
             <span className="size-1.5 animate-pulse bg-primary" />
             Demo Mode

--- a/apps/web/src/routes/builds/$buildId.tsx
+++ b/apps/web/src/routes/builds/$buildId.tsx
@@ -14,7 +14,11 @@ import {
 } from '@hugeicons/core-free-icons'
 import { toast } from 'sonner'
 
-import type { Artifact, BuildLogChunk, CreateScopedDownloadTokenResponse } from '@/lib/types'
+import type {
+  Artifact,
+  BuildLogChunk,
+  CreateScopedDownloadTokenResponse,
+} from '@/lib/types'
 import {
   getActiveInstanceOrRedirect,
   requireAuthOrRedirect,
@@ -66,6 +70,7 @@ import {
   relativeTime,
 } from '@/lib/format-utils'
 import { PageMeta } from '@/lib/seo'
+import { READ_ONLY_REASON, isDemoMode } from '@/lib/demo-mode'
 
 export const Route = createFileRoute('/builds/$buildId')({
   staticData: { breadcrumbLabel: 'Details' },
@@ -120,7 +125,11 @@ function BuildDetailPage() {
     ? `Build #${data.build.build_number}`
     : 'Build Details'
 
-  useBreadcrumbLabel(setLabel, '/builds/$buildId', data?.build.build_number ? `Build #${data.build.build_number}` : undefined)
+  useBreadcrumbLabel(
+    setLabel,
+    '/builds/$buildId',
+    data?.build.build_number ? `Build #${data.build.build_number}` : undefined,
+  )
 
   // ── Build notifications (title + browser Notification) ──
   useBuildNotification(data?.build, isTerminal)
@@ -138,7 +147,8 @@ function BuildDetailPage() {
       void refetchArtifacts()
     }, [refetchBuild, refetchArtifacts]),
   })
-  const { data: fullLogsData } = useBuildLogs(buildId)
+  const fullLogsQuery = useBuildLogs(buildId)
+  const { data: fullLogsData } = fullLogsQuery
 
   const mergedLogs: Array<BuildLogChunk> = useMemo(() => {
     if (streamEnabled && streamLogs.length > 0) return streamLogs
@@ -194,6 +204,17 @@ function BuildDetailPage() {
   const duration = build.started_at
     ? (build.finished_at ?? Math.floor(Date.now() / 1000)) - build.started_at
     : null
+  const failureReason =
+    build.status === 'failed'
+      ? ([...events].reverse().find((event) => event.reason)?.reason ??
+        `Build failed${build.exit_code != null ? ` with exit code ${build.exit_code}` : ''}.`)
+      : build.status === 'timed_out'
+        ? ([...events].reverse().find((event) => event.reason)?.reason ??
+          'Build timed out.')
+        : build.status === 'canceled'
+          ? ([...events].reverse().find((event) => event.reason)?.reason ??
+            'Build was canceled.')
+          : undefined
 
   return (
     <PageLayout width="full">
@@ -255,7 +276,9 @@ function BuildDetailPage() {
                 onClick={() => {
                   rerunMutation.mutate(build.id, {
                     onSuccess: (result) => {
-                      toast.success(`Re-run queued as build #${result.build.build_number}`)
+                      toast.success(
+                        `Re-run queued as build #${result.build.build_number}`,
+                      )
                       void navigate({
                         to: '/builds/$buildId',
                         params: { buildId: result.build.id },
@@ -266,7 +289,8 @@ function BuildDetailPage() {
                     },
                   })
                 }}
-                disabled={rerunMutation.isPending}
+                disabled={rerunMutation.isPending || isDemoMode}
+                title={isDemoMode ? READ_ONLY_REASON : undefined}
               >
                 <HugeiconsIcon icon={Refresh01Icon} size={14} />
                 {rerunMutation.isPending ? 'Re-running...' : 'Re-run'}
@@ -277,7 +301,8 @@ function BuildDetailPage() {
                 variant="destructive"
                 size="sm"
                 onClick={handleCancel}
-                disabled={cancelMutation.isPending}
+                disabled={cancelMutation.isPending || isDemoMode}
+                title={isDemoMode ? READ_ONLY_REASON : undefined}
               >
                 {cancelMutation.isPending ? 'Canceling...' : 'Cancel Build'}
               </Button>
@@ -285,6 +310,29 @@ function BuildDetailPage() {
           </div>
         }
       />
+
+      {failureReason ? (
+        <Alert variant="destructive">
+          <HugeiconsIcon icon={InformationCircleIcon} size={16} />
+          <AlertDescription>{failureReason}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      {build.context?.project_name ||
+      build.context?.pipeline_name ||
+      build.context?.runner_name ? (
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          {build.context.project_name ? (
+            <span>Project: {build.context.project_name}</span>
+          ) : null}
+          {build.context.pipeline_name ? (
+            <span>Pipeline: {build.context.pipeline_name}</span>
+          ) : null}
+          {build.context.runner_name ? (
+            <span>Runner: {build.context.runner_name}</span>
+          ) : null}
+        </div>
+      ) : null}
 
       {/* Two-column layout: logs + sidebar */}
       <div className="grid gap-6 xl:grid-cols-[1fr_340px]">
@@ -294,7 +342,9 @@ function BuildDetailPage() {
             logs={mergedLogs}
             stepResults={build.step_results ?? []}
             isStreaming={isStreaming}
-            streamError={streamError ?? undefined}
+            streamError={isTerminal ? undefined : (streamError ?? undefined)}
+            logsUnavailable={fullLogsQuery.isError}
+            isTerminal={isTerminal}
           />
         </div>
 
@@ -309,7 +359,6 @@ function BuildDetailPage() {
           <EventTimeline events={events} />
         </aside>
       </div>
-
     </PageLayout>
   )
 }
@@ -324,6 +373,22 @@ function artifactExpiryLabel(artifact: Artifact): string | null {
   const now = Math.floor(Date.now() / 1000)
   if (artifact.expires_at <= now) return 'Expired'
   return `Expires ${relativeTime(artifact.expires_at)}`
+}
+
+function artifactEmptyMessage(buildStatus: string): string {
+  switch (buildStatus) {
+    case 'succeeded':
+      return 'Build succeeded, but no files matched the pipeline artifact patterns.'
+    case 'failed':
+    case 'timed_out':
+      return 'This build ended before it could publish artifacts.'
+    case 'canceled':
+      return 'This build was canceled before artifacts were published.'
+    case 'expired':
+      return 'Artifacts are no longer available for this expired build.'
+    default:
+      return 'Artifacts will appear here once the build produces them.'
+  }
 }
 
 const TTL_OPTIONS = [
@@ -348,7 +413,8 @@ function ArtifactsPanel({
   const [shareArtifact, setShareArtifact] = useState<Artifact | null>(null)
   const [ttlSecs, setTtlSecs] = useState('86400')
   const [singleUse, setSingleUse] = useState(false)
-  const [createdToken, setCreatedToken] = useState<CreateScopedDownloadTokenResponse | null>(null)
+  const [createdToken, setCreatedToken] =
+    useState<CreateScopedDownloadTokenResponse | null>(null)
 
   function handleDownload(artifactId: string, name: string) {
     downloadMutation.mutate(artifactId, {
@@ -433,9 +499,7 @@ function ArtifactsPanel({
             </div>
           ) : !artifacts.length ? (
             <p className="text-xs text-muted-foreground">
-              {buildStatus === 'succeeded' || buildStatus === 'failed'
-                ? 'No artifacts were produced. Check that your pipeline has artifact patterns configured.'
-                : 'Artifacts will appear here once the build produces them.'}
+              {artifactEmptyMessage(buildStatus)}
             </p>
           ) : (
             <div className="space-y-2">
@@ -454,7 +518,9 @@ function ArtifactsPanel({
                       </p>
                       <div className="mt-0.5 flex items-center gap-1.5">
                         <Badge
-                          variant={artifactTypeBadgeVariant(artifact.artifact_type)}
+                          variant={artifactTypeBadgeVariant(
+                            artifact.artifact_type,
+                          )}
                           className="text-[10px]"
                         >
                           {artifact.artifact_type}
@@ -465,7 +531,9 @@ function ArtifactsPanel({
                             : '—'}
                         </span>
                         {expiryLabel ? (
-                          <span className={`text-[10px] ${expired ? 'text-destructive' : 'text-muted-foreground'}`}>
+                          <span
+                            className={`text-[10px] ${expired ? 'text-destructive' : 'text-muted-foreground'}`}
+                          >
                             {expiryLabel}
                           </span>
                         ) : null}
@@ -489,7 +557,9 @@ function ArtifactsPanel({
                         className="size-7 shrink-0"
                         title="Copy download link"
                         aria-label={`Copy link for ${artifact.name}`}
-                        onClick={() => handleCopyLink(artifact.id, artifact.name)}
+                        onClick={() =>
+                          handleCopyLink(artifact.id, artifact.name)
+                        }
                         disabled={downloadMutation.isPending || expired}
                       >
                         <HugeiconsIcon icon={Copy01Icon} size={14} />
@@ -500,7 +570,9 @@ function ArtifactsPanel({
                         className="size-7 shrink-0"
                         title="Download"
                         aria-label={`Download ${artifact.name}`}
-                        onClick={() => handleDownload(artifact.id, artifact.name)}
+                        onClick={() =>
+                          handleDownload(artifact.id, artifact.name)
+                        }
                         disabled={downloadMutation.isPending || expired}
                       >
                         <HugeiconsIcon icon={Download04Icon} size={14} />
@@ -515,7 +587,12 @@ function ArtifactsPanel({
       </Card>
 
       {/* Share Link Dialog */}
-      <Dialog open={shareArtifact !== null} onOpenChange={(open) => { if (!open) setShareArtifact(null) }}>
+      <Dialog
+        open={shareArtifact !== null}
+        onOpenChange={(open) => {
+          if (!open) setShareArtifact(null)
+        }}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>
@@ -538,15 +615,24 @@ function ArtifactsPanel({
               <div className="flex items-center gap-2 text-xs text-muted-foreground">
                 <span>Expires {relativeTime(createdToken.expires_at)}</span>
                 {createdToken.single_use ? (
-                  <Badge variant="secondary" className="text-[10px]">Single use</Badge>
+                  <Badge variant="secondary" className="text-[10px]">
+                    Single use
+                  </Badge>
                 ) : null}
               </div>
               <DialogFooter>
-                <Button variant="secondary" onClick={() => setShareArtifact(null)}>
+                <Button
+                  variant="secondary"
+                  onClick={() => setShareArtifact(null)}
+                >
                   Close
                 </Button>
                 <Button onClick={handleCopyShareUrl}>
-                  <HugeiconsIcon icon={Copy01Icon} size={14} className="mr-1.5" />
+                  <HugeiconsIcon
+                    icon={Copy01Icon}
+                    size={14}
+                    className="mr-1.5"
+                  />
                   Copy Link
                 </Button>
               </DialogFooter>
@@ -555,7 +641,12 @@ function ArtifactsPanel({
             <div className="space-y-4">
               <div className="space-y-2">
                 <Label htmlFor="ttl-select">Expires after</Label>
-                <Select value={ttlSecs} onValueChange={(v) => { if (v != null) setTtlSecs(v) }}>
+                <Select
+                  value={ttlSecs}
+                  onValueChange={(v) => {
+                    if (v != null) setTtlSecs(v)
+                  }}
+                >
                   <SelectTrigger id="ttl-select">
                     <SelectValue />
                   </SelectTrigger>
@@ -579,10 +670,16 @@ function ArtifactsPanel({
                 </Label>
               </div>
               <DialogFooter>
-                <Button variant="secondary" onClick={() => setShareArtifact(null)}>
+                <Button
+                  variant="secondary"
+                  onClick={() => setShareArtifact(null)}
+                >
                   Cancel
                 </Button>
-                <Button onClick={handleCreateToken} disabled={createTokenMutation.isPending}>
+                <Button
+                  onClick={handleCreateToken}
+                  disabled={createTokenMutation.isPending}
+                >
                   {createTokenMutation.isPending ? (
                     <>
                       <Spinner className="mr-1.5" />

--- a/apps/web/src/routes/builds/index.tsx
+++ b/apps/web/src/routes/builds/index.tsx
@@ -51,6 +51,7 @@ import {
 import { relativeTime } from '@/lib/format-utils'
 import { PageMeta } from '@/lib/seo'
 import TriggerBuildDialog from '@/components/trigger-build-dialog'
+import { READ_ONLY_REASON, isDemoMode } from '@/lib/demo-mode'
 
 const PAGE_SIZE = 20
 
@@ -123,7 +124,11 @@ function BuildsListPage() {
         description="Queue, execution, and historical run inventory across projects."
         actions={
           !missingProjects && canTriggerBuild ? (
-            <Button onClick={() => setTriggerBuildOpen(true)}>
+            <Button
+              onClick={() => setTriggerBuildOpen(true)}
+              disabled={isDemoMode}
+              title={isDemoMode ? READ_ONLY_REASON : undefined}
+            >
               <HugeiconsIcon icon={PlayIcon} size={16} />
               Run Build
             </Button>
@@ -284,7 +289,12 @@ function BuildsListPage() {
                     No builds yet.
                   </p>
                   {canTriggerBuild ? (
-                    <Button size="sm" onClick={() => setTriggerBuildOpen(true)}>
+                    <Button
+                      size="sm"
+                      onClick={() => setTriggerBuildOpen(true)}
+                      disabled={isDemoMode}
+                      title={isDemoMode ? READ_ONLY_REASON : undefined}
+                    >
                       <HugeiconsIcon icon={PlayIcon} size={14} />
                       Trigger first build
                     </Button>
@@ -295,6 +305,7 @@ function BuildsListPage() {
                   <TableHeader>
                     <TableRow>
                       <TableHead>Build</TableHead>
+                      <TableHead>Project</TableHead>
                       <TableHead>Status</TableHead>
                       <TableHead>Trigger</TableHead>
                       <TableHead>Branch</TableHead>
@@ -334,6 +345,20 @@ function BuildsListPage() {
                               {build.id.slice(0, 8)}
                             </p>
                           </div>
+                        </TableCell>
+                        <TableCell>
+                          <p className="text-sm">
+                            {build.context?.project_name ??
+                              projects.find(
+                                (project) => project.id === build.project_id,
+                              )?.name ??
+                              'Unknown project'}
+                          </p>
+                          {build.context?.pipeline_name ? (
+                            <p className="text-xs text-muted-foreground">
+                              {build.context.pipeline_name}
+                            </p>
+                          ) : null}
                         </TableCell>
                         <TableCell>
                           <Badge variant={getStatusVariant(build.status)}>

--- a/apps/web/src/routes/projects/$projectId/pipelines/$pipelineId.tsx
+++ b/apps/web/src/routes/projects/$projectId/pipelines/$pipelineId.tsx
@@ -151,7 +151,11 @@ function PipelineDetailPage() {
 
   const label = data?.pipeline.name ?? 'Pipeline Details'
 
-  useBreadcrumbLabel(setLabel, '/projects/$projectId/pipelines/$pipelineId', data?.pipeline.name)
+  useBreadcrumbLabel(
+    setLabel,
+    '/projects/$projectId/pipelines/$pipelineId',
+    data?.pipeline.name,
+  )
 
   if (isLoading) {
     return (
@@ -258,6 +262,7 @@ function PipelineDetailPage() {
                     <Link
                       to="/projects/$projectId/pipelines/$pipelineId/edit"
                       params={{ projectId, pipelineId }}
+                      search={{}}
                     />
                   }
                   nativeButton={false}

--- a/apps/web/src/routes/projects/$projectId/pipelines/$pipelineId_.edit.tsx
+++ b/apps/web/src/routes/projects/$projectId/pipelines/$pipelineId_.edit.tsx
@@ -62,6 +62,19 @@ export const Route = createFileRoute(
   '/projects/$projectId/pipelines/$pipelineId_/edit',
 )({
   staticData: { breadcrumbLabel: 'Edit Pipeline' },
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): {
+    signing?: 'android' | 'ios'
+    signingError?: string
+  } => ({
+    signing:
+      search.signing === 'android' || search.signing === 'ios'
+        ? search.signing
+        : undefined,
+    signingError:
+      typeof search.signingError === 'string' ? search.signingError : undefined,
+  }),
   beforeLoad: () => {
     const instance = getActiveInstanceOrRedirect()
     requireAuthOrRedirect(instance.id)
@@ -71,6 +84,7 @@ export const Route = createFileRoute(
 
 function EditPipelinePage() {
   const { projectId, pipelineId } = Route.useParams()
+  const { signing: retrySigning, signingError } = Route.useSearch()
   const navigate = useNavigate()
   const { data: projectData } = useProject(projectId)
   const repoProviderQuery = useRepositoryProvider(
@@ -287,30 +301,34 @@ function EditPipelinePage() {
     }
 
     try {
-      await updateMutation.mutateAsync({
-        pipelineId: pipeline.id,
-        data: payload,
-      })
-      if (signingPayload) {
+      if (!retrySigning) {
+        await updateMutation.mutateAsync({
+          pipelineId: pipeline.id,
+          data: payload,
+        })
+      }
+      if (signingPayload && retrySigning !== 'ios') {
         await updateSigningMutation.mutateAsync({
           pipelineId: pipeline.id,
           data: signingPayload,
         })
       }
-      if (iosSigningPayload) {
+      if (iosSigningPayload && retrySigning !== 'android') {
         await updateIosSigningMutation.mutateAsync({
           pipelineId: pipeline.id,
           data: iosSigningPayload,
         })
       }
-      toast.success('Pipeline updated')
+      toast.success(retrySigning ? 'Signing updated' : 'Pipeline updated')
       void navigate({
         to: '/projects/$projectId/pipelines/$pipelineId',
         params: { projectId, pipelineId },
       })
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error'
-      toast.error(`Failed to update pipeline: ${message}`)
+      toast.error(
+        `Failed to ${retrySigning ? 'update signing' : 'update pipeline'}: ${message}`,
+      )
     }
   }
 
@@ -611,7 +629,11 @@ function EditPipelinePage() {
           to: `/projects/${projectId}/pipelines/${pipelineId}`,
           label: 'Pipeline',
         }}
-        description="Update pipeline configuration."
+        description={
+          retrySigning
+            ? `Fix and retry ${retrySigning} signing without creating the pipeline again.`
+            : 'Update pipeline configuration.'
+        }
       />
       <div className="mx-auto max-w-4xl">
         <PipelineForm
@@ -628,13 +650,15 @@ function EditPipelinePage() {
               params: { projectId, pipelineId },
             })
           }
-          submitLabel="Save"
+          submitLabel={retrySigning ? `Retry ${retrySigning} signing` : 'Save'}
           isPending={
             updateMutation.isPending ||
             updateSigningMutation.isPending ||
             updateIosSigningMutation.isPending
           }
           validationErrors={validationErrors}
+          retrySigning={retrySigning}
+          signingError={signingError}
           signingData={signingQuery.data}
           iosSigningData={iosSigningQuery.data}
         >

--- a/apps/web/src/routes/projects/$projectId/pipelines/new.tsx
+++ b/apps/web/src/routes/projects/$projectId/pipelines/new.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { toast } from 'sonner'
 
@@ -38,6 +38,7 @@ import PageHeader from '@/components/page-header'
 import PipelineForm from '@/components/pipeline-form'
 import { PageMeta } from '@/lib/seo'
 import { cn } from '@/lib/utils'
+import { READ_ONLY_REASON, isDemoMode } from '@/lib/demo-mode'
 
 export const Route = createFileRoute('/projects/$projectId/pipelines/new')({
   staticData: { breadcrumbLabel: 'New Pipeline' },
@@ -82,7 +83,7 @@ const emptyDefaults: PipelineFormValues = {
   ios_command_override: '',
   macos_command_override: '',
   env_vars: '',
-  artifact_patterns: '*.apk',
+  artifact_patterns: 'build/app/outputs/flutter-apk/*.apk',
   branches: '',
   max_concurrent: undefined,
 }
@@ -98,7 +99,9 @@ const PIPELINE_TEMPLATES = [
       platform_android: true,
       platform_ios: false,
       platform_macos: false,
-      artifact_patterns: '*.apk',
+      enable_customization: true,
+      android_command_override: 'flutter build apk --debug',
+      artifact_patterns: 'build/app/outputs/flutter-apk/app-debug.apk',
     } satisfies PipelineFormValues,
     events: ['push'],
   },
@@ -113,7 +116,8 @@ const PIPELINE_TEMPLATES = [
       platform_ios: false,
       platform_macos: false,
       android_signing_release_enabled: true,
-      artifact_patterns: '*.apk\n*.aab',
+      artifact_patterns:
+        'build/app/outputs/flutter-apk/*.apk\nbuild/app/outputs/bundle/release/*.aab',
     } satisfies PipelineFormValues,
     events: ['push', 'tag_push'],
   },
@@ -127,7 +131,8 @@ const PIPELINE_TEMPLATES = [
       platform_android: true,
       platform_ios: true,
       platform_macos: false,
-      artifact_patterns: '*.apk\n*.aab\n*.ipa',
+      artifact_patterns:
+        'build/app/outputs/flutter-apk/*.apk\nbuild/app/outputs/bundle/release/*.aab\nbuild/ios/ipa/*.ipa',
     } satisfies PipelineFormValues,
     events: ['push', 'tag_push'],
   },
@@ -141,7 +146,8 @@ const PIPELINE_TEMPLATES = [
       platform_android: true,
       platform_ios: true,
       platform_macos: true,
-      artifact_patterns: '*.apk\n*.aab\n*.ipa\n*.app',
+      artifact_patterns:
+        'build/app/outputs/flutter-apk/*.apk\nbuild/app/outputs/bundle/release/*.aab\nbuild/ios/ipa/*.ipa\nbuild/macos/Build/Products/Release/*.app',
     } satisfies PipelineFormValues,
     events: ['push', 'tag_push'],
   },
@@ -167,6 +173,7 @@ function NewPipelinePage() {
   const updateSigningMutation = useUpdatePipelineAndroidSigning()
   const updateIosSigningMutation = useUpdatePipelineIosSigning()
   const [validationErrors, setValidationErrors] = useState<Array<string>>([])
+  const createdPipelineId = useRef<string | null>(null)
   const [selectedTemplate, setSelectedTemplate] = useState<string>('custom')
   const activeTemplate =
     PIPELINE_TEMPLATES.find((t) => t.key === selectedTemplate) ??
@@ -184,6 +191,7 @@ function NewPipelinePage() {
       profileFiles: Record<string, File | null>
     },
   ) {
+    if (createdPipelineId.current) return
     const platforms = selectedPlatforms(data)
     if (platforms.length === 0) {
       setValidationErrors(['Pick at least one platform to build'])
@@ -283,11 +291,20 @@ function NewPipelinePage() {
       return
     }
 
+    let created: { pipeline: { id: string } }
     try {
-      const created = await createMutation.mutateAsync({
+      created = await createMutation.mutateAsync({
         projectId,
         data: payload,
       })
+      createdPipelineId.current = created.pipeline.id
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      toast.error(`Failed to create pipeline: ${message}`)
+      return
+    }
+
+    try {
       if (signingPayload) {
         await updateSigningMutation.mutateAsync({
           pipelineId: created.pipeline.id,
@@ -304,7 +321,15 @@ function NewPipelinePage() {
       void navigate({ to: '/projects/$projectId', params: { projectId } })
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error'
-      toast.error(`Failed to create pipeline: ${message}`)
+      const signing = signingPayload ? 'android' : 'ios'
+      toast.error(
+        `Pipeline was created, but ${signing} signing failed: ${message}`,
+      )
+      void navigate({
+        to: '/projects/$projectId/pipelines/$pipelineId/edit',
+        params: { projectId, pipelineId: created.pipeline.id },
+        search: { signing, signingError: message },
+      })
     }
   }
 
@@ -580,6 +605,8 @@ function NewPipelinePage() {
             updateIosSigningMutation.isPending
           }
           validationErrors={validationErrors}
+          readOnly={isDemoMode}
+          readOnlyReason={READ_ONLY_REASON}
         />
       </div>
     </PageLayout>

--- a/apps/web/src/routes/projects/index.tsx
+++ b/apps/web/src/routes/projects/index.tsx
@@ -37,6 +37,7 @@ import {
 } from '@/components/ui/table'
 import { relativeTime } from '@/lib/format-utils'
 import { PageMeta } from '@/lib/seo'
+import { READ_ONLY_REASON, isDemoMode } from '@/lib/demo-mode'
 
 export const Route = createFileRoute('/projects/')({
   staticData: { breadcrumbLabel: 'Projects' },
@@ -108,7 +109,11 @@ function ProjectsListPage() {
         description="Repository and pipeline entry points for your build system."
         actions={
           projects.length > 0 && canWriteProjects ? (
-            <Button onClick={() => setCreateOpen(true)}>
+            <Button
+              onClick={() => setCreateOpen(true)}
+              disabled={isDemoMode}
+              title={isDemoMode ? READ_ONLY_REASON : undefined}
+            >
               <HugeiconsIcon icon={Add01Icon} size={16} />
               New Project
             </Button>
@@ -152,7 +157,11 @@ function ProjectsListPage() {
             </p>
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
               {canWriteProjects ? (
-                <Button onClick={() => setCreateOpen(true)}>
+                <Button
+                  onClick={() => setCreateOpen(true)}
+                  disabled={isDemoMode}
+                  title={isDemoMode ? READ_ONLY_REASON : undefined}
+                >
                   <HugeiconsIcon icon={Add01Icon} size={16} />
                   Create Project
                 </Button>

--- a/crates/oore-contract/Cargo.toml
+++ b/crates/oore-contract/Cargo.toml
@@ -7,4 +7,5 @@ license.workspace = true
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
+serde_yaml.workspace = true
 utoipa.workspace = true

--- a/crates/oore-contract/src/lib.rs
+++ b/crates/oore-contract/src/lib.rs
@@ -1099,6 +1099,13 @@ pub struct RunnerHeartbeatRequest {
     pub capabilities: serde_json::Value,
 }
 
+pub const RUNNER_PROTOCOL_VERSION: u32 = 2;
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ClaimJobRequest {
+    pub protocol_version: u32,
+}
+
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct UpdateRunnerRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1177,6 +1184,7 @@ pub struct Artifact {
     #[schema(value_type = Object)]
     pub metadata: serde_json::Value,
     pub created_at: i64,
+    pub state: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<i64>,
 }
@@ -1198,6 +1206,17 @@ pub struct CreateArtifactRequest {
 pub struct CreateArtifactResponse {
     pub artifact: Artifact,
     pub upload_url: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct CompleteArtifactRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct CompleteArtifactResponse {
+    pub artifact: Artifact,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -1723,6 +1742,7 @@ pub enum BuildPlatform {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]
+#[serde(deny_unknown_fields)]
 pub struct PipelineCommandStages {
     #[serde(default)]
     pub pre_build: Vec<String>,
@@ -1733,6 +1753,7 @@ pub struct PipelineCommandStages {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]
+#[serde(deny_unknown_fields)]
 pub struct PlatformBuildArgs {
     #[serde(default)]
     pub android: Vec<String>,
@@ -1743,6 +1764,7 @@ pub struct PlatformBuildArgs {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]
+#[serde(deny_unknown_fields)]
 pub struct PlatformBuildCommands {
     #[serde(default)]
     pub android: Option<String>,
@@ -1753,6 +1775,7 @@ pub struct PlatformBuildCommands {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
 pub struct PipelineEnvVar {
     pub key: String,
     pub value: String,
@@ -1781,7 +1804,198 @@ fn default_platforms() -> Vec<BuildPlatform> {
 }
 
 fn default_artifact_patterns() -> Vec<String> {
-    vec!["*.apk".to_string()]
+    vec!["build/app/outputs/flutter-apk/*.apk".to_string()]
+}
+
+pub fn default_artifact_patterns_for_platforms(platforms: &[BuildPlatform]) -> Vec<String> {
+    let mut patterns = Vec::new();
+    if platforms.contains(&BuildPlatform::Android) {
+        patterns.extend([
+            "build/app/outputs/flutter-apk/*.apk".to_string(),
+            "build/app/outputs/bundle/**/*.aab".to_string(),
+        ]);
+    }
+    if platforms.contains(&BuildPlatform::Ios) {
+        patterns.push("build/ios/ipa/*.ipa".to_string());
+    }
+    if platforms.contains(&BuildPlatform::Macos) {
+        patterns.push("build/macos/Build/Products/Release/*.app".to_string());
+    }
+    patterns
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RepositoryPipelineConfig {
+    version: u32,
+    platforms: Vec<BuildPlatform>,
+    #[serde(default)]
+    flutter_version: Option<String>,
+    #[serde(default)]
+    commands: PipelineCommandStages,
+    #[serde(default)]
+    platform_build_args: PlatformBuildArgs,
+    #[serde(default)]
+    platform_commands: PlatformBuildCommands,
+    #[serde(default)]
+    env: Vec<PipelineEnvVar>,
+    #[serde(default)]
+    artifacts: Option<RepositoryArtifacts>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RepositoryArtifacts {
+    #[serde(default)]
+    patterns: Vec<String>,
+}
+
+pub fn parse_repository_pipeline_yaml(raw: &str) -> Result<PipelineExecutionConfig, String> {
+    let parsed: RepositoryPipelineConfig =
+        serde_yaml::from_str(raw).map_err(|error| format!("YAML parse error: {error}"))?;
+    if parsed.version != 1 {
+        return Err(format!(
+            "unsupported config version {}, expected 1",
+            parsed.version
+        ));
+    }
+
+    let artifact_patterns = parsed.artifacts.map_or_else(
+        || default_artifact_patterns_for_platforms(&parsed.platforms),
+        |artifacts| artifacts.patterns,
+    );
+    let config = PipelineExecutionConfig {
+        platforms: parsed.platforms,
+        flutter_version: parsed.flutter_version,
+        commands: parsed.commands,
+        platform_build_args: parsed.platform_build_args,
+        platform_commands: parsed.platform_commands,
+        env: parsed.env,
+        artifact_patterns,
+    };
+    let errors = validate_repository_execution_config(&config);
+    if errors.is_empty() {
+        Ok(config)
+    } else {
+        Err(errors.join("\n"))
+    }
+}
+
+pub fn validate_artifact_pattern(pattern: &str) -> Result<(), String> {
+    let pattern = pattern.trim();
+    if pattern.is_empty() {
+        return Err("must not be empty".to_string());
+    }
+    if pattern.len() > 512 {
+        return Err("is too long (max 512 chars)".to_string());
+    }
+    if !pattern.contains(['*', '?']) {
+        return Err("must contain '*' or '?'".to_string());
+    }
+    if pattern.contains('\\') || pattern.starts_with('/') {
+        return Err("must be a workspace-relative path using '/' separators".to_string());
+    }
+    if pattern
+        .split('/')
+        .any(|part| part.is_empty() || part == "." || part == "..")
+    {
+        return Err("must not contain empty, '.' or '..' path segments".to_string());
+    }
+    Ok(())
+}
+
+pub fn artifact_pattern_matches(pattern: &str, relative_path: &str) -> bool {
+    fn segment_matches(pattern: &[u8], value: &[u8]) -> bool {
+        let (mut p, mut v, mut star, mut retry) = (0, 0, None, 0);
+        while v < value.len() {
+            if p < pattern.len() && (pattern[p] == b'?' || pattern[p] == value[v]) {
+                p += 1;
+                v += 1;
+            } else if p < pattern.len() && pattern[p] == b'*' {
+                star = Some(p);
+                p += 1;
+                retry = v;
+            } else if let Some(star_pos) = star {
+                p = star_pos + 1;
+                retry += 1;
+                v = retry;
+            } else {
+                return false;
+            }
+        }
+        while p < pattern.len() && pattern[p] == b'*' {
+            p += 1;
+        }
+        p == pattern.len()
+    }
+
+    fn path_matches(pattern: &[&str], path: &[&str]) -> bool {
+        match pattern.split_first() {
+            None => path.is_empty(),
+            Some((&"**", rest)) => {
+                path_matches(rest, path) || (!path.is_empty() && path_matches(pattern, &path[1..]))
+            }
+            Some((segment, rest)) => {
+                !path.is_empty()
+                    && segment_matches(segment.as_bytes(), path[0].as_bytes())
+                    && path_matches(rest, &path[1..])
+            }
+        }
+    }
+
+    let pattern = pattern.trim();
+    if !pattern.contains('/') {
+        return relative_path
+            .rsplit('/')
+            .next()
+            .is_some_and(|name| segment_matches(pattern.as_bytes(), name.as_bytes()));
+    }
+    path_matches(
+        &pattern.split('/').collect::<Vec<_>>(),
+        &relative_path.split('/').collect::<Vec<_>>(),
+    )
+}
+
+fn validate_repository_execution_config(config: &PipelineExecutionConfig) -> Vec<String> {
+    fn valid_env_key(key: &str) -> bool {
+        let mut chars = key.chars();
+        chars
+            .next()
+            .is_some_and(|first| first == '_' || first.is_ascii_alphabetic())
+            && chars.all(|character| character == '_' || character.is_ascii_alphanumeric())
+    }
+    let mut errors = Vec::new();
+    if config.platforms.is_empty() {
+        errors.push("platforms must include at least one target".to_string());
+    }
+    for (stage, commands) in [
+        ("pre_build", &config.commands.pre_build),
+        ("build", &config.commands.build),
+        ("post_build", &config.commands.post_build),
+    ] {
+        for (index, command) in commands.iter().enumerate() {
+            if command.trim().is_empty() {
+                errors.push(format!("commands.{stage}[{index}] must not be empty"));
+            }
+        }
+    }
+    for (index, pattern) in config.artifact_patterns.iter().enumerate() {
+        if let Err(error) = validate_artifact_pattern(pattern) {
+            errors.push(format!("artifacts.patterns[{index}] {error}"));
+        }
+    }
+    let mut env_keys = std::collections::HashSet::new();
+    for (index, entry) in config.env.iter().enumerate() {
+        let key = entry.key.trim();
+        if !valid_env_key(key) {
+            errors.push(format!(
+                "env[{index}].key must match [A-Za-z_][A-Za-z0-9_]*"
+            ));
+        } else if !env_keys.insert(key) {
+            errors.push(format!("env contains duplicate key '{key}'"));
+        }
+    }
+    errors
 }
 
 impl Default for PipelineExecutionConfig {
@@ -1877,6 +2091,8 @@ pub struct ValidatePipelineRequest {
     pub trigger_config: Option<TriggerConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub concurrency: Option<ConcurrencyPolicy>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repository_yaml: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -2464,7 +2680,56 @@ mod tests {
         assert!(cfg.platform_build_args.android.is_empty());
         assert!(cfg.platform_commands.android.is_none());
         assert!(cfg.env.is_empty());
-        assert_eq!(cfg.artifact_patterns, vec!["*.apk".to_string()]);
+        assert_eq!(
+            cfg.artifact_patterns,
+            vec!["build/app/outputs/flutter-apk/*.apk".to_string()]
+        );
+    }
+
+    #[test]
+    fn repository_pipeline_yaml_and_artifact_globs_share_the_runtime_contract() {
+        let config = parse_repository_pipeline_yaml(
+            r#"
+version: 1
+platforms: [android, ios, macos]
+commands:
+  build: ["flutter test"]
+artifacts:
+  patterns:
+    - "*.apk"
+    - "build/ios/**/*.ipa"
+    - "build/macos/Build/Products/Release/*.app"
+"#,
+        )
+        .expect("valid repository config");
+        assert_eq!(config.artifact_patterns.len(), 3);
+        assert!(artifact_pattern_matches(
+            "*.apk",
+            "build/app/outputs/app.apk"
+        ));
+        assert!(artifact_pattern_matches(
+            "build/ios/**/*.ipa",
+            "build/ios/ipa/app.ipa"
+        ));
+        assert!(!artifact_pattern_matches(
+            "build/ios/*.ipa",
+            "build/ios/ipa/app.ipa"
+        ));
+    }
+
+    #[test]
+    fn repository_pipeline_yaml_rejects_unsupported_fields_and_unsafe_globs() {
+        let triggers = parse_repository_pipeline_yaml(
+            "version: 1\nplatforms: [android]\ntriggers: { events: [push] }\n",
+        )
+        .expect_err("triggers are managed by the pipeline, not repository YAML");
+        assert!(triggers.contains("unknown field `triggers`"));
+
+        let traversal = parse_repository_pipeline_yaml(
+            "version: 1\nplatforms: [android]\nartifacts: { patterns: ['../*.apk'] }\n",
+        )
+        .expect_err("parent traversal must fail");
+        assert!(traversal.contains("'..'"));
     }
 
     #[test]

--- a/crates/oore-contract/src/lib.rs
+++ b/crates/oore-contract/src/lib.rs
@@ -958,6 +958,8 @@ pub struct Build {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runner_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<BuildContext>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub step_results: Option<Vec<StepResult>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exit_code: Option<i32>,
@@ -968,6 +970,16 @@ pub struct Build {
     pub finished_at: Option<i64>,
     pub created_at: i64,
     pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct BuildContext {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pipeline_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runner_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/crates/oore-runner/src/lib.rs
+++ b/crates/oore-runner/src/lib.rs
@@ -3,12 +3,15 @@ use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use anyhow::Context;
 use base64::Engine as _;
 use oore_contract::{
-    AndroidSigningBuildType, BuildPlatform, BuildStatus, ClaimJobResponse, ClaimedJob,
-    JobStatusResponse, PipelineCommandStages, PipelineEnvVar, PipelineExecutionConfig,
-    PlatformBuildArgs, PlatformBuildCommands, RunnerAndroidSigningProfile,
+    AndroidSigningBuildType, BuildPlatform, BuildStatus, ClaimJobRequest, ClaimJobResponse,
+    ClaimedJob, CompleteArtifactRequest, CompleteArtifactResponse, JobStatusResponse,
+    PipelineCommandStages, PipelineEnvVar, PipelineExecutionConfig, PlatformBuildArgs,
+    PlatformBuildCommands, RUNNER_PROTOCOL_VERSION, RunnerAndroidSigningProfile,
     RunnerAndroidSigningResponse, RunnerIosSigningBundle, RunnerIosSigningResponse, StepResult,
+    artifact_pattern_matches, parse_repository_pipeline_yaml,
 };
 use rand::RngCore;
 use sha2::{Digest, Sha256};
@@ -1071,6 +1074,9 @@ async fn claim_and_execute(
             daemon_url, config.runner_id
         ))
         .bearer_auth(&config.runner_token)
+        .json(&ClaimJobRequest {
+            protocol_version: RUNNER_PROTOCOL_VERSION,
+        })
         .send()
         .await?;
 
@@ -1184,72 +1190,6 @@ impl std::fmt::Display for BuildTerminated {
 }
 
 impl std::error::Error for BuildTerminated {}
-
-#[derive(Debug, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RepoPipelineConfig {
-    version: u32,
-    platforms: Vec<BuildPlatform>,
-    #[serde(default)]
-    flutter_version: Option<String>,
-    #[serde(default)]
-    commands: RepoCommandStages,
-    #[serde(default)]
-    platform_build_args: RepoPlatformBuildArgs,
-    #[serde(default)]
-    platform_commands: RepoPlatformBuildCommands,
-    #[serde(default)]
-    env: Vec<RepoEnvVar>,
-    #[serde(default)]
-    artifacts: RepoArtifacts,
-}
-
-#[derive(Debug, Default, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RepoCommandStages {
-    #[serde(default)]
-    pre_build: Vec<String>,
-    #[serde(default)]
-    build: Vec<String>,
-    #[serde(default)]
-    post_build: Vec<String>,
-}
-
-#[derive(Debug, Default, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RepoArtifacts {
-    #[serde(default)]
-    patterns: Vec<String>,
-}
-
-#[derive(Debug, Default, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RepoPlatformBuildArgs {
-    #[serde(default)]
-    android: Vec<String>,
-    #[serde(default)]
-    ios: Vec<String>,
-    #[serde(default)]
-    macos: Vec<String>,
-}
-
-#[derive(Debug, Default, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RepoPlatformBuildCommands {
-    #[serde(default)]
-    android: Option<String>,
-    #[serde(default)]
-    ios: Option<String>,
-    #[serde(default)]
-    macos: Option<String>,
-}
-
-#[derive(Debug, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
-struct RepoEnvVar {
-    key: String,
-    value: String,
-}
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -1494,41 +1434,7 @@ fn normalize_execution_config(
 }
 
 fn parse_repo_config_file(raw: &str) -> anyhow::Result<PipelineExecutionConfig> {
-    let parsed: RepoPipelineConfig =
-        serde_yaml::from_str(raw).map_err(|e| anyhow::anyhow!("YAML parse error: {e}"))?;
-
-    if parsed.version != 1 {
-        anyhow::bail!("unsupported config version {}, expected 1", parsed.version);
-    }
-
-    normalize_execution_config(PipelineExecutionConfig {
-        platforms: parsed.platforms,
-        flutter_version: parsed.flutter_version,
-        commands: PipelineCommandStages {
-            pre_build: parsed.commands.pre_build,
-            build: parsed.commands.build,
-            post_build: parsed.commands.post_build,
-        },
-        platform_build_args: PlatformBuildArgs {
-            android: parsed.platform_build_args.android,
-            ios: parsed.platform_build_args.ios,
-            macos: parsed.platform_build_args.macos,
-        },
-        platform_commands: PlatformBuildCommands {
-            android: parsed.platform_commands.android,
-            ios: parsed.platform_commands.ios,
-            macos: parsed.platform_commands.macos,
-        },
-        env: parsed
-            .env
-            .into_iter()
-            .map(|entry| PipelineEnvVar {
-                key: entry.key,
-                value: entry.value,
-            })
-            .collect(),
-        artifact_patterns: parsed.artifacts.patterns,
-    })
+    parse_repository_pipeline_yaml(raw).map_err(anyhow::Error::msg)
 }
 
 fn build_default_command_with_args(base: &str, args: &[String]) -> String {
@@ -1686,6 +1592,9 @@ async fn check_build_active(
             daemon_url, config.runner_id, build_id
         ))
         .bearer_auth(&config.runner_token)
+        .json(&ClaimJobRequest {
+            protocol_version: RUNNER_PROTOCOL_VERSION,
+        })
         .send()
         .await;
 
@@ -2391,7 +2300,8 @@ Install required tooling (for example Flutter/FVM) or override build commands. C
             })
         });
 
-    scan_and_upload_artifacts(
+    let artifacts_started = now_unix();
+    let artifact_result = scan_and_upload_artifacts(
         workspace.as_path(),
         client,
         daemon_url,
@@ -2401,6 +2311,23 @@ Install required tooling (for example Flutter/FVM) or override build commands. C
         ios_artifact_metadata.as_ref(),
     )
     .await;
+    let artifacts_finished = now_unix();
+    steps.push(StepResult {
+        name: "artifacts".to_string(),
+        status: if artifact_result.is_ok() {
+            "succeeded"
+        } else {
+            "failed"
+        }
+        .to_string(),
+        exit_code: artifact_result.as_ref().err().map(|_| 1),
+        started_at: artifacts_started,
+        finished_at: artifacts_finished,
+        duration_ms: (artifacts_finished - artifacts_started) * 1000,
+    });
+    if let Err(error) = artifact_result {
+        return (steps, Err(error));
+    }
 
     drop(ios_signing_cleanup);
 
@@ -2625,16 +2552,22 @@ fn artifact_type_for_extension(ext: &str) -> Option<&'static str> {
     }
 }
 
-fn walk_dir_files(dir: &std::path::Path) -> Vec<PathBuf> {
+fn walk_artifact_candidates(dir: &Path) -> Vec<PathBuf> {
     let mut result = Vec::new();
-    fn walk(dir: &std::path::Path, result: &mut Vec<PathBuf>) {
+    fn walk(dir: &Path, result: &mut Vec<PathBuf>) {
         let entries = match fs::read_dir(dir) {
             Ok(e) => e,
             Err(_) => return,
         };
         for entry in entries.flatten() {
             let path = entry.path();
-            if path.is_dir() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_symlink() {
+                continue;
+            }
+            if file_type.is_dir() {
                 let is_hidden_dir = path
                     .file_name()
                     .and_then(|n| n.to_str())
@@ -2642,8 +2575,12 @@ fn walk_dir_files(dir: &std::path::Path) -> Vec<PathBuf> {
                 if is_hidden_dir {
                     continue;
                 }
+                if path.extension().and_then(|ext| ext.to_str()) == Some("app") {
+                    result.push(path);
+                    continue;
+                }
                 walk(&path, result);
-            } else if path.is_file() {
+            } else if file_type.is_file() {
                 result.push(path);
             }
         }
@@ -2676,48 +2613,79 @@ async fn scan_and_upload_artifacts(
     build_id: &str,
     artifact_patterns: &[String],
     ios_metadata: Option<&serde_json::Value>,
-) {
-    let all_files = walk_dir_files(workspace);
+) -> anyhow::Result<()> {
+    if artifact_patterns.is_empty() {
+        return Ok(());
+    }
 
-    let custom_extensions: Vec<String> = artifact_patterns
-        .iter()
-        .filter_map(|pat| pat.strip_prefix("*."))
-        .map(|ext| ext.to_lowercase())
-        .collect();
+    let mut artifacts: Vec<(PathBuf, String, String)> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for path in walk_artifact_candidates(workspace) {
+        let relative = path
+            .strip_prefix(workspace)
+            .ok()
+            .and_then(Path::to_str)
+            .map(|value| value.replace(std::path::MAIN_SEPARATOR, "/"));
+        let Some(relative) = relative else { continue };
+        if !artifact_patterns
+            .iter()
+            .any(|pattern| artifact_pattern_matches(pattern, &relative))
+            || !seen.insert(relative)
+        {
+            continue;
+        }
 
-    let mut artifacts: Vec<(PathBuf, String)> = Vec::new();
-
-    for path in &all_files {
-        if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
-            if let Some(art_type) = artifact_type_for_extension(ext) {
-                artifacts.push((path.clone(), art_type.to_string()));
-            } else if custom_extensions.contains(&ext.to_lowercase()) {
-                artifacts.push((path.clone(), "generic".to_string()));
+        if path.extension().and_then(|ext| ext.to_str()) == Some("app") && path.is_dir() {
+            let bundle_name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("app.app");
+            let package_dir = workspace.join(".oore-artifacts");
+            fs::create_dir_all(&package_dir)?;
+            let package_path = package_dir.join(format!("{bundle_name}.zip"));
+            let status = tokio::process::Command::new("ditto")
+                .args(["-c", "-k", "--sequesterRsrc", "--keepParent"])
+                .arg(&path)
+                .arg(&package_path)
+                .status()
+                .await
+                .context("failed to package .app bundle with ditto")?;
+            if !status.success() {
+                anyhow::bail!("failed to package .app bundle {}", path.display());
             }
+            artifacts.push((
+                package_path,
+                "app".to_string(),
+                format!("{bundle_name}.zip"),
+            ));
+        } else {
+            let name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("artifact")
+                .to_string();
+            let artifact_type = path
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .and_then(artifact_type_for_extension)
+                .unwrap_or("generic")
+                .to_string();
+            artifacts.push((path, artifact_type, name));
         }
     }
 
     if artifacts.is_empty() {
-        return;
+        anyhow::bail!(
+            "artifact patterns matched no files: {}",
+            artifact_patterns.join(", ")
+        );
     }
 
     println!("Found {} artifact(s) to upload", artifacts.len());
 
-    for (path, artifact_type) in &artifacts {
-        let name = path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("unknown");
-
+    for (path, artifact_type, name) in &artifacts {
         let file_size = fs::metadata(path).map(|m| m.len() as i64).ok();
-
-        let checksum = match compute_file_sha256(path) {
-            Ok(c) => Some(c),
-            Err(e) => {
-                eprintln!("Warning: failed to compute checksum for {}: {}", name, e);
-                None
-            }
-        };
+        let checksum = Some(compute_file_sha256(path)?);
 
         let metadata = match ios_metadata {
             Some(value) if artifact_type == "ipa" => value.clone(),
@@ -2732,7 +2700,7 @@ async fn scan_and_upload_artifacts(
             "metadata": metadata,
         });
 
-        let resp = match client
+        let resp = client
             .post(format!(
                 "{}/v1/runners/{}/jobs/{}/artifacts",
                 daemon_url, config.runner_id, build_id
@@ -2741,68 +2709,92 @@ async fn scan_and_upload_artifacts(
             .json(&body)
             .send()
             .await
-        {
-            Ok(r) => r,
-            Err(e) => {
-                eprintln!("Warning: failed to register artifact {}: {}", name, e);
-                continue;
-            }
-        };
+            .with_context(|| format!("failed to reserve artifact {name}"))?;
 
         if !resp.status().is_success() {
-            eprintln!(
-                "Warning: artifact registration failed for {} (HTTP {})",
-                name,
+            anyhow::bail!(
+                "artifact reservation failed for {name} (HTTP {})",
                 resp.status()
             );
-            continue;
         }
 
-        let create_resp: serde_json::Value = match resp.json().await {
-            Ok(v) => v,
-            Err(e) => {
-                eprintln!(
-                    "Warning: failed to parse artifact response for {}: {}",
-                    name, e
-                );
-                continue;
-            }
-        };
-
-        let upload_url = create_resp
-            .get("upload_url")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
+        let create_resp: oore_contract::CreateArtifactResponse = resp.json().await?;
+        let artifact_id = create_resp.artifact.id;
+        let upload_url = create_resp.upload_url;
 
         if upload_url.is_empty() {
-            println!(
-                "  Registered artifact {} (no S3 upload URL — storage not configured)",
-                name
-            );
-            continue;
+            abort_artifact(
+                client,
+                daemon_url,
+                config,
+                build_id,
+                &artifact_id,
+                "artifact storage is not configured",
+            )
+            .await;
+            anyhow::bail!("artifact storage is not configured for {name}");
         }
 
-        match tokio::fs::read(path).await {
-            Ok(bytes) => match client.put(upload_url).body(bytes).send().await {
-                Ok(r) if r.status().is_success() => {
-                    println!("  Uploaded artifact {}", name);
-                }
-                Ok(r) => {
-                    eprintln!(
-                        "Warning: S3 upload failed for {} (HTTP {})",
-                        name,
-                        r.status()
-                    );
-                }
-                Err(e) => {
-                    eprintln!("Warning: S3 upload failed for {}: {}", name, e);
-                }
-            },
-            Err(e) => {
-                eprintln!("Warning: failed to read artifact file {}: {}", name, e);
+        let upload = async {
+            let bytes = tokio::fs::read(path).await?;
+            let response = client.put(&upload_url).body(bytes).send().await?;
+            if !response.status().is_success() {
+                anyhow::bail!("upload returned HTTP {}", response.status());
             }
+            let response = client
+                .post(format!(
+                    "{}/v1/runners/{}/jobs/{}/artifacts/{}/complete",
+                    daemon_url, config.runner_id, build_id, artifact_id
+                ))
+                .bearer_auth(&config.runner_token)
+                .json(&CompleteArtifactRequest {
+                    error_message: None,
+                })
+                .send()
+                .await?;
+            if !response.status().is_success() {
+                anyhow::bail!("completion returned HTTP {}", response.status());
+            }
+            let _: CompleteArtifactResponse = response.json().await?;
+            Ok::<_, anyhow::Error>(())
         }
+        .await;
+        if let Err(error) = upload {
+            abort_artifact(
+                client,
+                daemon_url,
+                config,
+                build_id,
+                &artifact_id,
+                &error.to_string(),
+            )
+            .await;
+            return Err(error.context(format!("failed to finalize artifact {name}")));
+        }
+        println!("  Uploaded artifact {}", name);
     }
+    Ok(())
+}
+
+async fn abort_artifact(
+    client: &reqwest::Client,
+    daemon_url: &str,
+    config: &RunnerConfig,
+    build_id: &str,
+    artifact_id: &str,
+    error_message: &str,
+) {
+    let _ = client
+        .post(format!(
+            "{}/v1/runners/{}/jobs/{}/artifacts/{}/abort",
+            daemon_url, config.runner_id, build_id, artifact_id
+        ))
+        .bearer_auth(&config.runner_token)
+        .json(&CompleteArtifactRequest {
+            error_message: Some(error_message.to_string()),
+        })
+        .send()
+        .await;
 }
 
 struct StatusReport<'a> {

--- a/crates/oore/src/main.rs
+++ b/crates/oore/src/main.rs
@@ -3949,3 +3949,48 @@ fn main() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_rollback_restores_previous_release() {
+        let temp = tempfile::tempdir().unwrap();
+        let install = temp.path().join("install");
+        let stage = temp.path().join("stage");
+        let snapshot = temp.path().join("snapshot");
+
+        for root in [&install, &stage] {
+            fs::create_dir_all(root.join("bin")).unwrap();
+            fs::create_dir_all(root.join("web-dist")).unwrap();
+        }
+        fs::write(install.join("bin/oore"), "old-binary").unwrap();
+        fs::write(install.join("VERSION"), "1.0.0").unwrap();
+        fs::write(install.join("web-dist/index.html"), "old-web").unwrap();
+        fs::write(stage.join("bin/oore"), "new-binary").unwrap();
+        fs::write(stage.join("VERSION"), "2.0.0").unwrap();
+        fs::write(stage.join("web-dist/index.html"), "new-web").unwrap();
+
+        copy_release_snapshot(&install, &snapshot).unwrap();
+        install_staged_release(&stage, &install, ReleaseChannel::Stable, "oorebuild/oore").unwrap();
+        assert_eq!(
+            fs::read_to_string(install.join("VERSION")).unwrap(),
+            "2.0.0"
+        );
+
+        restore_release_snapshot(&install, &snapshot).unwrap();
+        assert_eq!(
+            fs::read_to_string(install.join("bin/oore")).unwrap(),
+            "old-binary"
+        );
+        assert_eq!(
+            fs::read_to_string(install.join("VERSION")).unwrap(),
+            "1.0.0"
+        );
+        assert_eq!(
+            fs::read_to_string(install.join("web-dist/index.html")).unwrap(),
+            "old-web"
+        );
+    }
+}

--- a/crates/oore/src/main.rs
+++ b/crates/oore/src/main.rs
@@ -15,7 +15,7 @@ use oore_contract::{
     OidcConfigureRequest, OidcConfigureResponse, RegisterRunnerResponse, RemoteAuthMode,
     RuntimeMode, SetupCompleteResponse, SetupOidcStartRequest, SetupOidcStartResponse,
     SetupOidcVerifyRequest, SetupOidcVerifyResponse, SetupState, SetupStateFile, SetupStatus,
-    UserProfileResponse,
+    UserProfileResponse, parse_repository_pipeline_yaml,
 };
 use rand::RngCore;
 use ring::aead::{self, AES_256_GCM, Aad, BoundKey, NONCE_LEN, Nonce, NonceSequence, UnboundKey};
@@ -79,6 +79,7 @@ enum Commands {
     Runner(RunnerArgs),
     Config(ConfigArgs),
     Doctor(DoctorArgs),
+    Pipeline(PipelineArgs),
     /// Print the installed oore version
     Version,
     /// Update oore and oored to the latest release
@@ -135,6 +136,33 @@ struct BackupManifest {
     format: String,
     created_at: i64,
     files: HashMap<String, String>,
+}
+
+#[derive(Debug, Args)]
+struct PipelineArgs {
+    #[command(subcommand)]
+    command: PipelineSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum PipelineSubcommand {
+    /// Validate repository pipeline YAML using the runner's schema.
+    Validate(PipelineValidateArgs),
+}
+
+#[derive(Debug, Args)]
+struct PipelineValidateArgs {
+    /// Repository pipeline file to validate.
+    #[arg(default_value = ".oore.yaml")]
+    path: PathBuf,
+}
+
+fn handle_pipeline_validate(args: PipelineValidateArgs) -> anyhow::Result<()> {
+    let raw = fs::read_to_string(&args.path)
+        .with_context(|| format!("failed to read {}", args.path.display()))?;
+    parse_repository_pipeline_yaml(&raw).map_err(anyhow::Error::msg)?;
+    println!("{} is valid", args.path.display());
+    Ok(())
 }
 
 #[derive(Debug, Args)]
@@ -3896,6 +3924,9 @@ fn main() -> anyhow::Result<()> {
         Commands::Doctor(args) => {
             run_doctor_checks(args)?;
         }
+        Commands::Pipeline(pipeline) => match pipeline.command {
+            PipelineSubcommand::Validate(args) => handle_pipeline_validate(args)?,
+        },
         Commands::Version => {
             let install_root = resolve_install_root()?;
             if let Some(v) = read_trimmed_file(&install_root.join("VERSION")) {

--- a/crates/oore/src/main.rs
+++ b/crates/oore/src/main.rs
@@ -60,6 +60,7 @@ struct DoctorCheckResult {
 struct DoctorReport {
     checks: Vec<DoctorCheckResult>,
     missing_count: usize,
+    warning_count: usize,
 }
 
 #[derive(Debug, Parser)]
@@ -291,6 +292,21 @@ struct ConfigGetArgs {
 struct DoctorArgs {
     #[arg(long, default_value = "false")]
     json: bool,
+
+    /// Check requirements for a build platform. Repeat for multiple platforms.
+    #[arg(long, value_enum)]
+    platform: Vec<DoctorPlatform>,
+
+    /// Check Android, iOS, and macOS requirements.
+    #[arg(long, conflicts_with = "platform")]
+    all: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum DoctorPlatform {
+    Android,
+    Ios,
+    Macos,
 }
 
 fn parse_ttl(raw: &str) -> anyhow::Result<Duration> {
@@ -2410,7 +2426,12 @@ fn command_version(cmd: &str, args: &[&str]) -> Option<String> {
     command_output(cmd, args)
         .and_then(|out| {
             if out.status.success() {
-                String::from_utf8(out.stdout).ok()
+                let output = if out.stdout.is_empty() {
+                    out.stderr
+                } else {
+                    out.stdout
+                };
+                String::from_utf8(output).ok()
             } else {
                 None
             }
@@ -2418,26 +2439,115 @@ fn command_version(cmd: &str, args: &[&str]) -> Option<String> {
         .and_then(|s| s.lines().next().map(|line| line.trim().to_string()))
 }
 
+fn doctor_check(
+    name: &str,
+    status: &str,
+    detail: Option<String>,
+    install_hint: Option<&str>,
+) -> DoctorCheckResult {
+    DoctorCheckResult {
+        name: name.to_string(),
+        status: status.to_string(),
+        detail,
+        install_hint: install_hint.map(str::to_string),
+    }
+}
+
+fn doctor_has_platform(args: &DoctorArgs, platform: DoctorPlatform) -> bool {
+    args.all || args.platform.contains(&platform)
+}
+
+fn android_sdk_root() -> Option<PathBuf> {
+    ["ANDROID_HOME", "ANDROID_SDK_ROOT"]
+        .into_iter()
+        .find_map(|key| {
+            std::env::var_os(key)
+                .map(PathBuf::from)
+                .filter(|path| path.is_dir())
+        })
+}
+
+fn add_xcode_checks(checks: &mut Vec<DoctorCheckResult>) {
+    if std::env::consts::OS != "macos" {
+        checks.push(doctor_check(
+            "xcode",
+            "missing",
+            Some("iOS and macOS builds require a macOS runner".to_string()),
+            Some("run this job on macOS with Xcode installed"),
+        ));
+        return;
+    }
+
+    let developer_dir =
+        command_version("xcode-select", &["-p"]).filter(|path| Path::new(path).is_dir());
+    let xcode_version = command_version("xcodebuild", &["-version"]);
+    if let (Some(developer_dir), Some(xcode_version)) = (developer_dir, xcode_version) {
+        checks.push(doctor_check(
+            "xcode",
+            "ok",
+            Some(format!("{} ({})", xcode_version, developer_dir)),
+            None,
+        ));
+    } else {
+        checks.push(doctor_check(
+            "xcode",
+            "missing",
+            None,
+            Some("install Xcode, then run: sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer"),
+        ));
+    }
+}
+
+fn add_signing_warnings(checks: &mut Vec<DoctorCheckResult>) {
+    let codesign = command_output("security", &["find-identity", "-v", "-p", "codesigning"]);
+    match codesign {
+        Some(output) if output.status.success() => {
+            let output = format!(
+                "{}\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            if output.contains("0 valid identities found") {
+                checks.push(doctor_check(
+                    "codesign_identity",
+                    "warning",
+                    Some("0 valid identities found".to_string()),
+                    Some("import an Apple development or distribution certificate before signing"),
+                ));
+            } else {
+                checks.push(doctor_check(
+                    "codesign_identity",
+                    "ok",
+                    Some("signing identity available".to_string()),
+                    None,
+                ));
+            }
+        }
+        _ => checks.push(doctor_check(
+            "codesign_identity",
+            "warning",
+            None,
+            Some("import an Apple development or distribution certificate before signing"),
+        )),
+    }
+
+    if let Some(version) = command_version("xcrun", &["notarytool", "--version"]) {
+        checks.push(doctor_check("notarytool", "ok", Some(version), None));
+    } else {
+        checks.push(doctor_check(
+            "notarytool",
+            "warning",
+            None,
+            Some("install a current Xcode version before notarizing macOS apps"),
+        ));
+    }
+}
+
 fn run_doctor_checks(args: DoctorArgs) -> anyhow::Result<()> {
     let mut checks: Vec<DoctorCheckResult> = Vec::new();
 
-    let base_checks: [(&str, &[&str], &str); 6] = [
+    let base_checks: [(&str, &[&str], &str); 3] = [
         ("git", &["--version"], "brew install git"),
-        (
-            "rustc",
-            &["--version"],
-            "curl https://sh.rustup.rs -sSf | sh",
-        ),
-        (
-            "cargo",
-            &["--version"],
-            "curl https://sh.rustup.rs -sSf | sh",
-        ),
-        (
-            "bun",
-            &["--version"],
-            "curl -fsSL https://bun.sh/install | bash",
-        ),
         (
             "fvm",
             &["--version"],
@@ -2452,109 +2562,87 @@ fn run_doctor_checks(args: DoctorArgs) -> anyhow::Result<()> {
 
     for (name, command_args, install_hint) in base_checks {
         if let Some(version) = command_version(name, command_args) {
-            checks.push(DoctorCheckResult {
-                name: name.to_string(),
-                status: "ok".to_string(),
-                detail: Some(version),
-                install_hint: None,
-            });
+            checks.push(doctor_check(name, "ok", Some(version), None));
         } else {
-            checks.push(DoctorCheckResult {
-                name: name.to_string(),
-                status: "missing".to_string(),
-                detail: None,
-                install_hint: Some(install_hint.to_string()),
-            });
+            checks.push(doctor_check(name, "missing", None, Some(install_hint)));
         }
     }
 
-    let xcode_ready = command_version("xcodebuild", &["-version"]).is_some()
-        && command_version("xcode-select", &["-p"]).is_some();
-    checks.push(if xcode_ready {
-        DoctorCheckResult {
-            name: "xcode_cli".to_string(),
-            status: "ok".to_string(),
-            detail: Some("xcodebuild + xcode-select configured".to_string()),
-            install_hint: None,
+    if doctor_has_platform(&args, DoctorPlatform::Android) {
+        if let Some(version) = command_version("java", &["-version"]) {
+            checks.push(doctor_check("java", "ok", Some(version), None));
+        } else {
+            checks.push(doctor_check(
+                "java",
+                "missing",
+                None,
+                Some("install a supported JDK and set JAVA_HOME"),
+            ));
         }
-    } else {
-        DoctorCheckResult {
-            name: "xcode_cli".to_string(),
-            status: "missing".to_string(),
-            detail: None,
-            install_hint: Some(
-                "install/configure Xcode CLI tools: xcode-select --install".to_string(),
-            ),
-        }
-    });
 
-    let codesign_check = command_output("security", &["find-identity", "-v", "-p", "codesigning"]);
-    match codesign_check {
-        Some(output) if output.status.success() => {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            let merged = format!("{stdout}\n{stderr}");
-            if merged.contains("0 valid identities found") {
-                checks.push(DoctorCheckResult {
-                    name: "codesign_identity".to_string(),
-                    status: "missing".to_string(),
-                    detail: Some("0 valid identities found".to_string()),
-                    install_hint: Some(
-                        "import a Developer/Application certificate into Keychain Access"
-                            .to_string(),
-                    ),
-                });
+        if let Some(sdk_root) = android_sdk_root() {
+            let adb = sdk_root.join("platform-tools/adb");
+            if adb.is_file() {
+                checks.push(doctor_check(
+                    "android_sdk",
+                    "ok",
+                    Some(sdk_root.display().to_string()),
+                    None,
+                ));
             } else {
-                let identity_count = merged
-                    .lines()
-                    .filter(|line| line.contains('"') && line.contains(") "))
-                    .count();
-                checks.push(DoctorCheckResult {
-                    name: "codesign_identity".to_string(),
-                    status: "ok".to_string(),
-                    detail: Some(format!("{identity_count} identity entries available")),
-                    install_hint: None,
-                });
+                checks.push(doctor_check(
+                    "android_sdk",
+                    "missing",
+                    Some(sdk_root.display().to_string()),
+                    Some("install Android SDK Platform-Tools in this SDK"),
+                ));
             }
+        } else {
+            checks.push(doctor_check(
+                "android_sdk",
+                "missing",
+                None,
+                Some("install Android Studio, then set ANDROID_HOME to its SDK directory"),
+            ));
         }
-        _ => {
-            checks.push(DoctorCheckResult {
-                name: "codesign_identity".to_string(),
-                status: "missing".to_string(),
-                detail: None,
-                install_hint: Some(
-                    "run `security find-identity -v -p codesigning` and import required certificates"
-                        .to_string(),
-                ),
-            });
-        }
+    } else {
+        checks.push(doctor_check(
+            "android",
+            "skipped",
+            Some("run `oore doctor --platform android` for Android checks".to_string()),
+            None,
+        ));
     }
 
-    if let Some(version) = command_version("xcrun", &["notarytool", "--version"]) {
-        checks.push(DoctorCheckResult {
-            name: "notarytool".to_string(),
-            status: "ok".to_string(),
-            detail: Some(version),
-            install_hint: None,
-        });
+    let apple_selected = doctor_has_platform(&args, DoctorPlatform::Ios)
+        || doctor_has_platform(&args, DoctorPlatform::Macos);
+    if apple_selected {
+        add_xcode_checks(&mut checks);
+        add_signing_warnings(&mut checks);
     } else {
-        checks.push(DoctorCheckResult {
-            name: "notarytool".to_string(),
-            status: "missing".to_string(),
-            detail: None,
-            install_hint: Some(
-                "install/update Xcode CLT and verify with `xcrun notarytool --version`".to_string(),
+        checks.push(doctor_check(
+            "apple_platforms",
+            "skipped",
+            Some(
+                "run `oore doctor --platform ios` or `--platform macos` for Xcode checks"
+                    .to_string(),
             ),
-        });
+            None,
+        ));
     }
 
     let missing_count = checks
         .iter()
         .filter(|check| check.status == "missing")
         .count();
+    let warning_count = checks
+        .iter()
+        .filter(|check| check.status == "warning")
+        .count();
     let report = DoctorReport {
         checks,
         missing_count,
+        warning_count,
     };
 
     if args.json {
@@ -2562,24 +2650,20 @@ fn run_doctor_checks(args: DoctorArgs) -> anyhow::Result<()> {
     } else {
         println!("oore doctor -- environment checks");
         for check in &report.checks {
-            if check.status == "ok" {
-                println!(
-                    "  [ok] {:<18} {}",
-                    check.name,
-                    check.detail.as_deref().unwrap_or("")
-                );
-            } else {
-                println!(
-                    "  [missing] {:<18} install: {}",
-                    check.name,
-                    check.install_hint.as_deref().unwrap_or("")
-                );
-            }
+            let detail = check
+                .detail
+                .as_deref()
+                .or(check.install_hint.as_deref())
+                .unwrap_or("");
+            println!("  [{}] {:<18} {}", check.status, check.name, detail);
         }
         if report.missing_count == 0 {
-            println!("All required tools are installed.");
+            println!("All selected required checks passed.");
         } else {
-            println!("{} issue(s) found.", report.missing_count);
+            println!("{} required issue(s) found.", report.missing_count);
+        }
+        if report.warning_count > 0 {
+            println!("{} optional warning(s) found.", report.warning_count);
         }
     }
 

--- a/crates/oore/src/main.rs
+++ b/crates/oore/src/main.rs
@@ -83,6 +83,58 @@ enum Commands {
     Version,
     /// Update oore and oored to the latest release
     Update(UpdateArgs),
+    /// Create, verify, or restore an encrypted-state backup
+    Backup(BackupArgs),
+}
+
+#[derive(Debug, Args)]
+struct BackupArgs {
+    #[command(subcommand)]
+    command: BackupSubcommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum BackupSubcommand {
+    /// Create a consistent SQLite snapshot and package it with the encryption key.
+    Create(BackupCreateArgs),
+    /// Verify a backup manifest, checksums, and SQLite integrity.
+    Verify(BackupVerifyArgs),
+    /// Atomically restore a verified backup while the daemon is stopped.
+    Restore(BackupRestoreArgs),
+}
+
+#[derive(Debug, Args)]
+struct BackupCreateArgs {
+    /// Destination .tar.gz file.
+    #[arg(long)]
+    output: PathBuf,
+    /// Path to the SQLite state file.
+    #[arg(long, env = "OORE_SETUP_STATE_FILE")]
+    state_file: Option<String>,
+}
+
+#[derive(Debug, Args)]
+struct BackupVerifyArgs {
+    /// Backup .tar.gz file.
+    #[arg(long)]
+    input: PathBuf,
+}
+
+#[derive(Debug, Args)]
+struct BackupRestoreArgs {
+    /// Backup .tar.gz file.
+    #[arg(long)]
+    input: PathBuf,
+    /// Path to the SQLite state file to restore.
+    #[arg(long, env = "OORE_SETUP_STATE_FILE")]
+    state_file: Option<String>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct BackupManifest {
+    format: String,
+    created_at: i64,
+    files: HashMap<String, String>,
 }
 
 #[derive(Debug, Args)]
@@ -3043,6 +3095,519 @@ fn set_executable(path: &Path) -> anyhow::Result<()> {
         .with_context(|| format!("failed to set permissions on {}", path.display()))
 }
 
+const BACKUP_DATABASE_FILE: &str = "oore.db";
+const BACKUP_KEY_FILE: &str = "encryption.key";
+const BACKUP_MANIFEST_FILE: &str = "manifest.json";
+
+fn resolve_key_path() -> anyhow::Result<PathBuf> {
+    Ok(resolve_data_dir()?.join(BACKUP_KEY_FILE))
+}
+
+fn set_private_permissions(path: &Path) -> anyhow::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600)).with_context(|| {
+            format!(
+                "failed to set restrictive permissions on {}",
+                path.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn snapshot_sqlite_path(source: &Path, destination: &Path) -> anyhow::Result<()> {
+    use std::str::FromStr;
+
+    let source_url = format!("sqlite://{}?mode=rw", source.display());
+    let options = SqliteConnectOptions::from_str(&source_url)
+        .with_context(|| format!("failed to open SQLite database {}", source.display()))?;
+    let destination = destination.display().to_string().replace('\'', "''");
+    let runtime = tokio::runtime::Runtime::new().context("failed to create Tokio runtime")?;
+    runtime.block_on(async move {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(options)
+            .await
+            .context("failed to connect to SQLite database")?;
+        sqlx::query(&format!("VACUUM INTO '{destination}'"))
+            .execute(&pool)
+            .await
+            .context("failed to create a consistent SQLite snapshot")?;
+        pool.close().await;
+        Ok::<(), anyhow::Error>(())
+    })
+}
+
+fn sqlite_integrity_check(path: &Path) -> anyhow::Result<()> {
+    use std::str::FromStr;
+
+    let source_url = format!("sqlite://{}?mode=ro", path.display());
+    let options = SqliteConnectOptions::from_str(&source_url)
+        .with_context(|| format!("failed to open SQLite snapshot {}", path.display()))?;
+    let runtime = tokio::runtime::Runtime::new().context("failed to create Tokio runtime")?;
+    runtime.block_on(async move {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(options)
+            .await
+            .context("failed to connect to SQLite snapshot")?;
+        let result: String = sqlx::query_scalar("PRAGMA integrity_check")
+            .fetch_one(&pool)
+            .await
+            .context("failed to run SQLite integrity check")?;
+        pool.close().await;
+        if result != "ok" {
+            anyhow::bail!("SQLite integrity check failed: {result}");
+        }
+        Ok::<(), anyhow::Error>(())
+    })
+}
+
+fn unpack_backup(input: &Path, destination: &Path) -> anyhow::Result<BackupManifest> {
+    let file = fs::File::open(input)
+        .with_context(|| format!("failed to open backup {}", input.display()))?;
+    let decoder = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(decoder);
+    let mut found = HashMap::new();
+
+    for entry in archive.entries().context("failed to read backup archive")? {
+        let mut entry = entry.context("failed to read backup entry")?;
+        let path = entry.path().context("invalid backup entry path")?;
+        let name = path
+            .to_str()
+            .context("backup entry path is not UTF-8")?
+            .to_string();
+        if !matches!(
+            name.as_str(),
+            BACKUP_DATABASE_FILE | BACKUP_KEY_FILE | BACKUP_MANIFEST_FILE
+        ) || path.components().count() != 1
+        {
+            anyhow::bail!("backup contains unsupported path: {name}");
+        }
+        if found.insert(name.clone(), ()).is_some() {
+            anyhow::bail!("backup contains duplicate path: {name}");
+        }
+        entry
+            .unpack(destination.join(&name))
+            .with_context(|| format!("failed to unpack backup entry {name}"))?;
+    }
+
+    for name in [BACKUP_DATABASE_FILE, BACKUP_KEY_FILE, BACKUP_MANIFEST_FILE] {
+        if !found.contains_key(name) {
+            anyhow::bail!("backup is missing {name}");
+        }
+    }
+
+    let manifest = serde_json::from_slice::<BackupManifest>(
+        &fs::read(destination.join(BACKUP_MANIFEST_FILE))
+            .context("failed to read backup manifest")?,
+    )
+    .context("failed to parse backup manifest")?;
+    if manifest.format != "oore-backup-v1" {
+        anyhow::bail!("unsupported backup format: {}", manifest.format);
+    }
+    for name in [BACKUP_DATABASE_FILE, BACKUP_KEY_FILE] {
+        let expected = manifest
+            .files
+            .get(name)
+            .with_context(|| format!("backup manifest is missing checksum for {name}"))?;
+        let actual = hex::encode(Sha256::digest(
+            fs::read(destination.join(name))
+                .with_context(|| format!("failed to read backup {name}"))?,
+        ));
+        if expected != &actual {
+            anyhow::bail!("backup checksum mismatch for {name}");
+        }
+    }
+
+    let key = fs::read(destination.join(BACKUP_KEY_FILE)).context("failed to read backup key")?;
+    if key.len() != 32 {
+        anyhow::bail!("backup encryption key has invalid length");
+    }
+    sqlite_integrity_check(&destination.join(BACKUP_DATABASE_FILE))?;
+    Ok(manifest)
+}
+
+fn backup_create(args: BackupCreateArgs) -> anyhow::Result<()> {
+    let database = resolve_db_path(args.state_file.as_deref())?;
+    let key = resolve_key_path()?;
+    if !database.is_file() {
+        anyhow::bail!("database does not exist: {}", database.display());
+    }
+    if !key.is_file() {
+        anyhow::bail!("encryption key does not exist: {}", key.display());
+    }
+    if args.output.exists() {
+        anyhow::bail!(
+            "backup destination already exists: {}",
+            args.output.display()
+        );
+    }
+    let parent = args
+        .output
+        .parent()
+        .context("backup output must have a parent directory")?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create backup directory {}", parent.display()))?;
+
+    let stage =
+        tempfile::tempdir_in(parent).context("failed to create backup staging directory")?;
+    let snapshot = stage.path().join(BACKUP_DATABASE_FILE);
+    snapshot_sqlite_path(&database, &snapshot)?;
+    let staged_key = stage.path().join(BACKUP_KEY_FILE);
+    fs::copy(&key, &staged_key).context("failed to copy encryption key into backup")?;
+    set_private_permissions(&staged_key)?;
+
+    let mut files = HashMap::new();
+    for name in [BACKUP_DATABASE_FILE, BACKUP_KEY_FILE] {
+        files.insert(
+            name.to_string(),
+            hex::encode(Sha256::digest(fs::read(stage.path().join(name))?)),
+        );
+    }
+    let manifest = BackupManifest {
+        format: "oore-backup-v1".to_string(),
+        created_at: now_epoch_secs(),
+        files,
+    };
+    fs::write(
+        stage.path().join(BACKUP_MANIFEST_FILE),
+        serde_json::to_vec_pretty(&manifest).context("failed to serialize backup manifest")?,
+    )
+    .context("failed to write backup manifest")?;
+
+    let temp_output = parent.join(format!(
+        ".{}.tmp",
+        args.output
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+    ));
+    let file = fs::File::create(&temp_output)
+        .with_context(|| format!("failed to create backup {}", temp_output.display()))?;
+    let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+    let mut archive = tar::Builder::new(encoder);
+    for name in [BACKUP_DATABASE_FILE, BACKUP_KEY_FILE, BACKUP_MANIFEST_FILE] {
+        archive
+            .append_path_with_name(stage.path().join(name), name)
+            .with_context(|| format!("failed to add {name} to backup"))?;
+    }
+    archive
+        .finish()
+        .context("failed to finish backup archive")?;
+    let encoder = archive
+        .into_inner()
+        .context("failed to finalize backup archive")?;
+    encoder
+        .finish()
+        .context("failed to finalize backup compression")?;
+    set_private_permissions(&temp_output)?;
+    fs::rename(&temp_output, &args.output)
+        .with_context(|| format!("failed to publish backup {}", args.output.display()))?;
+    println!("Created backup: {}", args.output.display());
+    Ok(())
+}
+
+fn backup_verify(args: BackupVerifyArgs) -> anyhow::Result<()> {
+    let stage = tempfile::tempdir().context("failed to create backup verification directory")?;
+    let manifest = unpack_backup(&args.input, stage.path())?;
+    println!(
+        "Backup verified: {} (created {})",
+        args.input.display(),
+        manifest.created_at
+    );
+    Ok(())
+}
+
+fn database_is_open(path: &Path) -> bool {
+    std::process::Command::new("lsof")
+        .args(["-t", "--", &path.display().to_string()])
+        .output()
+        .map(|output| output.status.success() && !output.stdout.is_empty())
+        .unwrap_or(false)
+}
+
+fn backup_restore(args: BackupRestoreArgs) -> anyhow::Result<()> {
+    let client = github_client()?;
+    let runtime = tokio::runtime::Runtime::new().context("failed to create Tokio runtime")?;
+    if runtime.block_on(check_daemon_running(&client)) {
+        anyhow::bail!(
+            "refusing restore while oored is running; stop the managed service or daemon first"
+        );
+    }
+
+    let database = resolve_db_path(args.state_file.as_deref())?;
+    if database_is_open(&database) {
+        anyhow::bail!(
+            "refusing restore while the state database is open; stop the managed or unmanaged oored process first"
+        );
+    }
+    let stage = tempfile::tempdir().context("failed to create restore staging directory")?;
+    unpack_backup(&args.input, stage.path())?;
+    let key = resolve_key_path()?;
+    for path in [&database, &key] {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("failed to create restore directory {}", parent.display())
+            })?;
+        }
+    }
+
+    let nonce = now_epoch_secs();
+    let database_old = database.with_extension(format!("restore-{nonce}.old"));
+    let key_old = key.with_extension(format!("restore-{nonce}.old"));
+    let database_new = database.with_extension(format!("restore-{nonce}.new"));
+    let key_new = key.with_extension(format!("restore-{nonce}.new"));
+    fs::copy(stage.path().join(BACKUP_DATABASE_FILE), &database_new)?;
+    fs::copy(stage.path().join(BACKUP_KEY_FILE), &key_new)?;
+    set_private_permissions(&key_new)?;
+
+    let rollback = || -> anyhow::Result<()> {
+        if database_old.exists() {
+            fs::rename(&database_old, &database)?;
+        }
+        if key_old.exists() {
+            fs::rename(&key_old, &key)?;
+        }
+        Ok(())
+    };
+    if database.exists() {
+        fs::rename(&database, &database_old)?;
+    }
+    if key.exists() {
+        fs::rename(&key, &key_old)?;
+    }
+    let result = (|| -> anyhow::Result<()> {
+        fs::rename(&database_new, &database)?;
+        fs::rename(&key_new, &key)?;
+        set_private_permissions(&key)?;
+        Ok(())
+    })();
+    if let Err(error) = result {
+        let _ = fs::remove_file(&database);
+        let _ = fs::remove_file(&key);
+        rollback().context("restore failed and rollback failed")?;
+        return Err(error);
+    }
+    let _ = fs::remove_file(database_old);
+    let _ = fs::remove_file(key_old);
+    println!("Restored backup: {}", args.input.display());
+    Ok(())
+}
+
+const DAEMON_SERVICE_LABEL: &str = "build.oore.oored";
+const WEB_SERVICE_LABEL: &str = "build.oore.oore-web";
+
+fn launch_agent_plist(label: &str) -> anyhow::Result<PathBuf> {
+    Ok(dirs::home_dir()
+        .context("could not determine home directory")?
+        .join("Library/LaunchAgents")
+        .join(format!("{label}.plist")))
+}
+
+fn launchd_service_loaded(label: &str) -> bool {
+    if !cfg!(target_os = "macos") {
+        return false;
+    }
+    let Ok(uid) = std::process::Command::new("id").arg("-u").output() else {
+        return false;
+    };
+    let uid = String::from_utf8_lossy(&uid.stdout).trim().to_string();
+    std::process::Command::new("launchctl")
+        .args(["print", &format!("gui/{uid}/{label}")])
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn restart_launchd_service(label: &str) -> anyhow::Result<()> {
+    if !cfg!(target_os = "macos") {
+        anyhow::bail!("managed service restart is supported on macOS only");
+    }
+    let plist = launch_agent_plist(label)?;
+    if !plist.is_file() {
+        anyhow::bail!("managed service plist is missing: {}", plist.display());
+    }
+    let uid = std::process::Command::new("id")
+        .arg("-u")
+        .output()
+        .context("failed to determine current user id")?;
+    let uid = String::from_utf8_lossy(&uid.stdout).trim().to_string();
+    let service = format!("gui/{uid}/{label}");
+    let domain = format!("gui/{uid}");
+    let _ = std::process::Command::new("launchctl")
+        .args(["bootout", &service])
+        .status();
+    let status = std::process::Command::new("launchctl")
+        .args(["bootstrap", &domain, &plist.display().to_string()])
+        .status()
+        .context("failed to bootstrap launchd service")?;
+    if !status.success() {
+        anyhow::bail!("failed to bootstrap managed service {label}");
+    }
+    let _ = std::process::Command::new("launchctl")
+        .args(["kickstart", "-k", &service])
+        .status();
+    Ok(())
+}
+
+async fn endpoint_is_healthy(client: &reqwest::Client, url: &str) -> bool {
+    client
+        .get(url)
+        .timeout(Duration::from_secs(3))
+        .send()
+        .await
+        .map(|response| response.status().is_success())
+        .unwrap_or(false)
+}
+
+async fn wait_for_endpoint(client: &reqwest::Client, url: &str, name: &str) -> anyhow::Result<()> {
+    for _ in 0..15 {
+        if endpoint_is_healthy(client, url).await {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    anyhow::bail!("{name} failed its readiness check: {url}")
+}
+
+fn copy_release_snapshot(install_root: &Path, snapshot: &Path) -> anyhow::Result<()> {
+    for relative in [
+        "bin/oore",
+        "bin/oored",
+        "bin/oore-web",
+        "VERSION",
+        "CHANNEL",
+        "GITHUB_REPO",
+        "LICENSE",
+    ] {
+        let source = install_root.join(relative);
+        if source.is_file() {
+            let destination = snapshot.join(relative);
+            fs::create_dir_all(destination.parent().expect("snapshot file parent"))?;
+            fs::copy(&source, &destination)?;
+        }
+    }
+    let web = install_root.join("web-dist");
+    if web.is_dir() {
+        copy_dir_recursive(&web, &snapshot.join("web-dist"))?;
+    }
+    Ok(())
+}
+
+fn atomic_replace_file(source: &Path, destination: &Path, executable: bool) -> anyhow::Result<()> {
+    let parent = destination
+        .parent()
+        .context("release destination has no parent")?;
+    fs::create_dir_all(parent)?;
+    let next = parent.join(format!(
+        ".{}.update-{}",
+        destination
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy(),
+        std::process::id()
+    ));
+    fs::copy(source, &next)
+        .with_context(|| format!("failed to stage {}", destination.display()))?;
+    if executable {
+        set_executable(&next)?;
+    }
+    fs::rename(&next, destination)
+        .with_context(|| format!("failed to atomically replace {}", destination.display()))?;
+    Ok(())
+}
+
+fn atomic_replace_directory(source: &Path, destination: &Path) -> anyhow::Result<()> {
+    let parent = destination
+        .parent()
+        .context("release destination has no parent")?;
+    let stem = destination
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy();
+    let next = parent.join(format!(".{stem}.update-{}", std::process::id()));
+    let old = parent.join(format!(".{stem}.previous-{}", std::process::id()));
+    if next.exists() {
+        fs::remove_dir_all(&next)?;
+    }
+    copy_dir_recursive(source, &next)?;
+    if destination.exists() {
+        fs::rename(destination, &old)?;
+    }
+    if let Err(error) = fs::rename(&next, destination) {
+        if old.exists() {
+            let _ = fs::rename(&old, destination);
+        }
+        return Err(error)
+            .with_context(|| format!("failed to atomically replace {}", destination.display()));
+    }
+    if old.exists() {
+        fs::remove_dir_all(old)?;
+    }
+    Ok(())
+}
+
+fn restore_release_snapshot(install_root: &Path, snapshot: &Path) -> anyhow::Result<()> {
+    for relative in [
+        "bin/oore",
+        "bin/oored",
+        "bin/oore-web",
+        "VERSION",
+        "CHANNEL",
+        "GITHUB_REPO",
+        "LICENSE",
+    ] {
+        let source = snapshot.join(relative);
+        let destination = install_root.join(relative);
+        if source.is_file() {
+            atomic_replace_file(&source, &destination, relative.starts_with("bin/"))?;
+        } else if destination.exists() {
+            fs::remove_file(destination)?;
+        }
+    }
+    let source = snapshot.join("web-dist");
+    let destination = install_root.join("web-dist");
+    if source.is_dir() {
+        atomic_replace_directory(&source, &destination)?;
+    } else if destination.exists() {
+        fs::remove_dir_all(destination)?;
+    }
+    Ok(())
+}
+
+fn install_staged_release(
+    stage: &Path,
+    install_root: &Path,
+    channel: ReleaseChannel,
+    repo: &str,
+) -> anyhow::Result<()> {
+    for (relative, executable) in [
+        ("bin/oore", true),
+        ("bin/oored", true),
+        ("bin/oore-web", true),
+        ("VERSION", false),
+    ] {
+        let source = stage.join(relative);
+        if source.is_file() {
+            atomic_replace_file(&source, &install_root.join(relative), executable)?;
+        }
+    }
+    let web = stage.join("web-dist");
+    if web.is_dir() {
+        atomic_replace_directory(&web, &install_root.join("web-dist"))?;
+    }
+    let license = stage.join("LICENSE");
+    if license.is_file() {
+        atomic_replace_file(&license, &install_root.join("LICENSE"), false)?;
+    }
+    fs::write(install_root.join("CHANNEL"), channel.as_str())?;
+    fs::write(install_root.join("GITHUB_REPO"), repo)?;
+    Ok(())
+}
+
 async fn handle_update(args: UpdateArgs) -> anyhow::Result<()> {
     let install_root = resolve_install_root()?;
 
@@ -3143,7 +3708,7 @@ async fn handle_update(args: UpdateArgs) -> anyhow::Result<()> {
     }
     println!("Checksum verified (SHA-256).");
 
-    // 7. Extract tar.gz into tempdir
+    // 7. Extract outside the install then stage the verified release inside it.
     let tmpdir = tempfile::tempdir().context("failed to create temporary directory")?;
     let decoder = flate2::read::GzDecoder::new(&archive_bytes[..]);
     let mut archive = tar::Archive::new(decoder);
@@ -3151,14 +3716,11 @@ async fn handle_update(args: UpdateArgs) -> anyhow::Result<()> {
         .unpack(tmpdir.path())
         .context("failed to extract archive")?;
 
-    // 8. Verify expected files exist
+    // 8. Verify expected files exist.
     let extracted_bin = tmpdir.path().join("bin");
     let extracted_oore = extracted_bin.join("oore");
     let extracted_oored = extracted_bin.join("oored");
-    let extracted_oore_web = extracted_bin.join("oore-web");
     let extracted_version = tmpdir.path().join("VERSION");
-    let extracted_license = tmpdir.path().join("LICENSE");
-    let extracted_web_dist = tmpdir.path().join("web-dist");
 
     if !extracted_oore.exists() {
         anyhow::bail!("archive missing bin/oore");
@@ -3170,58 +3732,88 @@ async fn handle_update(args: UpdateArgs) -> anyhow::Result<()> {
         anyhow::bail!("archive missing VERSION");
     }
 
-    // 9. Stop daemon if running
+    // Keep both a restorable release snapshot and a consistent data backup before
+    // touching the installed files. The staging directory is inside the install
+    // root so the final renames stay on one filesystem.
+    fs::create_dir_all(&install_root)
+        .with_context(|| format!("failed to create install root {}", install_root.display()))?;
+    let update_stage = tempfile::Builder::new()
+        .prefix(".update-")
+        .tempdir_in(&install_root)
+        .context("failed to create update staging directory")?;
+    let staged_release = update_stage.path().join("release");
+    copy_dir_recursive(tmpdir.path(), &staged_release)?;
+    let previous_release = update_stage.path().join("previous");
+    copy_release_snapshot(&install_root, &previous_release)?;
+
+    let backup_dir = install_root.join("backups");
+    let backup_path = backup_dir.join(format!(
+        "pre-update-{}-{}.tar.gz",
+        current,
+        now_epoch_secs()
+    ));
+    backup_create(BackupCreateArgs {
+        output: backup_path.clone(),
+        state_file: None,
+    })?;
+    println!("Created pre-update backup: {}", backup_path.display());
+
+    // 9. Preserve running service state. launchd keeps the old executable alive
+    // until it is explicitly reloaded after replacement.
     let daemon_was_running = check_daemon_running(&client).await;
-    if daemon_was_running {
+    let daemon_is_managed = launchd_service_loaded(DAEMON_SERVICE_LABEL);
+    let web_url = "http://127.0.0.1:4173/__oore_web_healthz";
+    let web_was_running = endpoint_is_healthy(&client, web_url).await;
+    let web_is_managed = launchd_service_loaded(WEB_SERVICE_LABEL);
+    if daemon_was_running && !daemon_is_managed {
         println!("oored daemon is running. Stopping before update...");
         stop_daemon(&install_root)?;
     }
 
-    // 10. Copy binaries + assets into install root
-    let bin_dir = install_root.join("bin");
-    fs::create_dir_all(&bin_dir).context("failed to create bin directory")?;
-
-    fs::copy(&extracted_oore, bin_dir.join("oore")).context("failed to copy oore binary")?;
-    fs::copy(&extracted_oored, bin_dir.join("oored")).context("failed to copy oored binary")?;
-
-    if extracted_oore_web.exists() {
-        fs::copy(&extracted_oore_web, bin_dir.join("oore-web"))
-            .context("failed to copy oore-web binary")?;
-        set_executable(&bin_dir.join("oore-web"))?;
-    }
-
-    if extracted_web_dist.is_dir() {
-        let dst = install_root.join("web-dist");
-        if dst.exists() {
-            fs::remove_dir_all(&dst)
-                .with_context(|| format!("failed to remove {}", dst.display()))?;
+    // 10. Atomically install the staged release and only retain it if every
+    // readiness check succeeds. On any failure, restore the prior release.
+    let update_result = async {
+        install_staged_release(&staged_release, &install_root, channel, &repo)?;
+        if daemon_is_managed {
+            restart_launchd_service(DAEMON_SERVICE_LABEL)?;
+        } else if daemon_was_running {
+            restart_daemon(&install_root, &client).await?;
         }
-        copy_dir_recursive(&extracted_web_dist, &dst).context("failed to copy web-dist")?;
+        if daemon_was_running {
+            wait_for_endpoint(&client, "http://127.0.0.1:8787/readyz", "oored").await?;
+        }
+        if web_is_managed {
+            restart_launchd_service(WEB_SERVICE_LABEL)?;
+        } else if web_was_running {
+            anyhow::bail!("refusing to replace an unmanaged local web process; install it as the launchd service first");
+        }
+        if web_was_running {
+            wait_for_endpoint(&client, web_url, "oore-web").await?;
+        }
+        Ok::<(), anyhow::Error>(())
     }
-
-    fs::copy(&extracted_version, install_root.join("VERSION"))
-        .context("failed to copy VERSION file")?;
-    fs::write(install_root.join("CHANNEL"), channel.as_str())
-        .context("failed to write CHANNEL file")?;
-    fs::write(install_root.join("GITHUB_REPO"), &repo)
-        .context("failed to write GITHUB_REPO file")?;
-
-    if extracted_license.exists() {
-        fs::copy(&extracted_license, install_root.join("LICENSE"))
-            .context("failed to copy LICENSE")?;
+    .await;
+    if let Err(error) = update_result {
+        eprintln!("Update failed; restoring the previous release...");
+        let rollback = async {
+            restore_release_snapshot(&install_root, &previous_release)?;
+            if daemon_is_managed {
+                restart_launchd_service(DAEMON_SERVICE_LABEL)?;
+            } else if daemon_was_running {
+                restart_daemon(&install_root, &client).await?;
+            }
+            if web_is_managed && web_was_running {
+                restart_launchd_service(WEB_SERVICE_LABEL)?;
+            }
+            Ok::<(), anyhow::Error>(())
+        }
+        .await;
+        if let Err(rollback_error) = rollback {
+            return Err(error.context(format!("rollback also failed: {rollback_error}")));
+        }
+        return Err(error);
     }
-
-    set_executable(&bin_dir.join("oore"))?;
-    set_executable(&bin_dir.join("oored"))?;
-
     println!("Updated to version {latest}.");
-
-    // 11. Restart daemon if it was running
-    if daemon_was_running {
-        println!("Restarting oored daemon...");
-        restart_daemon(&install_root, &client).await?;
-        println!("Daemon restarted successfully.");
-    }
 
     // 12. Note about current process
     if current != latest {
@@ -3317,6 +3909,11 @@ fn main() -> anyhow::Result<()> {
                 tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
             runtime.block_on(handle_update(args))?;
         }
+        Commands::Backup(args) => match args.command {
+            BackupSubcommand::Create(args) => backup_create(args)?,
+            BackupSubcommand::Verify(args) => backup_verify(args)?,
+            BackupSubcommand::Restore(args) => backup_restore(args)?,
+        },
     }
 
     Ok(())

--- a/crates/oore/tests/cli_unimplemented.rs
+++ b/crates/oore/tests/cli_unimplemented.rs
@@ -42,6 +42,55 @@ fn cleanup_config_path(path: &Path) {
     }
 }
 
+fn temp_dir(name: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("oore-cli-test-{name}-{nanos}"));
+    fs::create_dir_all(&path).expect("create test directory");
+    path
+}
+
+#[test]
+fn backup_create_and_verify_round_trip() {
+    let root = temp_dir("backup");
+    let data_dir = root.join("data");
+    let database = root.join("oore.db");
+    let backup = root.join("backup.tar.gz");
+    fs::create_dir_all(&data_dir).expect("create data directory");
+    fs::write(data_dir.join("encryption.key"), [7u8; 32]).expect("write encryption key");
+
+    let database_arg = database.to_string_lossy().into_owned();
+    let data_dir_arg = data_dir.to_string_lossy().into_owned();
+    let backup_arg = backup.to_string_lossy().into_owned();
+    let setup = run_with_env(
+        &["setup", "token", "--state-file", database_arg.as_str()],
+        &[("OORE_DATA_DIR", data_dir_arg.as_str())],
+    );
+    assert_eq!(setup.status.code(), Some(0));
+
+    let create = run_with_env(
+        &[
+            "backup",
+            "create",
+            "--state-file",
+            database_arg.as_str(),
+            "--output",
+            backup_arg.as_str(),
+        ],
+        &[("OORE_DATA_DIR", data_dir_arg.as_str())],
+    );
+    assert_eq!(create.status.code(), Some(0));
+    assert!(backup.is_file());
+
+    let verify = run(&["backup", "verify", "--input", backup_arg.as_str()]);
+    assert_eq!(verify.status.code(), Some(0));
+    assert!(String::from_utf8_lossy(&verify.stdout).contains("Backup verified"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
 fn http_reason(status: u16) -> &'static str {
     match status {
         200 => "OK",

--- a/crates/oore/tests/cli_unimplemented.rs
+++ b/crates/oore/tests/cli_unimplemented.rs
@@ -185,6 +185,43 @@ fn login_command_surfaces_loopback_rejection() {
 }
 
 #[test]
+fn doctor_accepts_repeatable_platforms_and_reports_json_statuses() {
+    let output = run(&[
+        "doctor",
+        "--platform",
+        "android",
+        "--platform",
+        "ios",
+        "--json",
+    ]);
+    assert!(matches!(output.status.code(), Some(0 | 1)));
+
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("doctor should return JSON");
+    let checks = report["checks"].as_array().expect("checks array");
+    assert!(checks.iter().any(|check| check["name"] == "java"));
+    assert!(checks.iter().any(|check| check["name"] == "android_sdk"));
+    assert!(checks.iter().any(|check| check["name"] == "xcode"));
+    assert!(checks.iter().all(|check| matches!(
+        check["status"].as_str(),
+        Some("ok" | "warning" | "missing" | "skipped")
+    )));
+}
+
+#[test]
+fn doctor_all_includes_each_platform() {
+    let output = run(&["doctor", "--all", "--json"]);
+    assert!(matches!(output.status.code(), Some(0 | 1)));
+
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("doctor should return JSON");
+    let checks = report["checks"].as_array().expect("checks array");
+    assert!(checks.iter().any(|check| check["name"] == "java"));
+    assert!(checks.iter().any(|check| check["name"] == "android_sdk"));
+    assert!(checks.iter().any(|check| check["name"] == "xcode"));
+}
+
+#[test]
 fn config_set_get_round_trip_supported_keys() {
     let config_path = temp_config_path("config-roundtrip");
     let cfg = config_path.to_string_lossy().into_owned();

--- a/crates/oored/migrations/028_artifact_lifecycle.sql
+++ b/crates/oored/migrations/028_artifact_lifecycle.sql
@@ -1,0 +1,14 @@
+ALTER TABLE artifacts ADD COLUMN state TEXT NOT NULL DEFAULT 'available'
+    CHECK (state IN ('pending', 'available', 'failed'));
+ALTER TABLE artifacts ADD COLUMN finalized_at INTEGER;
+ALTER TABLE artifacts ADD COLUMN error_message TEXT;
+
+UPDATE artifacts SET finalized_at = created_at WHERE state = 'available';
+
+DROP INDEX IF EXISTS idx_artifacts_build_id_checksum_unique;
+CREATE UNIQUE INDEX idx_artifacts_build_id_checksum_available
+ON artifacts (build_id, checksum)
+WHERE state = 'available' AND checksum IS NOT NULL AND trim(checksum) <> '';
+
+CREATE INDEX idx_artifacts_pending_created
+ON artifacts (created_at) WHERE state = 'pending';

--- a/crates/oored/src/artifact_tokens.rs
+++ b/crates/oored/src/artifact_tokens.rs
@@ -61,7 +61,7 @@ async fn load_artifact_access(
         "SELECT a.expires_at, b.project_id \
          FROM artifacts a \
          JOIN builds b ON b.id = a.build_id \
-         WHERE a.id = ?1",
+         WHERE a.id = ?1 AND a.state = 'available'",
     )
     .bind(artifact_id)
     .fetch_optional(pool)
@@ -134,6 +134,7 @@ pub async fn validate_download_token(
          FROM artifact_download_tokens t \
          JOIN artifacts a ON a.id = t.artifact_id \
          WHERE t.token_hash = ?1 \
+           AND a.state = 'available' \
            AND t.revoked_at IS NULL \
            AND t.expires_at > ?2 \
            AND (t.single_use = 0 OR t.used_at IS NULL)",

--- a/crates/oored/src/artifacts.rs
+++ b/crates/oored/src/artifacts.rs
@@ -6,8 +6,8 @@ use axum::extract::{Path, State};
 use axum::http::{HeaderValue, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use oore_contract::{
-    ApiError, Artifact, ArtifactDownloadLinkResponse, CreateArtifactRequest,
-    CreateArtifactResponse, ListArtifactsResponse,
+    ApiError, Artifact, ArtifactDownloadLinkResponse, CompleteArtifactRequest,
+    CompleteArtifactResponse, CreateArtifactRequest, CreateArtifactResponse, ListArtifactsResponse,
 };
 use sqlx::Row;
 use tracing::{error, info};
@@ -60,6 +60,7 @@ fn row_to_artifact(row: &sqlx::sqlite::SqliteRow) -> Artifact {
         checksum: row.get("checksum"),
         metadata,
         created_at: row.get("created_at"),
+        state: row.get("state"),
         expires_at: row.get("expires_at"),
     }
 }
@@ -162,7 +163,7 @@ pub async fn create_artifact(
     // This avoids duplicate attachments when the same file is discovered more than once.
     if let Some(checksum_value) = &checksum
         && let Some(existing_row) = sqlx::query(
-            "SELECT * FROM artifacts WHERE build_id = ?1 AND checksum = ?2 \
+            "SELECT * FROM artifacts WHERE build_id = ?1 AND checksum = ?2 AND state = 'available' \
              ORDER BY created_at ASC LIMIT 1",
         )
         .bind(&build_id)
@@ -227,8 +228,8 @@ pub async fn create_artifact(
 
     // Insert artifact row only after URL generation succeeds
     let insert_result = sqlx::query(
-        "INSERT INTO artifacts (id, build_id, name, artifact_type, file_path, file_size, checksum, metadata, created_at, expires_at) \
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+        "INSERT INTO artifacts (id, build_id, name, artifact_type, file_path, file_size, checksum, metadata, created_at, expires_at, state) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 'pending')",
     )
     .bind(&artifact_id)
     .bind(&build_id)
@@ -248,7 +249,7 @@ pub async fn create_artifact(
         if is_unique_constraint(&e)
             && let Some(checksum_value) = &checksum
             && let Some(existing_row) = sqlx::query(
-                "SELECT * FROM artifacts WHERE build_id = ?1 AND checksum = ?2 \
+                "SELECT * FROM artifacts WHERE build_id = ?1 AND checksum = ?2 AND state = 'available' \
                  ORDER BY created_at ASC LIMIT 1",
             )
             .bind(&build_id)
@@ -303,6 +304,7 @@ pub async fn create_artifact(
         checksum,
         metadata: req.metadata,
         created_at: now,
+        state: "pending".to_string(),
         expires_at,
     };
 
@@ -310,6 +312,109 @@ pub async fn create_artifact(
         artifact,
         upload_url,
     }))
+}
+
+async fn finish_artifact(
+    state: Arc<AppState>,
+    runner_id: String,
+    job_id: String,
+    artifact_id: String,
+    runner_auth: RunnerAuth,
+    available: bool,
+    error_message: Option<String>,
+) -> ApiResult<CompleteArtifactResponse> {
+    if runner_auth.runner_id != runner_id {
+        return Err(api_err(
+            StatusCode::FORBIDDEN,
+            "runner_mismatch",
+            "Runner token does not match the requested runner ID",
+        ));
+    }
+    let pool = {
+        let store = state.store.lock().await;
+        store.pool().clone()
+    };
+    let now = now_unix();
+    let new_state = if available { "available" } else { "failed" };
+    let result = sqlx::query(
+        "UPDATE artifacts SET state = ?1, finalized_at = ?2, error_message = ?3 \
+         WHERE id = ?4 AND build_id = ?5 AND state = 'pending' \
+         AND EXISTS (SELECT 1 FROM builds WHERE id = ?5 AND runner_id = ?6)",
+    )
+    .bind(new_state)
+    .bind(now)
+    .bind(error_message.as_deref())
+    .bind(&artifact_id)
+    .bind(&job_id)
+    .bind(&runner_id)
+    .execute(&pool)
+    .await
+    .map_err(|error| {
+        error!(error = %error, artifact_id = %artifact_id, "failed to finalize artifact");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to finalize artifact",
+        )
+    })?;
+    if result.rows_affected() == 0 {
+        return Err(api_err(
+            StatusCode::CONFLICT,
+            "artifact_not_pending",
+            "Artifact is not pending or does not belong to this runner job",
+        ));
+    }
+    let row = sqlx::query("SELECT * FROM artifacts WHERE id = ?1")
+        .bind(&artifact_id)
+        .fetch_one(&pool)
+        .await
+        .map_err(|error| {
+            error!(error = %error, artifact_id = %artifact_id, "failed to load finalized artifact");
+            api_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "store_error",
+                "Failed to load artifact",
+            )
+        })?;
+    Ok(Json(CompleteArtifactResponse {
+        artifact: row_to_artifact(&row),
+    }))
+}
+
+pub async fn complete_artifact(
+    State(state): State<Arc<AppState>>,
+    Path((runner_id, job_id, artifact_id)): Path<(String, String, String)>,
+    runner_auth: RunnerAuth,
+    Json(req): Json<CompleteArtifactRequest>,
+) -> ApiResult<CompleteArtifactResponse> {
+    finish_artifact(
+        state,
+        runner_id,
+        job_id,
+        artifact_id,
+        runner_auth,
+        true,
+        req.error_message,
+    )
+    .await
+}
+
+pub async fn abort_artifact(
+    State(state): State<Arc<AppState>>,
+    Path((runner_id, job_id, artifact_id)): Path<(String, String, String)>,
+    runner_auth: RunnerAuth,
+    Json(req): Json<CompleteArtifactRequest>,
+) -> ApiResult<CompleteArtifactResponse> {
+    finish_artifact(
+        state,
+        runner_id,
+        job_id,
+        artifact_id,
+        runner_auth,
+        false,
+        req.error_message,
+    )
+    .await
 }
 
 /// `GET /v1/builds/{build_id}/artifacts` — list artifacts for a build.
@@ -338,7 +443,7 @@ pub async fn list_artifacts(
         .ok_or_else(|| api_err(StatusCode::NOT_FOUND, "not_found", "Build not found"))?;
     require_project_artifact_read(&pool, &auth, &project_id).await?;
 
-    let rows = sqlx::query("SELECT * FROM artifacts WHERE build_id = ?1 ORDER BY created_at ASC")
+    let rows = sqlx::query("SELECT * FROM artifacts WHERE build_id = ?1 AND state = 'available' ORDER BY created_at ASC")
         .bind(&build_id)
         .fetch_all(&pool)
         .await
@@ -372,7 +477,7 @@ pub async fn generate_download_link(
         "SELECT a.*, b.project_id AS project_id \
          FROM artifacts a \
          JOIN builds b ON b.id = a.build_id \
-         WHERE a.id = ?1",
+         WHERE a.id = ?1 AND a.state = 'available'",
     )
     .bind(&artifact_id)
     .fetch_optional(&pool)

--- a/crates/oored/src/background.rs
+++ b/crates/oored/src/background.rs
@@ -41,7 +41,49 @@ pub fn start_background_tasks(
     tokio::spawn(build_timeout_monitor(pool.clone(), scheduler.clone()));
     tokio::spawn(runner_heartbeat_monitor(pool.clone(), scheduler));
     tokio::spawn(retention_cleanup_monitor(pool.clone(), storage.clone()));
+    tokio::spawn(stale_pending_artifact_monitor(
+        pool.clone(),
+        storage.clone(),
+    ));
     tokio::spawn(expired_artifact_monitor(pool, storage));
+}
+
+async fn stale_pending_artifact_monitor(pool: SqlitePool, storage: Arc<RwLock<StorageBackend>>) {
+    loop {
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        let cutoff = now_unix() - 30 * 60;
+        let rows = match sqlx::query(
+            "SELECT id, file_path FROM artifacts WHERE state = 'pending' AND created_at < ?1",
+        )
+        .bind(cutoff)
+        .fetch_all(&pool)
+        .await
+        {
+            Ok(rows) => rows,
+            Err(error) => {
+                warn!(error = %error, "stale_pending_artifact_monitor: query failed");
+                continue;
+            }
+        };
+        for row in rows {
+            let artifact_id: String = row.get("id");
+            let file_path: String = row.get("file_path");
+            if let Err(error) = storage.read().await.delete_object(&file_path).await {
+                warn!(artifact_id = %artifact_id, error = %error, "stale_pending_artifact_monitor: storage cleanup failed");
+                continue;
+            }
+            if let Err(error) = sqlx::query(
+                "UPDATE artifacts SET state = 'failed', finalized_at = ?1, error_message = 'upload reservation expired' WHERE id = ?2 AND state = 'pending'",
+            )
+            .bind(now_unix())
+            .bind(&artifact_id)
+            .execute(&pool)
+            .await
+            {
+                warn!(artifact_id = %artifact_id, error = %error, "stale_pending_artifact_monitor: state update failed");
+            }
+        }
+    }
 }
 
 /// Monitor assigned builds whose lease has expired.

--- a/crates/oored/src/bin/openapi_export.rs
+++ b/crates/oored/src/bin/openapi_export.rs
@@ -143,6 +143,8 @@ use utoipa::OpenApi;
         paths::create_stream_token,
         // ── Artifacts ──
         paths::create_artifact,
+        paths::complete_artifact,
+        paths::abort_artifact,
         paths::list_artifacts,
         paths::generate_download_link,
         // ── Scoped Download Tokens (OOR-140) ──
@@ -299,6 +301,7 @@ use utoipa::OpenApi;
         oore_contract::RunnerHeartbeatRequest,
         oore_contract::UpdateRunnerRequest,
         oore_contract::UpdateRunnerResponse,
+        oore_contract::ClaimJobRequest,
         oore_contract::ClaimJobResponse,
         oore_contract::ClaimedJob,
         oore_contract::UpdateJobStatusRequest,
@@ -311,6 +314,8 @@ use utoipa::OpenApi;
         oore_contract::Artifact,
         oore_contract::CreateArtifactRequest,
         oore_contract::CreateArtifactResponse,
+        oore_contract::CompleteArtifactRequest,
+        oore_contract::CompleteArtifactResponse,
         oore_contract::ListArtifactsResponse,
         oore_contract::ArtifactDownloadLinkResponse,
         oore_contract::CreateScopedDownloadTokenRequest,
@@ -1573,6 +1578,7 @@ mod paths {
     /// Runner claims the next queued build. Returns `null` job if no builds are available.
     #[utoipa::path(post, path = "/v1/runners/{runner_id}/claim", tag = "Runners",
         params(("runner_id" = String, Path, description = "Runner ID")),
+        request_body = ClaimJobRequest,
         security(("bearer_auth" = [])),
         responses(
             (status = 200, description = "Job claimed (or null)", body = ClaimJobResponse),
@@ -1692,6 +1698,30 @@ mod paths {
         )
     )]
     pub(super) async fn create_artifact() {}
+
+    #[utoipa::path(post, path = "/v1/runners/{runner_id}/jobs/{job_id}/artifacts/{artifact_id}/complete", tag = "Artifacts",
+        params(
+            ("runner_id" = String, Path),
+            ("job_id" = String, Path),
+            ("artifact_id" = String, Path),
+        ),
+        request_body = CompleteArtifactRequest,
+        security(("bearer_auth" = [])),
+        responses((status = 200, body = CompleteArtifactResponse))
+    )]
+    pub(super) async fn complete_artifact() {}
+
+    #[utoipa::path(post, path = "/v1/runners/{runner_id}/jobs/{job_id}/artifacts/{artifact_id}/abort", tag = "Artifacts",
+        params(
+            ("runner_id" = String, Path),
+            ("job_id" = String, Path),
+            ("artifact_id" = String, Path),
+        ),
+        request_body = CompleteArtifactRequest,
+        security(("bearer_auth" = [])),
+        responses((status = 200, body = CompleteArtifactResponse))
+    )]
+    pub(super) async fn abort_artifact() {}
 
     /// List build artifacts
     #[utoipa::path(get, path = "/v1/builds/{build_id}/artifacts", tag = "Artifacts",

--- a/crates/oored/src/builds.rs
+++ b/crates/oored/src/builds.rs
@@ -4,9 +4,9 @@ use axum::Json;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use oore_contract::{
-    ApiError, Build, BuildDetailResponse, BuildEvent, BuildStatus, CancelBuildResponse,
-    ConcurrencyPolicy, CreateBuildRequest, CreateBuildResponse, ListBuildsResponse,
-    PipelineExecutionConfig, RerunBuildResponse, TriggerConfig,
+    ApiError, Build, BuildContext, BuildDetailResponse, BuildEvent, BuildStatus,
+    CancelBuildResponse, ConcurrencyPolicy, CreateBuildRequest, CreateBuildResponse,
+    ListBuildsResponse, PipelineExecutionConfig, RerunBuildResponse, TriggerConfig,
 };
 use serde::Deserialize;
 use sqlx::Row;
@@ -32,6 +32,15 @@ fn row_to_build(row: &sqlx::sqlite::SqliteRow) -> Build {
 
     let step_results_str: Option<String> = row.get("step_results");
     let step_results = step_results_str.and_then(|s| serde_json::from_str(&s).ok());
+    let context = BuildContext {
+        project_name: row.try_get("project_name").ok(),
+        pipeline_name: row.try_get("pipeline_name").ok(),
+        runner_name: row.try_get("runner_name").ok(),
+    };
+    let context = (context.project_name.is_some()
+        || context.pipeline_name.is_some()
+        || context.runner_name.is_some())
+    .then_some(context);
 
     Build {
         id: row.get("id"),
@@ -48,6 +57,7 @@ fn row_to_build(row: &sqlx::sqlite::SqliteRow) -> Build {
         source_build_id: row.get("source_build_id"),
         config_snapshot,
         runner_id: row.get("runner_id"),
+        context,
         step_results,
         exit_code: row.get("exit_code"),
         queued_at: row.get("queued_at"),
@@ -677,6 +687,7 @@ pub async fn create_build(
         source_build_id: None,
         config_snapshot,
         runner_id: None,
+        context: None,
         step_results: None,
         exit_code: None,
         queued_at: now,
@@ -714,19 +725,19 @@ pub async fn list_builds(
     }
     if let Some(ref project_id) = params.project_id {
         bind_values.push(project_id.clone());
-        conditions.push(format!("project_id = ?{}", bind_values.len()));
+        conditions.push(format!("builds.project_id = ?{}", bind_values.len()));
     }
     if let Some(ref pipeline_id) = params.pipeline_id {
         bind_values.push(pipeline_id.clone());
-        conditions.push(format!("pipeline_id = ?{}", bind_values.len()));
+        conditions.push(format!("builds.pipeline_id = ?{}", bind_values.len()));
     }
     if let Some(ref status) = params.status {
         bind_values.push(status.clone());
-        conditions.push(format!("status = ?{}", bind_values.len()));
+        conditions.push(format!("builds.status = ?{}", bind_values.len()));
     }
     if let Some(ref branch) = params.branch {
         bind_values.push(branch.clone());
-        conditions.push(format!("branch = ?{}", bind_values.len()));
+        conditions.push(format!("builds.branch = ?{}", bind_values.len()));
     }
 
     let where_clause = if conditions.is_empty() {
@@ -737,7 +748,12 @@ pub async fn list_builds(
 
     let count_query = format!("SELECT COUNT(*) FROM builds {where_clause}");
     let list_query = format!(
-        "SELECT * FROM builds {where_clause} ORDER BY created_at DESC LIMIT ?{} OFFSET ?{}",
+        "SELECT builds.*, projects.name AS project_name, pipelines.name AS pipeline_name, runners.name AS runner_name \
+         FROM builds \
+         LEFT JOIN projects ON projects.id = builds.project_id \
+         LEFT JOIN pipelines ON pipelines.id = builds.pipeline_id \
+         LEFT JOIN runners ON runners.id = builds.runner_id \
+         {where_clause} ORDER BY builds.created_at DESC LIMIT ?{} OFFSET ?{}",
         bind_values.len() + 1,
         bind_values.len() + 2
     );
@@ -779,7 +795,14 @@ pub async fn get_build(
     let store = state.store.lock().await;
     let pool = store.pool();
 
-    let build_row = sqlx::query("SELECT * FROM builds WHERE id = ?1")
+    let build_row = sqlx::query(
+        "SELECT builds.*, projects.name AS project_name, pipelines.name AS pipeline_name, runners.name AS runner_name \
+         FROM builds \
+         LEFT JOIN projects ON projects.id = builds.project_id \
+         LEFT JOIN pipelines ON pipelines.id = builds.pipeline_id \
+         LEFT JOIN runners ON runners.id = builds.runner_id \
+         WHERE builds.id = ?1",
+    )
         .bind(&build_id)
         .fetch_optional(pool)
         .await
@@ -1067,6 +1090,7 @@ pub async fn rerun_build(
         source_build_id: Some(build_id),
         config_snapshot,
         runner_id: None,
+        context: None,
         step_results: None,
         exit_code: None,
         queued_at: now,
@@ -1302,6 +1326,7 @@ pub async fn trigger_build_from_webhook(
                 source_build_id: None,
                 config_snapshot,
                 runner_id: None,
+                context: None,
                 step_results: None,
                 exit_code: None,
                 queued_at: now,

--- a/crates/oored/src/instance_settings.rs
+++ b/crates/oored/src/instance_settings.rs
@@ -1928,16 +1928,10 @@ pub async fn update_instance_preferences(
         preflight_result = Some(result);
     }
 
-    let active_source =
-        crypto::persist_current_key_for_mode(state.encryption_key.as_ref(), KeyStorageMode::File)
-            .map_err(|e| {
-            error!(error = %e, mode = %KeyStorageMode::File, "failed to persist key storage mode");
-            api_err(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "key_storage_error",
-                "Failed to persist key storage mode",
-            )
-        })?;
+    // File mode is the only supported mode in this release. The runtime key was
+    // already loaded from (or created in) file storage during daemon startup, so
+    // updating unrelated preferences must not rewrite it through a global path.
+    let active_source = crypto::KeySource::LegacyFile;
 
     sqlx::query(
         "INSERT INTO instance_preferences (id, key_storage_mode, runtime_mode, remote_auth_mode, updated_by, created_at, updated_at)

--- a/crates/oored/src/lib.rs
+++ b/crates/oored/src/lib.rs
@@ -2410,6 +2410,14 @@ async fn build_router_inner(
             post(artifacts::create_artifact),
         )
         .route(
+            "/v1/runners/{runner_id}/jobs/{job_id}/artifacts/{artifact_id}/complete",
+            post(artifacts::complete_artifact),
+        )
+        .route(
+            "/v1/runners/{runner_id}/jobs/{job_id}/artifacts/{artifact_id}/abort",
+            post(artifacts::abort_artifact),
+        )
+        .route(
             "/v1/builds/{build_id}/artifacts",
             get(artifacts::list_artifacts),
         )

--- a/crates/oored/src/lib.rs
+++ b/crates/oored/src/lib.rs
@@ -485,6 +485,31 @@ async fn healthz() -> Json<serde_json::Value> {
     Json(metadata)
 }
 
+/// Liveness is intentionally independent of SQLite so a process which can
+/// accept requests remains observable while a dependency is being repaired.
+async fn readyz(State(state): State<Arc<AppState>>) -> (StatusCode, Json<serde_json::Value>) {
+    let db_ready = {
+        let store = state.store.lock().await;
+        sqlx::query("SELECT 1").execute(store.pool()).await.is_ok()
+    };
+    let encryption_ready = state.encryption_key.len() == 32;
+    let ready = db_ready && encryption_ready;
+    (
+        if ready {
+            StatusCode::OK
+        } else {
+            StatusCode::SERVICE_UNAVAILABLE
+        },
+        Json(json!({
+            "ok": ready,
+            "database": db_ready,
+            // Migrations and the runtime key are completed before the router is built.
+            "migrations": db_ready,
+            "encryption": encryption_ready,
+        })),
+    )
+}
+
 async fn setup_status(State(state): State<Arc<AppState>>) -> ApiResult<SetupStatus> {
     let store = state.store.lock().await;
     let sf = store.load().await.map_err(|e| {
@@ -2113,6 +2138,7 @@ async fn build_router_inner(
 
     Router::new()
         .route("/healthz", get(healthz))
+        .route("/readyz", get(readyz))
         .route("/v1/public/setup-status", get(setup_status))
         .route(
             "/v1/setup/bootstrap-token/verify",

--- a/crates/oored/src/pipelines.rs
+++ b/crates/oored/src/pipelines.rs
@@ -8,6 +8,7 @@ use oore_contract::{
     ApiError, BuildPlatform, ConcurrencyPolicy, CreatePipelineRequest, CreatePipelineResponse,
     ListPipelinesResponse, Pipeline, PipelineDetailResponse, PipelineExecutionConfig,
     TriggerConfig, UpdatePipelineRequest, ValidatePipelineRequest, ValidatePipelineResponse,
+    parse_repository_pipeline_yaml, validate_artifact_pattern,
 };
 use serde::Deserialize;
 use sqlx::Row;
@@ -174,13 +175,8 @@ fn validate_execution_config(cfg: &PipelineExecutionConfig) -> Vec<String> {
     }
 
     for (idx, pattern) in cfg.artifact_patterns.iter().enumerate() {
-        let trimmed = pattern.trim();
-        let looks_like_ext_glob = trimmed.starts_with("*.") && trimmed.len() > 2;
-        let has_whitespace = trimmed.chars().any(char::is_whitespace);
-        if !looks_like_ext_glob || has_whitespace {
-            errors.push(format!(
-                "execution_config.artifact_patterns[{idx}] must be extension globs like '*.apk'"
-            ));
+        if let Err(error) = validate_artifact_pattern(pattern) {
+            errors.push(format!("execution_config.artifact_patterns[{idx}] {error}"));
         }
     }
 
@@ -988,6 +984,11 @@ pub async fn validate_pipeline(
 
     if let Some(ref cfg) = req.execution_config {
         errors.extend(validate_execution_config(cfg));
+    }
+    if let Some(ref yaml) = req.repository_yaml
+        && let Err(error) = parse_repository_pipeline_yaml(yaml)
+    {
+        errors.extend(error.lines().map(str::to_string));
     }
 
     let valid = errors.is_empty();

--- a/crates/oored/src/runners.rs
+++ b/crates/oored/src/runners.rs
@@ -5,10 +5,10 @@ use axum::extract::{FromRequestParts, Path, State};
 use axum::http::StatusCode;
 use axum::http::request::Parts;
 use oore_contract::{
-    ApiError, BuildDetailResponse, BuildEvent, BuildStatus, ClaimJobResponse, ClaimedJob,
-    JobStatusResponse, ListRunnersResponse, RegisterRunnerRequest, RegisterRunnerResponse, Runner,
-    RunnerHeartbeatRequest, RunnerStatus, UpdateJobStatusRequest, UpdateRunnerRequest,
-    UpdateRunnerResponse,
+    ApiError, BuildDetailResponse, BuildEvent, BuildStatus, ClaimJobRequest, ClaimJobResponse,
+    ClaimedJob, JobStatusResponse, ListRunnersResponse, RUNNER_PROTOCOL_VERSION,
+    RegisterRunnerRequest, RegisterRunnerResponse, Runner, RunnerHeartbeatRequest, RunnerStatus,
+    UpdateJobStatusRequest, UpdateRunnerRequest, UpdateRunnerResponse,
 };
 use sqlx::Row;
 use tracing::{error, info, warn};
@@ -268,12 +268,23 @@ pub async fn claim_job(
     State(state): State<Arc<AppState>>,
     Path(runner_id): Path<String>,
     runner_auth: RunnerAuth,
+    Json(req): Json<ClaimJobRequest>,
 ) -> ApiResult<ClaimJobResponse> {
     if runner_auth.runner_id != runner_id {
         return Err(api_err(
             StatusCode::FORBIDDEN,
             "runner_mismatch",
             "Runner token does not match the requested runner ID",
+        ));
+    }
+    if req.protocol_version != RUNNER_PROTOCOL_VERSION {
+        return Err(api_err(
+            StatusCode::CONFLICT,
+            "runner_protocol_mismatch",
+            format!(
+                "Runner protocol {} is unsupported; expected {}",
+                req.protocol_version, RUNNER_PROTOCOL_VERSION
+            ),
         ));
     }
 

--- a/crates/oored/tests/artifact_storage_settings_integration.rs
+++ b/crates/oored/tests/artifact_storage_settings_integration.rs
@@ -86,6 +86,29 @@ async fn seed_running_build(
     build_id
 }
 
+async fn complete_artifact(
+    app: &axum::Router,
+    runner_id: &str,
+    runner_token: &str,
+    build_id: &str,
+    artifact_id: &str,
+) {
+    let req = Request::builder()
+        .uri(format!(
+            "/v1/runners/{runner_id}/jobs/{build_id}/artifacts/{artifact_id}/complete"
+        ))
+        .method("POST")
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .header(
+            http::header::AUTHORIZATION,
+            format!("Bearer {runner_token}"),
+        )
+        .body(Body::from("{}"))
+        .unwrap();
+    let response = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
 #[tokio::test]
 async fn test_owner_can_configure_local_storage_and_download_artifact() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -160,6 +183,7 @@ async fn test_owner_can_configure_local_storage_and_download_artifact() {
     assert_eq!(resp.status(), StatusCode::OK);
 
     let artifact_id = create_json["artifact"]["id"].as_str().unwrap();
+    complete_artifact(&app, &runner_id, &runner_token, &build_id, artifact_id).await;
     let req = Request::builder()
         .uri(format!("/v1/artifacts/{artifact_id}/download-link"))
         .method("POST")
@@ -263,6 +287,7 @@ async fn test_local_storage_large_artifact_upload_download() {
     assert_eq!(resp.status(), StatusCode::OK);
 
     let artifact_id = create_json["artifact"]["id"].as_str().unwrap();
+    complete_artifact(&app, &runner_id, &runner_token, &build_id, artifact_id).await;
     let req = Request::builder()
         .uri(format!("/v1/artifacts/{artifact_id}/download-link"))
         .method("POST")

--- a/crates/oored/tests/logs_artifacts_integration.rs
+++ b/crates/oored/tests/logs_artifacts_integration.rs
@@ -179,6 +179,24 @@ async fn full_scaffold() -> (
     (app, pool, session_token, runner_id, runner_token, build_id)
 }
 
+async fn complete_artifact(
+    app: &axum::Router,
+    runner_id: &str,
+    runner_token: &str,
+    build_id: &str,
+    artifact_id: &str,
+) {
+    let (status, _) = json_request(
+        app,
+        "POST",
+        &format!("/v1/runners/{runner_id}/jobs/{build_id}/artifacts/{artifact_id}/complete"),
+        runner_token,
+        Some(serde_json::json!({})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+}
+
 // ── Log ingestion tests ─────────────────────────────────────────
 
 #[tokio::test]
@@ -470,6 +488,7 @@ async fn test_non_member_cannot_read_build_logs_or_artifacts() {
     assert_eq!(resp.status(), StatusCode::OK);
     let artifact_json = body_json(resp.into_body()).await;
     let artifact_id = artifact_json["artifact"]["id"].as_str().unwrap();
+    complete_artifact(&app, &runner_id, &runner_token, &build_id, artifact_id).await;
 
     let (status, owner_token_json) = json_request(
         &app,
@@ -653,6 +672,7 @@ async fn test_create_artifact() {
     assert!(artifact["build_id"].as_str().is_some());
     // upload_url should be empty when S3 is not configured
     assert_eq!(json["upload_url"].as_str().unwrap(), "");
+    assert_eq!(artifact["state"].as_str(), Some("pending"));
 }
 
 #[tokio::test]
@@ -762,6 +782,7 @@ async fn test_create_artifact_checksum_dedup() {
     assert_eq!(resp.status(), StatusCode::OK);
     let first_json = body_json(resp.into_body()).await;
     let first_id = first_json["artifact"]["id"].as_str().unwrap().to_string();
+    complete_artifact(&app, &runner_id, &runner_token, &build_id, &first_id).await;
 
     let body = serde_json::json!({
         "name": "release-copy.apk",
@@ -834,6 +855,15 @@ async fn test_list_artifacts() {
 
         let resp = app.clone().oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+        let json = body_json(resp.into_body()).await;
+        complete_artifact(
+            &app,
+            &runner_id,
+            &runner_token,
+            &build_id,
+            json["artifact"]["id"].as_str().unwrap(),
+        )
+        .await;
     }
 
     // List artifacts
@@ -906,6 +936,7 @@ async fn test_download_link_no_storage() {
     assert_eq!(resp.status(), StatusCode::OK);
     let create_json = body_json(resp.into_body()).await;
     let artifact_id = create_json["artifact"]["id"].as_str().unwrap();
+    complete_artifact(&app, &runner_id, &runner_token, &build_id, artifact_id).await;
 
     // Request download link — should fail because S3 is not configured
     let req = Request::builder()
@@ -998,6 +1029,15 @@ async fn test_full_log_and_artifact_flow() {
 
     let resp = app.clone().oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
+    let artifact_json = body_json(resp.into_body()).await;
+    complete_artifact(
+        &app,
+        &runner_id,
+        &runner_token,
+        &build_id,
+        artifact_json["artifact"]["id"].as_str().unwrap(),
+    )
+    .await;
 
     // 3. Operator fetches logs
     let req = Request::builder()

--- a/crates/oored/tests/logs_artifacts_integration.rs
+++ b/crates/oored/tests/logs_artifacts_integration.rs
@@ -200,6 +200,29 @@ async fn complete_artifact(
 // ── Log ingestion tests ─────────────────────────────────────────
 
 #[tokio::test]
+async fn test_build_list_and_detail_include_display_context() {
+    let (app, _pool, session_token, _runner_id, _runner_token, build_id) = full_scaffold().await;
+
+    let (status, list) = json_request(&app, "GET", "/v1/builds", &session_token, None).await;
+    assert_eq!(status, StatusCode::OK);
+    let build = &list["builds"][0];
+    assert_eq!(build["context"]["project_name"], "Test Project");
+    assert_eq!(build["context"]["pipeline_name"], "Default");
+    assert_eq!(build["context"]["runner_name"], "test-runner");
+
+    let (status, detail) = json_request(
+        &app,
+        "GET",
+        &format!("/v1/builds/{build_id}"),
+        &session_token,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(detail["build"]["context"], build["context"]);
+}
+
+#[tokio::test]
 async fn test_append_build_logs() {
     let (app, _pool, _session_token, runner_id, runner_token, build_id) = full_scaffold().await;
 

--- a/crates/oored/tests/runner_integration.rs
+++ b/crates/oored/tests/runner_integration.rs
@@ -256,7 +256,8 @@ async fn test_runner_claim_empty_queue() {
             http::header::AUTHORIZATION,
             format!("Bearer {runner_token}"),
         )
-        .body(Body::empty())
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(Body::from(r#"{"protocol_version":2}"#))
         .unwrap();
 
     let resp = app.clone().oneshot(req).await.unwrap();
@@ -298,7 +299,8 @@ async fn test_runner_claim_and_execute() {
             http::header::AUTHORIZATION,
             format!("Bearer {runner_token}"),
         )
-        .body(Body::empty())
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(Body::from(r#"{"protocol_version":2}"#))
         .unwrap();
 
     let resp = app.clone().oneshot(req).await.unwrap();
@@ -391,7 +393,8 @@ async fn test_no_double_claim() {
             http::header::AUTHORIZATION,
             format!("Bearer {runner1_token}"),
         )
-        .body(Body::empty())
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(Body::from(r#"{"protocol_version":2}"#))
         .unwrap();
 
     let resp1 = app.clone().oneshot(req1).await.unwrap();
@@ -406,7 +409,8 @@ async fn test_no_double_claim() {
             http::header::AUTHORIZATION,
             format!("Bearer {runner2_token}"),
         )
-        .body(Body::empty())
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(Body::from(r#"{"protocol_version":2}"#))
         .unwrap();
 
     let resp2 = app.clone().oneshot(req2).await.unwrap();
@@ -421,6 +425,30 @@ async fn test_no_double_claim() {
         got_job_1 ^ got_job_2,
         "exactly one runner should get the job: runner1={got_job_1}, runner2={got_job_2}"
     );
+}
+
+#[tokio::test]
+async fn test_incompatible_runner_cannot_claim() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let db_path = tmp.path().join("test.db");
+    let app = create_test_app(&db_path).await;
+    let pool = connect_pool(&db_path).await;
+    let user_id = seed_test_user(&pool).await;
+    let session_token = create_session_token(&pool, &user_id).await;
+    let (runner_id, runner_token) = register_runner(&app, &session_token, "old-runner").await;
+
+    let request = Request::builder()
+        .uri(format!("/v1/runners/{runner_id}/claim"))
+        .method("POST")
+        .header(
+            http::header::AUTHORIZATION,
+            format!("Bearer {runner_token}"),
+        )
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(Body::from(r#"{"protocol_version":1}"#))
+        .unwrap();
+    let response = app.clone().oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::CONFLICT);
 }
 
 #[tokio::test]

--- a/crates/oored/tests/setup_integration.rs
+++ b/crates/oored/tests/setup_integration.rs
@@ -565,6 +565,29 @@ async fn test_healthz() {
     assert_eq!(body["ok"], true);
 }
 
+#[tokio::test]
+async fn test_readyz_reports_runtime_dependencies() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let db_path = tmp.path().join("oore.db");
+    let app = create_test_app(&db_path).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/readyz")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let body = body_json(resp).await;
+    assert_eq!(body["database"], true);
+    assert_eq!(body["migrations"], true);
+    assert_eq!(body["encryption"], true);
+}
+
 // ── Bootstrap token edge cases ──────────────────────────────────
 
 #[tokio::test]

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -12,6 +12,11 @@ Rules:
 
 ## 2026-05-22
 
+- **Product trust hardening: local-first installer and operator diagnostics**:
+  - Default macOS installation now installs and starts the loopback daemon and local web UI as launch-at-login services, opens the local web root for interactive installs, and relies on loopback local login instead of bootstrap tokens or `/setup` routing. Split and remote topology choices remain available through `scripts/install.sh --advanced`; `--no-open` and `OORE_OPEN_BROWSER` control browser opening.
+  - `oore doctor` now separates core runner requirements from repeatable Android, iOS, and macOS platform checks. Java, Android SDK, and Xcode checks are target-specific; signing and notarization are warnings rather than release-runner blockers; JSON statuses are explicit.
+  - Linear feature doc: https://linear.app/oorebuild/document/feature-product-trust-hardening-release-592dfc525e77
+
 - **Frontend guided setup hints**:
   - Builds empty state now spaces and aligns first-run actions consistently and explains the shortest path from source/project setup to the first build.
   - Source setup screens now surface GitHub App access, GitLab PAT scopes, webhook secret placement, built-in CI variables, and Android/iOS signing project hints directly in the UI.

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -10,9 +10,11 @@ Rules:
 - Any code change under `apps/`, `crates/`, `tools/`, etc. must add an entry here.
 - Include a Linear issue/doc link for each entry.
 
-## 2026-05-22
+## 2026-07-12
 
 - **Product trust hardening release**:
+  - Repository YAML now uses one strict parser across runner execution, daemon validation, and `oore pipeline validate`; repository YAML no longer accepts trigger/concurrency fields and artifact globs are safe workspace-relative patterns.
+  - Runner protocol v2 prevents old runners from claiming work and adds artifact reservation, upload, completion/abort, pending visibility, stale cleanup, required-artifact failure, and `.app` bundle packaging.
   - Default macOS installation now installs and starts the loopback daemon and local web UI as launch-at-login services, opens the local web root for interactive installs, and relies on loopback local login instead of bootstrap tokens or `/setup` routing. Split and remote topology choices remain available through `scripts/install.sh --advanced`; `--no-open` and `OORE_OPEN_BROWSER` control browser opening.
   - `oore doctor` now separates core runner requirements from repeatable Android, iOS, and macOS platform checks. Java, Android SDK, and Xcode checks are target-specific; signing and notarization are warnings rather than release-runner blockers; JSON statuses are explicit.
   - Added liveness-only `/healthz` and dependency-aware `/readyz`; added verified `oore backup create|verify|restore`; and made `oore update` stage, back up, atomically replace, verify, and roll back installed releases while preserving managed service state.
@@ -22,6 +24,8 @@ Rules:
   - Builds show project context globally and accept optional named project/pipeline/runner context from the backend; terminal details prioritize failure reasons, failed steps, final-log states, and status-appropriate artifact empty states.
   - The hosted demo is explicitly sample-data, read-only UI: common build/project/pipeline mutations are visibly disabled and the API guard rejects all other mutations without returning fake success.
   - Linear feature doc: https://linear.app/oorebuild/document/feature-product-trust-hardening-release-592dfc525e77
+
+## 2026-05-22
 
 - **Frontend guided setup hints**:
   - Builds empty state now spaces and aligns first-run actions consistently and explains the shortest path from source/project setup to the first build.

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -12,10 +12,12 @@ Rules:
 
 ## 2026-05-22
 
-- **Product trust hardening: local-first installer and operator diagnostics**:
+- **Product trust hardening release**:
   - Default macOS installation now installs and starts the loopback daemon and local web UI as launch-at-login services, opens the local web root for interactive installs, and relies on loopback local login instead of bootstrap tokens or `/setup` routing. Split and remote topology choices remain available through `scripts/install.sh --advanced`; `--no-open` and `OORE_OPEN_BROWSER` control browser opening.
   - `oore doctor` now separates core runner requirements from repeatable Android, iOS, and macOS platform checks. Java, Android SDK, and Xcode checks are target-specific; signing and notarization are warnings rather than release-runner blockers; JSON statuses are explicit.
-  - Linear feature doc: https://linear.app/oorebuild/document/feature-product-trust-hardening-release-592dfc525e77
+  - Added liveness-only `/healthz` and dependency-aware `/readyz`; added verified `oore backup create|verify|restore`; and made `oore update` stage, back up, atomically replace, verify, and roll back installed releases while preserving managed service state.
+  - Validation now covers master/alpha/beta/stable, release-tooling paths, and only runs autotag after Validate succeeds for the exact pushed commit.
+  - Feature doc: https://linear.app/oorebuild/document/feature-product-trust-hardening-release-592dfc525e77
 
 - **Frontend guided setup hints**:
   - Builds empty state now spaces and aligns first-run actions consistently and explains the shortest path from source/project setup to the first build.

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -19,6 +19,7 @@ Rules:
   - `oore doctor` now separates core runner requirements from repeatable Android, iOS, and macOS platform checks. Java, Android SDK, and Xcode checks are target-specific; signing and notarization are warnings rather than release-runner blockers; JSON statuses are explicit.
   - Added liveness-only `/healthz` and dependency-aware `/readyz`; added verified `oore backup create|verify|restore`; and made `oore update` stage, back up, atomically replace, verify, and roll back installed releases while preserving managed service state.
   - Validation now covers master/alpha/beta/stable, release-tooling paths, and only runs autotag after Validate succeeds for the exact pushed commit.
+  - Release smoke now exercises updater snapshot/install/rollback restoration, and build list/detail responses include project, pipeline, and runner display context for truthful operator UI.
   - Quick Debug APK pipelines now explicitly run `flutter build apk --debug`, and generated defaults use Flutter's real Android, iOS, and macOS output paths.
   - Pipeline creation preserves a successful create when a later signing request fails, then routes to a signing-only retry with the failed signing section expanded.
   - Builds show project context globally and accept optional named project/pipeline/runner context from the backend; terminal details prioritize failure reasons, failed steps, final-log states, and status-appropriate artifact empty states.

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -17,7 +17,11 @@ Rules:
   - `oore doctor` now separates core runner requirements from repeatable Android, iOS, and macOS platform checks. Java, Android SDK, and Xcode checks are target-specific; signing and notarization are warnings rather than release-runner blockers; JSON statuses are explicit.
   - Added liveness-only `/healthz` and dependency-aware `/readyz`; added verified `oore backup create|verify|restore`; and made `oore update` stage, back up, atomically replace, verify, and roll back installed releases while preserving managed service state.
   - Validation now covers master/alpha/beta/stable, release-tooling paths, and only runs autotag after Validate succeeds for the exact pushed commit.
-  - Feature doc: https://linear.app/oorebuild/document/feature-product-trust-hardening-release-592dfc525e77
+  - Quick Debug APK pipelines now explicitly run `flutter build apk --debug`, and generated defaults use Flutter's real Android, iOS, and macOS output paths.
+  - Pipeline creation preserves a successful create when a later signing request fails, then routes to a signing-only retry with the failed signing section expanded.
+  - Builds show project context globally and accept optional named project/pipeline/runner context from the backend; terminal details prioritize failure reasons, failed steps, final-log states, and status-appropriate artifact empty states.
+  - The hosted demo is explicitly sample-data, read-only UI: common build/project/pipeline mutations are visibly disabled and the API guard rejects all other mutations without returning fake success.
+  - Linear feature doc: https://linear.app/oorebuild/document/feature-product-trust-hardening-release-592dfc525e77
 
 - **Frontend guided setup hints**:
   - Builds empty state now spaces and aligns first-run actions consistently and explains the shortest path from source/project setup to the first build.

--- a/scripts/install-acceptance.sh
+++ b/scripts/install-acceptance.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Load installer functions without running main or reaching the network.
+INSTALLER_LIB="$(mktemp)"
+trap 'rm -f "$INSTALLER_LIB"' EXIT
+sed '$d' "$ROOT_DIR/scripts/install.sh" > "$INSTALLER_LIB"
+# shellcheck disable=SC1090
+source "$INSTALLER_LIB"
+
+OORE_ADVANCED=0
+OORE_INSTALL_MODE=auto
+RELEASE_OS=darwin
+configure_install_mode
+[[ "$OORE_INSTALL_MODE" == "all" ]]
+
+OORE_DAEMON_LISTEN=""
+OORE_DAEMON_URL="http://127.0.0.1:8787"
+DAEMON_URL="$OORE_DAEMON_URL"
+OORE_INSTALL_DAEMON_SERVICE=""
+OORE_START_DAEMON=""
+configure_backend_install
+[[ "$OORE_DAEMON_LISTEN" == "127.0.0.1:8787" ]]
+[[ "$OORE_INSTALL_DAEMON_SERVICE" == "true" ]]
+[[ "$OORE_START_DAEMON" == "true" ]]
+
+OORE_LOCAL_WEB_MODE=""
+OORE_LOCAL_WEB_LISTEN=""
+configure_frontend_install
+[[ "$OORE_LOCAL_WEB_LISTEN" == "127.0.0.1:4173" ]]
+[[ "$OORE_LOCAL_WEB_MODE" == "login" ]]
+
+OORE_NONINTERACTIVE=1
+OORE_OPEN_BROWSER=""
+OORE_NO_OPEN=0
+! should_open_browser
+OORE_OPEN_BROWSER=true
+should_open_browser
+OORE_NO_OPEN=1
+! should_open_browser
+
+echo "[install-acceptance] passed"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,6 +16,7 @@ OORE_RELEASE_BASE_URL="${OORE_RELEASE_BASE_URL:-https://github.com/$OORE_GITHUB_
 OORE_RELEASE_MANIFEST_URL="${OORE_RELEASE_MANIFEST_URL:-https://api.github.com/repos/$OORE_GITHUB_REPO/releases/latest}"
 OORE_RELEASES_LIST_URL="${OORE_RELEASES_LIST_URL:-https://api.github.com/repos/$OORE_GITHUB_REPO/releases?per_page=100}"
 OORE_NONINTERACTIVE="${OORE_NONINTERACTIVE:-0}"
+OORE_OPEN_BROWSER="${OORE_OPEN_BROWSER:-}"
 OORE_START_DAEMON="${OORE_START_DAEMON:-}"
 OORE_INSTALL_DAEMON_SERVICE="${OORE_INSTALL_DAEMON_SERVICE:-}"
 OORE_DAEMON_LISTEN="${OORE_DAEMON_LISTEN:-}"
@@ -72,6 +73,8 @@ UI_ACCENT=""
 UI_SUCCESS=""
 UI_WARNING=""
 UI_ERROR=""
+OORE_ADVANCED=0
+OORE_NO_OPEN=0
 
 print_help() {
   cat <<'EOF'
@@ -79,6 +82,8 @@ Oore CI installer
 
 Usage:
   ./scripts/install.sh
+  ./scripts/install.sh --advanced
+  ./scripts/install.sh --no-open
   ./scripts/install.sh --help
 
 Environment overrides:
@@ -87,6 +92,7 @@ Environment overrides:
   OORE_INSTALL_MODE          Install mode: auto|all|backend|frontend (default: auto; full is a legacy alias for all)
   OORE_INSTALL_ROOT          Install root (default: ~/.oore)
   OORE_NONINTERACTIVE        Non-interactive mode (true/false)
+  OORE_OPEN_BROWSER          Open the local web root after install (true/false; defaults to true only for interactive local installs)
   OORE_DAEMON_LISTEN         Daemon listen address for all/backend installs (default: from OORE_DAEMON_URL)
   OORE_START_DAEMON          Start daemon in non-interactive mode (true/false)
   OORE_INSTALL_DAEMON_SERVICE Install oored as a launchd service in all/backend mode (true/false)
@@ -113,6 +119,32 @@ Environment overrides:
   OORE_RELEASE_MANIFEST_URL  Release metadata URL for latest tag resolution (default: GitHub Releases API)
   OORE_RELEASES_LIST_URL     Release list URL for prerelease channel resolution (default: GitHub Releases API list)
 EOF
+}
+
+is_default_local_install() {
+  [[ "$RELEASE_OS" == "darwin" && "$OORE_ADVANCED" -eq 0 && "$OORE_INSTALL_MODE" == "all" ]]
+}
+
+should_open_browser() {
+  [[ "$OORE_NO_OPEN" -eq 0 ]] || return 1
+
+  if [[ -n "$OORE_OPEN_BROWSER" ]]; then
+    normalize_bool "$OORE_OPEN_BROWSER"
+    return $?
+  fi
+
+  ! is_noninteractive
+}
+
+report_component_failure() {
+  local component="$1"
+  local log_path="$2"
+  local retry_command="$3"
+  local expected_url="$4"
+
+  log "$component failed. Logs: $log_path"
+  log "Retry: $retry_command"
+  log "Expected URL: $expected_url"
 }
 
 step() {
@@ -713,6 +745,11 @@ normalize_runtime_config() {
 configure_install_mode() {
   normalize_install_mode
 
+  if [[ "$OORE_ADVANCED" -eq 0 && "$RELEASE_OS" == "darwin" ]]; then
+    OORE_INSTALL_MODE="all"
+    return 0
+  fi
+
   if [[ "$OORE_INSTALL_MODE" == "auto" ]]; then
     case "$RELEASE_OS" in
       linux)
@@ -749,6 +786,17 @@ configure_backend_install() {
     OORE_DAEMON_LISTEN="$(url_to_host_port "$DAEMON_URL")"
   fi
   [[ -n "$OORE_DAEMON_LISTEN" ]] || OORE_DAEMON_LISTEN="127.0.0.1:8787"
+
+  if is_default_local_install; then
+    OORE_DAEMON_LISTEN="127.0.0.1:8787"
+    OORE_DAEMON_URL="http://127.0.0.1:8787"
+    DAEMON_URL="$OORE_DAEMON_URL"
+    OORE_WEB_BACKEND_URL="$DAEMON_URL"
+    WEB_BACKEND_URL="$DAEMON_URL"
+    OORE_INSTALL_DAEMON_SERVICE=true
+    OORE_START_DAEMON=true
+    return 0
+  fi
 
   if ! is_noninteractive && has_prompt_tty; then
     local listen_default="$OORE_DAEMON_LISTEN"
@@ -828,9 +876,17 @@ configure_backend_install() {
 }
 
 configure_frontend_install() {
-  [[ "$OORE_INSTALL_MODE" == "frontend" ]] || return 0
+  is_web_install || return 0
 
-  if ! is_noninteractive && has_prompt_tty; then
+  if is_default_local_install; then
+    OORE_LOCAL_WEB_LISTEN="127.0.0.1:4173"
+    OORE_LOCAL_WEB_MODE=login
+    WEB_BACKEND_URL="$DAEMON_URL"
+    resolve_local_web_url
+    return 0
+  fi
+
+  if [[ "$OORE_INSTALL_MODE" == "frontend" ]] && ! is_noninteractive && has_prompt_tty; then
     local backend_default="$WEB_BACKEND_URL"
     if [[ "$OORE_WEB_BACKEND_URL_WAS_SET" -eq 0 && "$OORE_DAEMON_URL_WAS_SET" -eq 0 ]]; then
       backend_default=""
@@ -906,11 +962,13 @@ configure_frontend_install() {
         )"
       fi
     fi
-  else
+  elif [[ "$OORE_INSTALL_MODE" == "frontend" ]]; then
     if [[ "$OORE_WEB_BACKEND_URL_WAS_SET" -eq 0 && "$OORE_DAEMON_URL_WAS_SET" -eq 0 ]]; then
       die 'Frontend-only non-interactive install requires OORE_WEB_BACKEND_URL, for example http://<backend-host>:8787.'
     fi
   fi
+
+  [[ "$OORE_INSTALL_MODE" == "frontend" ]] || return 0
 
   ensure_frontend_secret_files
   WEB_BACKEND_URL="$OORE_WEB_BACKEND_URL"
@@ -919,6 +977,8 @@ configure_frontend_install() {
 
 configure_setup_prefill() {
   is_daemon_install || return 0
+
+  is_default_local_install && return 0
 
   if ! is_noninteractive && has_prompt_tty; then
     print_prompt_section \
@@ -1377,7 +1437,11 @@ start_daemon() {
     return 0
   fi
 
-  log "Daemon failed to start. Check logs: $DAEMON_LOG"
+  report_component_failure \
+    "oored" \
+    "$DAEMON_LOG" \
+    "$BIN_DIR/oored run --listen $OORE_DAEMON_LISTEN" \
+    "$DAEMON_URL/healthz"
   return 1
 }
 
@@ -1392,7 +1456,14 @@ install_daemon_service() {
   fi
   cmd+=("--env" "RUST_LOG=${RUST_LOG:-info}")
 
-  "${cmd[@]}" || return 1
+  if ! "${cmd[@]}"; then
+    report_component_failure \
+      "oored launchd service" \
+      "$DAEMON_LOG" \
+      "$BIN_DIR/oored install-service --listen $OORE_DAEMON_LISTEN" \
+      "$DAEMON_URL/healthz"
+    return 1
+  fi
 
   local i
   for i in $(seq 1 15); do
@@ -1404,6 +1475,15 @@ install_daemon_service() {
     fi
     sleep 1
   done
+
+  if is_default_local_install; then
+    report_component_failure \
+      "oored launchd service" \
+      "$DAEMON_LOG" \
+      "$BIN_DIR/oored install-service --listen $OORE_DAEMON_LISTEN" \
+      "$DAEMON_URL/healthz"
+    return 1
+  fi
 
   log "Daemon service was installed, but this host could not reach $DAEMON_URL/healthz. Continuing; check logs if clients cannot connect."
   DAEMON_STARTED=1
@@ -1560,7 +1640,11 @@ start_local_web() {
     sleep 1
   done
 
-  log "Local web UI failed to become healthy. Check logs: $WEB_LOG"
+  report_component_failure \
+    "oore-web" \
+    "$WEB_LOG" \
+    "$WEB_BINARY --listen $OORE_LOCAL_WEB_LISTEN --backend-url $WEB_BACKEND_URL --dist-dir $WEB_DIST_DIR" \
+    "$LOCAL_WEB_URL"
   return 1
 }
 
@@ -1607,8 +1691,14 @@ EOF
 
   if ! launchctl bootstrap "gui/$uid" "$WEB_LAUNCH_AGENT_PLIST" >/dev/null 2>&1; then
     # Fallback for older macOS launchctl variants.
-    launchctl load -w "$WEB_LAUNCH_AGENT_PLIST" >/dev/null 2>&1 \
-      || return 1
+    if ! launchctl load -w "$WEB_LAUNCH_AGENT_PLIST" >/dev/null 2>&1; then
+      report_component_failure \
+        "oore-web launch agent" \
+        "$WEB_LOG" \
+        "launchctl load -w $WEB_LAUNCH_AGENT_PLIST" \
+        "$LOCAL_WEB_URL"
+      return 1
+    fi
   fi
 
   launchctl kickstart -k "gui/$uid/$WEB_LAUNCH_AGENT_LABEL" >/dev/null 2>&1 \
@@ -1723,7 +1813,7 @@ configure_local_web_noninteractive() {
     login)
       install_local_web_autostart \
         || die "Failed to install local web autostart in non-interactive mode."
-      start_local_web || true
+      start_local_web
       ;;
     *)
       die 'OORE_LOCAL_WEB_MODE must be one of: off,run,login.'
@@ -1942,6 +2032,9 @@ print_next_steps() {
     fi
     if [[ "$BACKEND_SETUP_INITIALIZED" -eq 1 ]]; then
       printf 'Setup is initialized. Sign in through your configured auth path.\n'
+    elif is_default_local_install; then
+      printf 'Open the local web UI and use loopback local login:\n'
+      printf '  %s\n' "$LOCAL_WEB_URL"
     else
       printf 'Complete setup:\n'
       if has_local_web_bundle; then
@@ -1998,17 +2091,24 @@ cleanup() {
 }
 
 main() {
-  if [[ $# -gt 0 ]]; then
+  while [[ $# -gt 0 ]]; do
     case "$1" in
       -h|--help)
         print_help
         return 0
         ;;
+      --advanced)
+        OORE_ADVANCED=1
+        ;;
+      --no-open)
+        OORE_NO_OPEN=1
+        ;;
       *)
         die "Unknown argument: $1 (use --help)"
         ;;
     esac
-  fi
+    shift
+  done
 
   trap cleanup EXIT
   init_ui_theme
@@ -2018,6 +2118,7 @@ main() {
   validate_optional_bool_env OORE_START_DAEMON "$OORE_START_DAEMON"
   validate_optional_bool_env OORE_INSTALL_DAEMON_SERVICE "$OORE_INSTALL_DAEMON_SERVICE"
   validate_optional_bool_env OORE_ENABLE_LINGER "$OORE_ENABLE_LINGER"
+  validate_optional_bool_env OORE_OPEN_BROWSER "$OORE_OPEN_BROWSER"
 
   if normalize_bool "$OORE_NONINTERACTIVE"; then
     :
@@ -2099,8 +2200,11 @@ main() {
     # Step 5: Non-interactive daemon handling
     if should_install_daemon_service; then
       step "Installing daemon service..."
-      install_daemon_service || die "Daemon service startup failed. Check logs: $DAEMON_LOG"
+      install_daemon_service || exit 1
       initialize_backend_setup_if_requested
+      if is_default_local_install; then
+        configure_local_web_noninteractive || exit 1
+      fi
       if [[ "$DAEMON_HEALTH_REACHABLE" -eq 1 ]]; then
         step_done "$DAEMON_URL (launchd)"
       else
@@ -2109,7 +2213,7 @@ main() {
     elif [[ -n "$OORE_START_DAEMON" ]]; then
       if normalize_bool "$OORE_START_DAEMON"; then
         step "Starting daemon..."
-        start_daemon || die "Daemon startup failed. Check logs: $DAEMON_LOG"
+        start_daemon || exit 1
         initialize_backend_setup_if_requested
         if is_localhost_backend; then
           configure_local_web_noninteractive
@@ -2136,6 +2240,9 @@ main() {
       step "Installing daemon service..."
       if install_daemon_service; then
         initialize_backend_setup_if_requested
+        if is_default_local_install; then
+          configure_local_web_noninteractive
+        fi
         daemon_started=0
       else
         daemon_started=1
@@ -2165,6 +2272,9 @@ main() {
       if [[ "$BACKEND_SETUP_INITIALIZED" -eq 1 ]]; then
         printf '\n'
         log "Backend setup was initialized by the installer."
+      elif is_default_local_install; then
+        printf '\n'
+        log "Local web UI is ready. Loopback local login will complete first-run setup."
       elif ! is_already_configured; then
         printf '\n'
         generate_setup_token || true
@@ -2186,6 +2296,19 @@ main() {
   fi
 
   print_next_steps
+
+  if is_default_local_install && should_open_browser; then
+    if is_local_web_healthy; then
+      open "$LOCAL_WEB_URL" >/dev/null 2>&1 || log "Could not open browser. Open: $LOCAL_WEB_URL"
+    else
+      report_component_failure \
+        "oore-web" \
+        "$WEB_LOG" \
+        "$WEB_BINARY --listen $OORE_LOCAL_WEB_LISTEN --backend-url $WEB_BACKEND_URL --dist-dir $WEB_DIST_DIR" \
+        "$LOCAL_WEB_URL"
+      return 1
+    fi
+  fi
 }
 
 main "$@"

--- a/tools/autotag.sh
+++ b/tools/autotag.sh
@@ -6,6 +6,7 @@ cd "$ROOT_DIR"
 
 CHANNEL="${AUTOTAG_CHANNEL:-}"
 BRANCH="${AUTOTAG_BRANCH:-$CHANNEL}"
+SHA="${AUTOTAG_SHA:-}"
 
 if [[ -z "$CHANNEL" ]]; then
   echo "AUTOTAG_CHANNEL is required (stable|alpha|beta)." >&2
@@ -98,7 +99,13 @@ fi
 maybe_configure_github_token_remote
 
 git fetch origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH" "+refs/tags/*:refs/tags/*"
-git checkout -B "$BRANCH" "origin/$BRANCH"
+if [[ -n "$SHA" ]]; then
+  git merge-base --is-ancestor "$SHA" "origin/$BRANCH" \
+    || { echo "Validated commit $SHA is not on origin/$BRANCH" >&2; exit 1; }
+  git checkout --detach "$SHA"
+else
+  git checkout -B "$BRANCH" "origin/$BRANCH"
+fi
 
 cargo_ver="$(read_workspace_version)"
 if [[ -z "$cargo_ver" ]]; then

--- a/tools/docs-check.sh
+++ b/tools/docs-check.sh
@@ -48,7 +48,7 @@ if [[ -n "$BASE_SHA" ]]; then
     while IFS= read -r file; do
       [[ -z "$file" ]] && continue
 
-      if [[ "$file" =~ ^(apps/|crates/|backend/|frontend/|src/|oore/|oored/|runner/|tools/|\\.github/workflows/) ]]; then
+      if [[ "$file" =~ ^(apps/|crates/|backend/|frontend/|src/|oore/|oored/|runner/|tools/|scripts/|\\.github/workflows/) ]]; then
         code_changed="true"
       fi
 

--- a/tools/release-smoke.sh
+++ b/tools/release-smoke.sh
@@ -23,5 +23,6 @@ cargo test -p oore --test cli_unimplemented
 
 # Installed-state backup format and integrity verification.
 cargo test -p oore --test cli_unimplemented backup_create_and_verify_round_trip
+cargo test -p oore update_rollback_restores_previous_release
 
 echo "[release-smoke] All smoke checks passed."

--- a/tools/release-smoke.sh
+++ b/tools/release-smoke.sh
@@ -6,6 +6,9 @@ cd "$ROOT_DIR"
 
 echo "[release-smoke] Running local-first regression smoke checks..."
 
+# Release installer local-first defaults and browser-open policy.
+bash scripts/install-acceptance.sh
+
 # Runner checkout reliability: nested submodules + explicit failure markers.
 cargo test -p oore-runner checkout_
 

--- a/tools/release-smoke.sh
+++ b/tools/release-smoke.sh
@@ -15,7 +15,13 @@ cargo test -p oore-runner checkout_
 # Local-first onboarding critical path (loopback local login behavior).
 cargo test -p oored --features test-support --test local_login_integration
 
+# Liveness and dependency-aware readiness stay distinct.
+cargo test -p oored --features test-support --test setup_integration test_readyz_reports_runtime_dependencies
+
 # CLI flow coverage for login/config/status contract surfaces.
 cargo test -p oore --test cli_unimplemented
+
+# Installed-state backup format and integrity verification.
+cargo test -p oore --test cli_unimplemented backup_create_and_verify_round_trip
 
 echo "[release-smoke] All smoke checks passed."


### PR DESCRIPTION
## What

- harden runner artifact publication with an explicit pending/available/failed lifecycle
- make local-first installation, diagnostics, updates, rollback, and backups reliable on macOS
- improve build context, failure recovery, demo behavior, and pipeline-signing feedback in the web UI
- strengthen release gates, documentation checks, public docs, and OpenAPI coverage

## Why

The product's core flows were individually present, but users could still encounter ambiguous build context, partially published artifacts, fragile setup/update behavior, and release automation that did not prove the exact commit being shipped. This change treats those paths as one trust boundary: users should know what they are operating on, recover safely when something fails, and receive artifacts built from a verified commit.

## User impact

- local setup defaults to the shortest safe path and reports actionable diagnostics
- failed builds retain enough project, pipeline, runner, and step context to debug them
- incomplete artifacts never appear as downloadable successes
- updates are staged atomically and can restore the previous installation on failure
- backups are verifiable and restorable through the CLI
- alpha releases are cut only after validation succeeds for the exact merged commit

## Verification

- `make validate`
- `make release-smoke`
- `cargo test -p oored --features test-support --test logs_artifacts_integration test_build_list_and_detail_include_display_context`

The Linear feature document and V1 roadmap have been updated to reflect the implemented scope.
