### PR TITLE
fix(release): fall back from unavailable runner

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -17,7 +17,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
       contains(fromJSON('["stable","alpha","beta"]'), github.event.workflow_run.head_branch)
-    runs-on: [self-hosted, jarvis]
+    runs-on: ${{ vars.RUNNER_MACOS || 'macos-latest' }}
     # Only run after validate completes — but since validate is a separate workflow,
     # we rely on branch protection rules to enforce this ordering.
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   release:
     name: Build, deploy & publish
-    runs-on: [self-hosted, jarvis]
+    runs-on: ${{ vars.RUNNER_MACOS || 'macos-latest' }}
     permissions:
       contents: write
     steps:

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -12,6 +12,8 @@ Rules:
 
 ## 2026-07-12
 
+- Release automation now uses the configurable macOS runner with a `macos-latest` fallback for validation, autotagging, and release packaging, so an unavailable self-hosted runner cannot indefinitely block alpha delivery.
+  - Release channels doc: https://linear.app/oorebuild/document/release-channels-alpha-beta-stable-via-woodpecker-github-releases-993db297927a
 - **Product trust hardening release**:
   - Repository YAML now uses one strict parser across runner execution, daemon validation, and `oore pipeline validate`; repository YAML no longer accepts trigger/concurrency fields and artifact globs are safe workspace-relative patterns.
   - Runner protocol v2 prevents old runners from claiming work and adds artifact reservation, upload, completion/abort, pending visibility, stale cleanup, required-artifact failure, and `.app` bundle packaging.


### PR DESCRIPTION
## What

- run Autotag and Release on the configurable `RUNNER_MACOS` target
- fall back to GitHub's `macos-latest` runner when no override is configured
- document the release-availability change in the ledger

## Why

The `jarvis` self-hosted runner will be unavailable for an extended period. Validation already supported a configurable macOS runner, but the two downstream release workflows were still hard-coded to Jarvis, leaving successful alpha builds unable to tag or publish.

## Impact

Alpha, beta, and stable releases can complete without the self-hosted runner. The repository variable remains available for switching back to another macOS runner later.

## Verification

- `bun run docs:check`
- `git diff --check`
- full alpha validation for the preceding product-hardening merge passed on `macos-latest`
