### PR TITLE
fix(release): bootstrap hosted macos runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Setup Rust targets
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
@@ -173,7 +179,8 @@ jobs:
           export PAGES_PROJECT_WEB="oore-ci"
           export PAGES_PROJECT_DEMO="oore-demo"
           export PAGES_BRANCH="$pages_branch"
-          export PAGES_COMMIT_HASH="$(git rev-list -n 1 "$tag")"
+          PAGES_COMMIT_HASH="$(git rev-list -n 1 "$tag")"
+          export PAGES_COMMIT_HASH
           export PAGES_COMMIT_MESSAGE="$tag"
           export WRANGLER="./node_modules/.bin/wrangler"
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -12,7 +12,7 @@ Rules:
 
 ## 2026-07-12
 
-- Release automation now uses the configurable macOS runner with a `macos-latest` fallback for validation, autotagging, and release packaging, so an unavailable self-hosted runner cannot indefinitely block alpha delivery.
+- Release automation now uses the configurable macOS runner with a `macos-latest` fallback for validation, autotagging, and release packaging, and bootstraps Bun plus both Rust macOS targets so an unavailable pre-provisioned self-hosted runner cannot block alpha delivery.
   - Release channels doc: https://linear.app/oorebuild/document/release-channels-alpha-beta-stable-via-woodpecker-github-releases-993db297927a
 - **Product trust hardening release**:
   - Repository YAML now uses one strict parser across runner execution, daemon validation, and `oore pipeline validate`; repository YAML no longer accepts trigger/concurrency fields and artifact globs are safe workspace-relative patterns.


### PR DESCRIPTION
## What

- install Bun explicitly in the Release workflow
- install the Apple Silicon and Intel macOS Rust targets before cross-compilation
- keep the Pages commit hash export shellcheck-clean

## Why

The release workflow previously depended on tools preinstalled on the `jarvis` self-hosted runner. After moving to `macos-latest`, the first alpha release attempt failed immediately because Bun was unavailable.

## Impact

The hosted release runner now provisions the build tools it needs and no longer relies on machine-local state.

## Verification

- `actionlint .github/workflows/release.yml`
- `bun run docs:check`
- `git diff --check`
- failure reproduced in Release run `29172721644` as `bun: command not found`
