### PR TITLE
fix(deploy): harden split trusted-proxy setup

### DIFF
--- a/apps/docs-site/docs/operations/mac-studio-netbird-warpgate.md
+++ b/apps/docs-site/docs/operations/mac-studio-netbird-warpgate.md
@@ -9,34 +9,17 @@ This is the recommended first company rollout shape for an internal-only Oore CI
 
 - Mac Studio runs `oored` and the embedded runner
 - NetBird provides private network reachability
-- Warpgate protects access and forwards user identity
-- A same-host reverse proxy serves the web UI and proxies API requests to `oored`
+- Ubuntu runs the browser-facing `oore-web` behind Warpgate and HAProxy
 
-Use this when you want the UI visible only while connected to your VPN, without exposing the daemon directly on the LAN or internet.
+Use this when many users need the UI but only a small operator group may access the Mac Studio. The daemon has no browser-facing route: the AWS host is its only permitted network peer.
 
-## Target architecture
-
-```text
-Browser on VPN
-  -> Warpgate (auth)
-  -> Caddy/nginx on Mac Studio (HTTPS UI + API proxy)
-  -> oored on 127.0.0.1:8787
-  -> embedded runner on same Mac Studio
-```
-
-Keep `oored` bound to loopback. Expose HTTPS from the reverse proxy, not from the daemon itself.
-
-For the split frontend variant below, bind `oored` to the Mac Studio's NetBird address instead of loopback, and firewall it so only the frontend host can reach the daemon.
-
-## Split frontend architecture
-
-Use this variant when the Mac Studio should stay private on NetBird and a small Ubuntu host should own HTTPS, Warpgate, and the static web UI:
+## Architecture
 
 ```text
 Browser
   -> Warpgate on Ubuntu (auth)
-  -> Caddy/nginx on Ubuntu (HTTPS)
-  -> oore-web on 127.0.0.1:4173
+  -> HAProxy on Ubuntu
+  -> oore-web on a separate loopback port
   -> NetBird
   -> oored on Mac Studio NetBird address:8787
   -> embedded runner on Mac Studio
@@ -46,12 +29,25 @@ In this shape:
 
 - Mac Studio runs `oored` and the embedded runner.
 - Ubuntu runs only `oore-web` plus the static frontend assets.
-- Warpgate forwards the authenticated identity header to the Ubuntu reverse proxy.
-- The Ubuntu reverse proxy forwards that header to `oore-web`.
-- `oore-web` forwards `/v1/*` requests, including Warpgate identity headers and cookies, to the Mac daemon over NetBird.
+- Warpgate overwrites `X-Warpgate-Username` with the authenticated email before forwarding the request to HAProxy.
+- HAProxy is reachable only from Warpgate, forwards that identity, and adds the frontend proof header expected by `oore-web`.
+- `oore-web` validates the frontend proof, strips browser-controlled identity/proof headers, then injects a separate backend proof when proxying `/v1/*` to the Mac daemon.
 - Users add the instance with an empty **Backend URL** so browser requests stay on the HTTPS frontend origin.
 
-On the Mac Studio, install the backend on the NetBird address. The interactive installer asks for this listen address, public URL, allowed origins, and whether to install a launchd service:
+The two proxy proofs are intentionally different:
+
+- **Frontend proof:** HAProxy -> `oore-web`. It proves the identity header came through the authenticated frontend path.
+- **Backend proof:** `oore-web` -> `oored`. It proves the AWS frontend is the trusted backend peer.
+
+Do not send the backend proof from the browser-facing proxy. Do not configure both hops with one shared value.
+
+## Fresh split deployment
+
+Choose an `oore-web` loopback port that is not already owned by HAProxy. The examples use `4174` because HAProxy commonly owns `4173`; keep the existing HAProxy listener unchanged.
+
+### 1. Install and initialize the Mac backend
+
+Install the backend on the Mac Studio's NetBird address. Backend-owned initialization creates the real owner immediately and avoids the browser bootstrap-token flow:
 
 ```bash
 curl -fsSL https://alpha.oore.pages.dev/install | OORE_CHANNEL=alpha OORE_INSTALL_MODE=backend bash
@@ -64,13 +60,43 @@ curl -fsSL https://alpha.oore.pages.dev/install | \
   OORE_CHANNEL=alpha \
   OORE_INSTALL_MODE=backend \
   OORE_DAEMON_LISTEN=100.64.10.20:8787 \
-  OORE_PUBLIC_URL=https://ci.builds.example.corp \
+  OORE_SETUP_OWNER_EMAIL=owner@example.com \
+  OORE_SETUP_PROXY_PRESET=warpgate \
+  OORE_TRUSTED_PROXY_CIDRS=100.64.10.30/32 \
   OORE_INSTALL_DAEMON_SERVICE=true \
   OORE_NONINTERACTIVE=1 \
   bash
 ```
 
-Install the frontend-only bundle on Ubuntu. On Linux, `auto` mode selects frontend-only and prompts for the backend URL, loopback listen address, systemd service, and lingering:
+Replace `100.64.10.20` with the Mac NetBird address, `100.64.10.30/32` with the AWS frontend's NetBird address, and use the real initial owner email. Keep `OORE_PUBLIC_URL` and browser CORS unset because browsers reach the API through same-origin `oore-web`.
+
+The installer creates the backend proof at:
+
+```text
+~/.oore/trusted-proxy-shared-secret
+```
+
+Transfer that file to the Ubuntu service account through your approved secret-delivery path. Do not paste it into shell history or store it in the repository.
+
+### 2. Prepare the Ubuntu proof files
+
+Store the transferred backend proof at a user-readable, mode-`0600` path such as:
+
+```text
+~/.config/oore/backend-proof
+```
+
+Create a different random frontend proof for HAProxy and `oore-web`, also mode `0600`, at:
+
+```text
+~/.config/oore/frontend-proof
+```
+
+Configure HAProxy through its protected runtime configuration to send that frontend proof in `X-Oore-Web-Trusted-Proxy-Secret`. The `oore-web` service reads the same value from the frontend proof file.
+
+### 3. Install the Ubuntu frontend
+
+Install the frontend-only bundle on an unused loopback port:
 
 ```bash
 curl -fsSL https://alpha.oore.pages.dev/install | OORE_CHANNEL=alpha bash
@@ -83,14 +109,17 @@ curl -fsSL https://alpha.oore.pages.dev/install | \
   OORE_CHANNEL=alpha \
   OORE_INSTALL_MODE=frontend \
   OORE_WEB_BACKEND_URL=http://100.64.10.20:8787 \
-  OORE_LOCAL_WEB_LISTEN=127.0.0.1:4173 \
+  OORE_LOCAL_WEB_LISTEN=127.0.0.1:4174 \
   OORE_LOCAL_WEB_MODE=login \
   OORE_ENABLE_LINGER=true \
+  OORE_TRUSTED_PROXY_SHARED_SECRET_FILE="$HOME/.config/oore/backend-proof" \
+  OORE_WEB_TRUSTED_PROXY_USER_EMAIL_HEADER=x-warpgate-username \
+  OORE_WEB_UPSTREAM_TRUSTED_PROXY_SHARED_SECRET_FILE="$HOME/.config/oore/frontend-proof" \
   OORE_NONINTERACTIVE=1 \
   bash
 ```
 
-Replace `100.64.10.20` with the Mac Studio NetBird IP or DNS name. Keep `OORE_LOCAL_WEB_LISTEN` on loopback unless you have a reason to expose the launcher directly.
+The installer now fails before changing service state if the selected port is occupied. Keep `oore-web` on loopback; HAProxy is the only local process that should call it.
 
 For the Linux user service to survive logout and reboot, the installer can run this when `OORE_ENABLE_LINGER=true`:
 
@@ -98,160 +127,41 @@ For the Linux user service to survive logout and reboot, the installer can run t
 sudo loginctl enable-linger "$USER"
 ```
 
-Example Caddyfile on Ubuntu:
+### 4. Point HAProxy at `oore-web`
 
-```caddy
-ci.builds.example.corp {
-    reverse_proxy 127.0.0.1:4173 {
-        header_up Host {host}
-        header_up X-Forwarded-Proto https
-        header_up X-Forwarded-For {remote_host}
-        header_up X-Warpgate-Username {header.X-Warpgate-Username}
-        header_up X-Oore-Trusted-Proxy-Secret {env.OORE_TRUSTED_PROXY_SHARED_SECRET}
-    }
-}
-```
-
-Configure the Mac daemon's trusted proxy CIDRs to allow the Ubuntu NetBird address or subnet, because the backend sees the request as coming from the frontend host over NetBird rather than loopback.
-
-## 1. Build the binaries and web UI
-
-For release installs, prefer the installer commands above. Build from source only when you are testing local code changes.
-
-```bash
-bun install
-bun run build:web
-cargo build --release -p oored
-cargo build --release -p oore
-```
-
-Artifacts:
-
-- daemon: `target/release/oored`
-- operator CLI: `target/release/oore`
-- web UI: `apps/web/dist`
-
-## 2. Start the daemon on loopback
-
-Choose the VPN-visible HTTPS origin you want users to open, for example:
-
-- `https://ci.macstudio.internal`
-- `https://ci.builds.example.corp`
-
-Then start `oored` on loopback, or use `oored install-service` for a persistent daemon:
-
-```bash
-export OORED_LISTEN_ADDR=127.0.0.1:8787
-export OORE_CORS_ORIGINS=https://ci.macstudio.internal
-export RUST_LOG=info
-
-./target/release/oored run --listen 127.0.0.1:8787
-```
-
-Notes:
-
-- The embedded runner starts automatically in the default daemon mode, so a low-risk first app can build on the same Mac Studio.
-- Keep the daemon private. Do not bind it to `0.0.0.0` for this topology.
-
-## 3. Serve the UI and API behind internal HTTPS
-
-Example Caddyfile for the same Mac Studio:
-
-```caddy
-ci.macstudio.internal {
-    root * /absolute/path/to/oore.build/apps/web/dist
-    file_server
-
-    handle /v1/* {
-        reverse_proxy 127.0.0.1:8787 {
-            header_up Host {host}
-            header_up X-Forwarded-Proto https
-            header_up X-Forwarded-For {remote_host}
-            header_up X-Warpgate-Username {header.X-Warpgate-Username}
-            header_up X-Oore-Trusted-Proxy-Secret {env.OORE_TRUSTED_PROXY_SHARED_SECRET}
-        }
-    }
-
-    handle /healthz {
-        reverse_proxy 127.0.0.1:8787
-    }
-
-    handle /metrics {
-        reverse_proxy 127.0.0.1:8787
-    }
-}
-```
-
-Important details:
-
-- Serve `apps/web/dist` from the same HTTPS origin users open in the browser.
-- Preserve the Warpgate identity header when proxying `/v1/*`.
-- If you configure a trusted-proxy shared secret in Oore, forward the same value as `X-Oore-Trusted-Proxy-Secret` from the reverse proxy.
-- If Warpgate and the reverse proxy both run on the Mac Studio, `oored` will see the proxy peer as loopback, so `trusted_proxy_cidrs` can stay empty.
-- If `oored` sees a non-loopback proxy peer, add that proxy source CIDR during trusted-proxy setup.
-
-## 4. Put Warpgate in front of the HTTPS origin
-
-Configure Warpgate to:
-
-- require user authentication before access
-- forward the authenticated email in `X-Warpgate-Username`
-- proxy traffic to the HTTPS origin served by Caddy/nginx
-
-Oore expects the forwarded identity to be an email address by default.
-
-## 5. Complete setup from the VPN-visible UI
-
-Generate a bootstrap token on the Mac Studio:
-
-```bash
-./target/release/oore setup token --ttl 15m
-```
-
-Then, from a browser connected through NetBird, open:
+The existing HAProxy frontend keeps its current listener. Its Oore backend must target the separate loopback port:
 
 ```text
-https://ci.macstudio.internal/setup
+backend oore_web
+    mode http
+    http-request del-header X-Oore-Trusted-Proxy-Secret
+    http-request set-header X-Oore-Web-Trusted-Proxy-Secret "${OORE_WEB_FRONTEND_PROOF}"
+    server oore_web 127.0.0.1:4174 check
 ```
 
-In setup:
+`OORE_WEB_FRONTEND_PROOF` represents the protected HAProxy runtime value matching `~/.config/oore/frontend-proof`; wire it using your existing HAProxy service-secret mechanism. Warpgate must overwrite, not merely pass through, `X-Warpgate-Username`. Network policy must ensure clients cannot reach this HAProxy listener without Warpgate.
 
-1. Verify the bootstrap token.
-2. Choose `Remote (Trusted Proxy)`.
-3. Enter the initial owner email.
-4. Use `x-warpgate-username` as the user email header if Warpgate forwards the authenticated email in `X-Warpgate-Username`.
-5. Set a shared secret and configure the reverse proxy to send it as `X-Oore-Trusted-Proxy-Secret`.
-6. Leave trusted proxy CIDRs empty if the reverse proxy talks to `oored` over loopback.
-7. Claim the owner account from the Warpgate-authenticated request. The forwarded email must match the initial owner email.
-7. Finalize setup.
+### 5. Verify before opening access
 
-## 6. Set External Access network settings after setup
-
-After the owner account is created, open **Settings -> Preferences -> External Access** and set:
-
-- `public_url`: `https://ci.macstudio.internal`
-- `allowed_origins`: include `https://ci.macstudio.internal`
-
-This keeps runtime auth, callback validation, and artifact links aligned with the VPN-visible HTTPS origin.
-
-## 7. Verify from a VPN-connected client
+On Ubuntu:
 
 ```bash
-curl -I https://ci.macstudio.internal
-curl https://ci.macstudio.internal/healthz
-curl https://ci.macstudio.internal/v1/public/setup-status
+oore-web status --url http://127.0.0.1:4174
+systemctl --user status oore-web.service --no-pager
 ```
 
-Expected outcomes:
+The status command must report both the frontend launcher and Mac backend ready before HAProxy is pointed at the service.
 
-- the UI HTML loads over HTTPS
-- `/healthz` returns `200 OK`
-- `/v1/public/setup-status` returns JSON
-- the login page signs in through Warpgate without loopback-only errors
+From the browser, open the Warpgate-protected public URL. The authenticated email matching `OORE_SETUP_OWNER_EMAIL` signs in as the existing owner; there is no placeholder `owner@local` account and no database role swap.
+
+Configure External Access `public_url` and `allowed_origins` with that same HTTPS URL after login.
 
 ## Common mistakes
 
-- Binding `oored` directly to `0.0.0.0`: this bypasses the intended trust boundary.
+- Binding `oored` to `0.0.0.0`: bind only the Mac private/NetBird address used by the AWS frontend.
+- Reusing HAProxy's listener port for `oore-web`: the launcher needs its own loopback port.
+- Reusing one secret for both proxy hops: compromise of one boundary would then compromise both.
+- Sending `X-Oore-Trusted-Proxy-Secret` from HAProxy: `oore-web` strips it and injects its own backend proof.
 - Using HTTP for the browser-visible origin: External Access expects a non-loopback HTTPS origin.
 - Serving the UI from one origin and API from another without adding the UI origin to `allowed_origins`.
 - Forgetting to forward `X-Warpgate-Username` to `/v1/*`.

--- a/apps/docs-site/docs/operations/split-roles.md
+++ b/apps/docs-site/docs/operations/split-roles.md
@@ -76,7 +76,9 @@ curl -fsSL https://alpha.oore.pages.dev/install | \
 
 Put your HTTPS reverse proxy in front of `http://127.0.0.1:4173`. In the web UI, add the instance with **Backend URL** empty so browser API calls stay on the same HTTPS origin and flow through the frontend proxy.
 
-`oore-web` proxies `/v1/*` and `/healthz` to `OORE_WEB_BACKEND_URL`. If you use trusted-proxy authentication, configure the frontend host with the backend shared secret file and configure your HTTPS auth proxy to send an upstream proof header to `oore-web`. Browser-supplied identity headers are stripped unless that proof is present.
+The installer checks the selected listen port before changing service state. If your reverse proxy already owns `4173`, choose another loopback port such as `127.0.0.1:4174` and point the proxy backend at that address.
+
+`oore-web` proxies `/v1/*`, `/healthz`, and `/readyz` to `OORE_WEB_BACKEND_URL`. Trusted Proxy mode uses two distinct proofs: the authenticated reverse proxy sends an upstream proof to `oore-web`, then `oore-web` injects a separate backend proof for `oored`. Configure both restrictive secret files on the frontend service. Browser-supplied identity and proof headers are stripped, and the identity header is forwarded only when the upstream proof matches.
 
 During first-run setup, choose `Remote (Trusted Proxy)`, enter the initial owner email, and select a proxy preset. `Generic proxy` uses `x-oore-user-email`, `Warpgate` uses `x-warpgate-username`, and `Custom header` lets you enter the exact header your proxy forwards. The first owner claim must come from that same proxy-authenticated email, avoiding manual database edits.
 
@@ -87,6 +89,12 @@ oore-web update
 ```
 
 `oore-web update --check` reports whether the installed channel has a newer release without changing files. Restart the `oore-web` service after an update if you want the running launcher process to pick up binary changes immediately.
+
+Verify both frontend and backend readiness through the installed proxy path:
+
+```bash
+oore-web status --url http://127.0.0.1:4173
+```
 
 ## Provider-Specific Examples
 

--- a/apps/docs-site/docs/reference/cli/oore-setup.md
+++ b/apps/docs-site/docs/reference/cli/oore-setup.md
@@ -5,7 +5,41 @@ description: "CLI reference for the oore setup command and bootstrap token manag
 
 # oore setup
 
-The `setup` command configures a fresh Oore CI instance. It can be run interactively (default) or used to generate bootstrap tokens with the `token` subcommand.
+The `setup` command configures a fresh Oore CI instance. It can initialize a known deployment mode directly, run the legacy interactive OIDC flow, or generate bootstrap tokens.
+
+## Backend-owned initialization {#setup-init}
+
+```bash
+oore setup init --mode local|trusted-proxy --owner-email <email> [options]
+```
+
+Use `setup init` when the backend operator already knows the deployment mode. It creates the real owner and completes setup without a browser bootstrap token. This is the recommended path for split frontend/backend Trusted Proxy deployments.
+
+Trusted Proxy example:
+
+```bash
+OORE_TRUSTED_PROXY_SHARED_SECRET_FILE="$HOME/.oore/trusted-proxy-shared-secret" \
+  oore setup init \
+  --mode trusted-proxy \
+  --owner-email owner@example.com \
+  --user-email-header x-warpgate-username \
+  --trusted-proxy-cidr 100.64.10.30/32
+```
+
+The secret file must contain the backend proof that `oore-web` injects when proxying API requests. Keep it mode `0600`, distribute it to the frontend service account through an approved secret-delivery path, and never reuse the separate HAProxy-to-`oore-web` frontend proof.
+
+Run `oored` once before `setup init` so database migrations exist. Initialization refuses to overwrite an owner-created setup unless `--force` is explicitly supplied.
+
+### Flags
+
+| Flag | Description |
+|---|---|
+| `--mode` | `local` or `trusted-proxy` |
+| `--owner-email` | Initial owner identity |
+| `--user-email-header` | Trusted-proxy identity header; required for Trusted Proxy mode |
+| `--trusted-proxy-cidr` | Allowed proxy peer CIDR; repeat for additional peers |
+| `--shared-secret-file` | File containing the backend trusted-proxy proof |
+| `--force` | Reinitialize only before owner creation; use deliberately |
 
 ## Interactive setup
 

--- a/apps/site/public/uninstall
+++ b/apps/site/public/uninstall
@@ -12,6 +12,9 @@ DAEMON_LAUNCH_AGENT_LABEL="build.oore.oored"
 DAEMON_LAUNCH_AGENT_PLIST="$HOME/Library/LaunchAgents/$DAEMON_LAUNCH_AGENT_LABEL.plist"
 WEB_LAUNCH_AGENT_LABEL="build.oore.oore-web"
 WEB_LAUNCH_AGENT_PLIST="$HOME/Library/LaunchAgents/$WEB_LAUNCH_AGENT_LABEL.plist"
+WEB_SYSTEMD_USER_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+WEB_SYSTEMD_SERVICE_NAME="oore-web.service"
+WEB_SYSTEMD_SERVICE_FILE="$WEB_SYSTEMD_USER_DIR/$WEB_SYSTEMD_SERVICE_NAME"
 UI_RESET=""
 UI_BOLD=""
 UI_DIM=""
@@ -287,6 +290,24 @@ remove_local_web_launch_agent() {
   fi
 }
 
+remove_local_web_systemd_user_service() {
+  [[ "$(uname -s)" == "Linux" ]] || return 0
+
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl --user disable --now "$WEB_SYSTEMD_SERVICE_NAME" >/dev/null 2>&1 || true
+  fi
+
+  if [[ -f "$WEB_SYSTEMD_SERVICE_FILE" ]]; then
+    log "Removing systemd user service: $WEB_SYSTEMD_SERVICE_FILE"
+    rm -f "$WEB_SYSTEMD_SERVICE_FILE"
+  fi
+
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl --user daemon-reload >/dev/null 2>&1 || true
+    systemctl --user reset-failed "$WEB_SYSTEMD_SERVICE_NAME" >/dev/null 2>&1 || true
+  fi
+}
+
 remove_from_path() {
   local rc_files=("$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile")
 
@@ -356,7 +377,7 @@ main() {
 
   print_uninstall_intro
 
-  if [[ ! -d "$OORE_INSTALL_ROOT" ]] && ! grep -rqF "$BIN_DIR" "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile" 2>/dev/null; then
+  if [[ ! -d "$OORE_INSTALL_ROOT" ]] && [[ ! -f "$WEB_SYSTEMD_SERVICE_FILE" ]] && ! grep -rqF "$BIN_DIR" "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile" 2>/dev/null; then
     log "Oore CI does not appear to be installed."
     exit 0
   fi
@@ -372,6 +393,7 @@ main() {
   stop_daemon
   stop_local_web
   remove_local_web_launch_agent
+  remove_local_web_systemd_user_service
   remove_from_path
   remove_install_dir
   remove_data_dir

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -10,6 +10,7 @@ export default [
       'prettier.config.js',
       'public/mockServiceWorker.js',
       'tools/oore-web.js',
+      'tools/oore-web.test.js',
     ],
   },
   {

--- a/apps/web/tools/oore-web.js
+++ b/apps/web/tools/oore-web.js
@@ -48,6 +48,7 @@ function printHelp() {
 
 Usage:
   oore-web [serve] [--listen <host:port>] [--backend-url <url>] [--dist-dir <path>]
+  oore-web status [--url <frontend-url>] [--json]
   oore-web update [--channel stable|beta|alpha] [--repo owner/name] [--check] [--force]
   oore-web version
 
@@ -68,6 +69,19 @@ Options:
   --upstream-trusted-proxy-secret-header
                   Header carrying the upstream proof (default: ${DEFAULT_UPSTREAM_TRUSTED_PROXY_SECRET_HEADER})
   --help          Show this help text
+`)
+}
+
+function printStatusHelp() {
+  console.log(`oore-web status - check frontend and backend readiness
+
+Usage:
+  oore-web status [--url <frontend-url>] [--json]
+
+Options:
+  --url    Frontend URL (default: derived from ${DEFAULT_LISTEN})
+  --json   Print machine-readable output
+  --help   Show this help text
 `)
 }
 
@@ -142,6 +156,46 @@ function parseListen(raw) {
   }
 
   return { hostname, port }
+}
+
+function defaultStatusUrl() {
+  const { hostname, port } = parseListen(DEFAULT_LISTEN)
+  const host = hostname.includes(':') ? `[${hostname}]` : hostname
+  return `http://${host}:${port}`
+}
+
+function parseStatusArgs(argv) {
+  const config = { url: defaultStatusUrl(), json: false }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === '--help' || arg === '-h') {
+      printStatusHelp()
+      process.exit(0)
+    }
+    if (arg === '--url') {
+      const value = argv[i + 1]
+      if (!value) throw new Error('--url requires a value')
+      config.url = value
+      i += 1
+      continue
+    }
+    if (arg === '--json') {
+      config.json = true
+      continue
+    }
+    throw new Error(`unknown status argument: ${arg}`)
+  }
+
+  const url = new URL(config.url)
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new Error('--url must use http or https')
+  }
+  if (url.username || url.password) {
+    throw new Error('--url must not include credentials')
+  }
+  config.url = url.origin
+  return config
 }
 
 function parseServeArgs(argv) {
@@ -582,6 +636,156 @@ function printVersion() {
   console.log(version || 'unknown')
 }
 
+async function statusProbe(baseUrl, pathname) {
+  let response
+  try {
+    response = await fetch(new URL(pathname, baseUrl), {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(5000),
+    })
+  } catch {
+    return { ok: false, error: 'connection_failed' }
+  }
+
+  let data
+  try {
+    data = await response.json()
+  } catch {
+    return { ok: false, status: response.status, error: 'invalid_json' }
+  }
+
+  return {
+    ok: response.ok && data?.ok === true,
+    status: response.status,
+    proxied: response.headers.get('x-oore-web-proxy') === '1',
+    data,
+  }
+}
+
+function statusValue(value) {
+  if (typeof value !== 'string') return 'unknown'
+  return value.replace(/[^\x20-\x7e]/g, '').slice(0, 128) || 'unknown'
+}
+
+function probeFailure(probe) {
+  if (probe.error === 'connection_failed') return 'connection failed'
+  if (probe.error === 'invalid_json') return 'invalid JSON response'
+  if (probe.status) return `HTTP ${probe.status}`
+  return 'unhealthy response'
+}
+
+async function getStatus(baseUrl) {
+  const frontendProbe = await statusProbe(baseUrl, '/__oore_web_healthz')
+  if (!frontendProbe.ok) {
+    return {
+      ok: false,
+      url: baseUrl,
+      frontend: {
+        ok: false,
+        version: 'unknown',
+        error: `Frontend check failed (${probeFailure(frontendProbe)}). Check that oore-web is running and --url is correct.`,
+      },
+      backend: {
+        ok: false,
+        version: 'unknown',
+        skipped: true,
+        error: 'Backend check skipped because the frontend is unavailable.',
+      },
+    }
+  }
+
+  const [backendHealth, backendReady] = await Promise.all([
+    statusProbe(baseUrl, '/healthz'),
+    statusProbe(baseUrl, '/readyz'),
+  ])
+  const checks = {
+    database:
+      typeof backendReady.data?.database === 'boolean'
+        ? backendReady.data.database
+        : null,
+    migrations:
+      typeof backendReady.data?.migrations === 'boolean'
+        ? backendReady.data.migrations
+        : null,
+    encryption:
+      typeof backendReady.data?.encryption === 'boolean'
+        ? backendReady.data.encryption
+        : null,
+  }
+
+  let backendError
+  if (!backendHealth.ok) {
+    backendError = `Backend liveness check failed (${probeFailure(backendHealth)}). Check OORE_WEB_BACKEND_URL and that oored is running.`
+  } else if (!backendHealth.proxied) {
+    backendError =
+      'Backend response did not pass through oore-web. Check that --url points to oore-web.'
+  } else if (!backendReady.ok) {
+    if (backendReady.proxied) {
+      const failed = Object.entries(checks)
+        .filter(([, ok]) => ok === false)
+        .map(([name]) => name)
+        .join(', ')
+      backendError = `Backend is not ready${failed ? ` (${failed} failed)` : ''}. Check oored logs and dependencies.`
+    } else {
+      backendError = `Backend readiness check failed (${probeFailure(backendReady)}). Check OORE_WEB_BACKEND_URL and that oored is running.`
+    }
+  } else if (!backendReady.proxied) {
+    backendError =
+      'Backend response did not pass through oore-web. Check that --url points to oore-web.'
+  }
+
+  const backendOk = !backendError
+  return {
+    ok: backendOk,
+    url: baseUrl,
+    frontend: {
+      ok: true,
+      version: statusValue(frontendProbe.data?.version),
+      channel: statusValue(frontendProbe.data?.channel),
+    },
+    backend: {
+      ok: backendOk,
+      version: statusValue(backendHealth.data?.version),
+      channel: statusValue(backendHealth.data?.channel),
+      ready: backendReady.ok,
+      checks,
+      ...(backendError ? { error: backendError } : {}),
+    },
+  }
+}
+
+function printStatus(report, json) {
+  if (json) {
+    console.log(JSON.stringify(report, null, 2))
+    return
+  }
+
+  console.log(`URL:      ${report.url}`)
+  console.log(
+    `Frontend: ${report.frontend.ok ? 'ok' : 'failed'} (version ${report.frontend.version}, channel ${report.frontend.channel || 'unknown'})`,
+  )
+  if (report.frontend.error) console.log(`          ${report.frontend.error}`)
+
+  if (report.backend.skipped) {
+    console.log(`Backend:  skipped - ${report.backend.error}`)
+    return
+  }
+
+  console.log(
+    `Backend:  ${report.backend.ok ? 'ok' : 'failed'} (version ${report.backend.version}, channel ${report.backend.channel})`,
+  )
+  if (report.backend.error) console.log(`          ${report.backend.error}`)
+  console.log(
+    `Ready:    database=${report.backend.checks.database ?? 'unknown'} migrations=${report.backend.checks.migrations ?? 'unknown'} encryption=${report.backend.checks.encryption ?? 'unknown'}`,
+  )
+}
+
+async function runStatus(config) {
+  const report = await getStatus(config.url)
+  printStatus(report, config.json)
+  if (!report.ok) process.exitCode = 1
+}
+
 async function runUpdate(config) {
   const installRoot = resolveInstallRoot()
   const currentRaw = readInstalledVersion(installRoot) || '0.0.0'
@@ -681,9 +885,12 @@ async function runUpdate(config) {
   )
 }
 
-function isApiPath(pathname) {
+export function isApiPath(pathname) {
   return (
-    pathname === '/healthz' || pathname === '/v1' || pathname.startsWith('/v1/')
+    pathname === '/healthz' ||
+    pathname === '/readyz' ||
+    pathname === '/v1' ||
+    pathname.startsWith('/v1/')
   )
 }
 
@@ -706,7 +913,7 @@ function headersToStripForTrustedProxy(config) {
   ])
 }
 
-function applyTrustedProxyHeaders(request, headers, config) {
+export function applyTrustedProxyHeaders(request, headers, config) {
   const trustedProxySecret = config.trustedProxySecret.trim()
   const upstreamSecret = config.upstreamTrustedProxySecret.trim()
   const identityHeader = config.trustedProxyUserEmailHeader
@@ -802,6 +1009,20 @@ async function main() {
   }
   if (parsedCommand.command === 'version') {
     printVersion()
+    return
+  }
+  if (parsedCommand.command === 'status') {
+    let statusConfig
+    try {
+      statusConfig = parseStatusArgs(parsedCommand.args)
+    } catch (error) {
+      console.error(
+        `[oore-web] ${error instanceof Error ? error.message : 'failed to parse status args'}`,
+      )
+      printStatusHelp()
+      process.exit(2)
+    }
+    await runStatus(statusConfig)
     return
   }
   if (parsedCommand.command === 'update') {
@@ -923,7 +1144,11 @@ async function main() {
   process.on('SIGTERM', shutdown)
 }
 
-main().catch((error) => {
-  console.error(`[oore-web] ${error instanceof Error ? error.message : error}`)
-  process.exit(1)
-})
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(
+      `[oore-web] ${error instanceof Error ? error.message : error}`,
+    )
+    process.exit(1)
+  })
+}

--- a/apps/web/tools/oore-web.test.js
+++ b/apps/web/tools/oore-web.test.js
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest'
+import path from 'node:path'
+import { spawn } from 'node:child_process'
+import { createServer } from 'node:http'
+
+import { applyTrustedProxyHeaders, isApiPath } from './oore-web.js'
+
+const ooreWebPath = path.resolve(process.cwd(), 'tools/oore-web.js')
+
+async function runStatus(url, json = false) {
+  return await new Promise((resolve, reject) => {
+    const child = spawn('bun', [
+      ooreWebPath,
+      'status',
+      '--url',
+      url,
+      ...(json ? ['--json'] : []),
+    ])
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk) => (stdout += chunk))
+    child.stderr.on('data', (chunk) => (stderr += chunk))
+    child.once('error', reject)
+    child.once('close', (exitCode) => resolve({ stdout, stderr, exitCode }))
+  })
+}
+
+async function startServer(handler) {
+  const server = createServer(handler)
+  await new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  return { server, url: `http://127.0.0.1:${server.address().port}` }
+}
+
+async function stopServer(server) {
+  await new Promise((resolve) => server.close(resolve))
+}
+
+function sendJson(response, data, proxied = false) {
+  response.setHeader('content-type', 'application/json')
+  if (proxied) response.setHeader('x-oore-web-proxy', '1')
+  response.end(JSON.stringify(data))
+}
+
+describe('oore-web trusted proxy contract', () => {
+  it('proxies the backend readiness endpoint', () => {
+    expect(isApiPath('/readyz')).toBe(true)
+  })
+
+  it('forwards identity only with valid upstream proof', () => {
+    const config = {
+      trustedProxySecret: 'backend-proof',
+      upstreamTrustedProxySecret: 'upstream-proof',
+      trustedProxyUserEmailHeader: 'x-warpgate-username',
+      upstreamTrustedProxySecretHeader: 'x-oore-web-trusted-proxy-secret',
+    }
+
+    const unprovedRequest = new Request('https://ci.example.com/v1/auth', {
+      headers: {
+        'x-warpgate-username': 'attacker@example.com',
+        'x-oore-web-trusted-proxy-secret': 'wrong-proof',
+        'x-oore-trusted-proxy-secret': 'attacker-proof',
+      },
+    })
+    const unprovedHeaders = new Headers(unprovedRequest.headers)
+    applyTrustedProxyHeaders(unprovedRequest, unprovedHeaders, config)
+
+    expect(unprovedHeaders.get('x-warpgate-username')).toBeNull()
+    expect(unprovedHeaders.get('x-oore-web-trusted-proxy-secret')).toBeNull()
+    expect(unprovedHeaders.get('x-oore-trusted-proxy-secret')).toBe(
+      'backend-proof',
+    )
+
+    const provedRequest = new Request('https://ci.example.com/v1/auth', {
+      headers: {
+        'x-warpgate-username': 'owner@example.com',
+        'x-oore-web-trusted-proxy-secret': 'upstream-proof',
+      },
+    })
+    const provedHeaders = new Headers(provedRequest.headers)
+    applyTrustedProxyHeaders(provedRequest, provedHeaders, config)
+
+    expect(provedHeaders.get('x-warpgate-username')).toBe('owner@example.com')
+    expect(provedHeaders.get('x-oore-web-trusted-proxy-secret')).toBeNull()
+    expect(provedHeaders.get('x-oore-trusted-proxy-secret')).toBe(
+      'backend-proof',
+    )
+  })
+})
+
+describe('oore-web status', () => {
+  it('reports frontend and backend versions with dependency readiness', async () => {
+    const { server, url } = await startServer((request, response) => {
+      if (request.url === '/__oore_web_healthz') {
+        sendJson(response, {
+          ok: true,
+          version: 'web-1',
+          channel: 'alpha',
+          backend_url: 'http://secret-backend',
+        })
+        return
+      }
+      if (request.url === '/healthz') {
+        sendJson(
+          response,
+          { ok: true, version: 'backend-2', channel: 'beta' },
+          true,
+        )
+        return
+      }
+      if (request.url === '/readyz') {
+        sendJson(
+          response,
+          {
+            ok: true,
+            database: true,
+            migrations: true,
+            encryption: true,
+          },
+          true,
+        )
+        return
+      }
+      response.statusCode = 404
+      response.end('not found')
+    })
+
+    try {
+      const result = await runStatus(url, true)
+      const report = JSON.parse(result.stdout)
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stderr).toBe('')
+      expect(report).toMatchObject({
+        ok: true,
+        frontend: { ok: true, version: 'web-1', channel: 'alpha' },
+        backend: {
+          ok: true,
+          version: 'backend-2',
+          channel: 'beta',
+          ready: true,
+          checks: { database: true, migrations: true, encryption: true },
+        },
+      })
+      expect(result.stdout).not.toContain('secret-backend')
+    } finally {
+      await stopServer(server)
+    }
+  })
+
+  it('reports an actionable frontend connection failure', async () => {
+    const { server, url } = await startServer((_request, response) =>
+      response.end(),
+    )
+    await stopServer(server)
+
+    const result = await runStatus(url)
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stdout).toContain('Frontend: failed')
+    expect(result.stdout).toContain(
+      'Check that oore-web is running and --url is correct.',
+    )
+    expect(result.stdout).toContain('Backend:  skipped')
+    expect(result.stderr).toBe('')
+  })
+})

--- a/crates/oore/src/main.rs
+++ b/crates/oore/src/main.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -3019,61 +3020,124 @@ fn parse_checksum(text: &str, filename: &str) -> anyhow::Result<String> {
     anyhow::bail!("checksum not found for {filename} in checksums.txt")
 }
 
-/// Check if the daemon is reachable on 127.0.0.1:8787.
-async fn check_daemon_running(client: &reqwest::Client) -> bool {
-    client
-        .get("http://127.0.0.1:8787/healthz")
-        .timeout(Duration::from_secs(3))
-        .send()
-        .await
-        .map(|r| r.status().is_success())
+fn endpoint_url(base_url: &str, path: &str) -> String {
+    format!("{}{}", base_url.trim_end_matches('/'), path)
+}
+
+/// Check whether the daemon is reachable at its configured address.
+async fn check_daemon_running(client: &reqwest::Client, daemon_url: &str) -> bool {
+    endpoint_is_healthy(client, &endpoint_url(daemon_url, "/healthz")).await
+}
+
+fn lsof_name_matches_socket(name: &str, listen: SocketAddr) -> bool {
+    let name = name.strip_prefix("TCP ").unwrap_or(name);
+    let name = name.strip_suffix(" (LISTEN)").unwrap_or(name);
+    if name == listen.to_string() {
+        return true;
+    }
+    listen.ip().is_unspecified() && name == format!("*:{}", listen.port())
+}
+
+fn oored_listener_pids(lsof_fields: &str, listen: SocketAddr) -> Vec<i32> {
+    let mut pid = None;
+    let mut command_is_oored = false;
+    let mut matches = Vec::new();
+
+    for field in lsof_fields.lines() {
+        match field.as_bytes().first() {
+            Some(b'p') => {
+                pid = field[1..].parse().ok();
+                command_is_oored = false;
+            }
+            Some(b'c') => command_is_oored = field.get(1..) == Some("oored"),
+            Some(b'n') if command_is_oored && lsof_name_matches_socket(&field[1..], listen) => {
+                if let Some(pid) = pid
+                    && !matches.contains(&pid)
+                {
+                    matches.push(pid);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    matches
+}
+
+fn process_is_oored(pid: i32) -> bool {
+    std::process::Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "comm="])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| {
+            let command = String::from_utf8(output.stdout).ok()?;
+            Path::new(command.trim())
+                .file_name()
+                .map(|name| name == "oored")
+        })
         .unwrap_or(false)
 }
 
+fn terminate_oored(pid: i32) -> bool {
+    if !process_is_oored(pid) {
+        return false;
+    }
+    unsafe { libc::kill(pid, 0) == 0 && libc::kill(pid, libc::SIGTERM) == 0 }
+}
+
 /// Stop the daemon using PID file first, then lsof fallback (mirrors uninstall.sh).
-fn stop_daemon(install_root: &Path) -> anyhow::Result<()> {
+fn stop_daemon(install_root: &Path, listen: &str) -> anyhow::Result<()> {
     let pid_file = install_root.join("oored.pid");
+    let mut stopped = false;
 
     // Try PID file first
     if pid_file.exists() {
         if let Ok(contents) = fs::read_to_string(&pid_file)
             && let Ok(pid) = contents.trim().parse::<i32>()
+            && terminate_oored(pid)
         {
-            // Check if process exists (kill -0)
-            unsafe {
-                if libc::kill(pid, 0) == 0 {
-                    libc::kill(pid, libc::SIGTERM);
-                    std::thread::sleep(Duration::from_secs(1));
-                }
-            }
+            stopped = true;
         }
         let _ = fs::remove_file(&pid_file);
     }
 
-    // lsof fallback: kill anything still listening on port 8787
+    let listen = listen
+        .parse::<SocketAddr>()
+        .with_context(|| format!("invalid daemon listen address: {listen}"))?;
+
+    // Ask by port, then filter the structured output by exact address and command.
     if let Ok(output) = std::process::Command::new("lsof")
-        .args(["-nP", "-iTCP:8787", "-sTCP:LISTEN", "-t"])
+        .args([
+            "-nP",
+            "-a",
+            &format!("-iTCP:{}", listen.port()),
+            "-sTCP:LISTEN",
+            "-Fpcn",
+        ])
         .output()
         && output.status.success()
     {
-        let pids = String::from_utf8_lossy(&output.stdout);
-        for pid_str in pids.split_whitespace() {
-            if let Ok(pid) = pid_str.parse::<i32>() {
-                unsafe {
-                    libc::kill(pid, libc::SIGTERM);
-                }
+        for pid in oored_listener_pids(&String::from_utf8_lossy(&output.stdout), listen) {
+            if terminate_oored(pid) {
+                stopped = true;
             }
         }
-        if !pids.trim().is_empty() {
-            std::thread::sleep(Duration::from_secs(1));
-        }
+    }
+    if stopped {
+        std::thread::sleep(Duration::from_secs(1));
     }
 
     Ok(())
 }
 
 /// Restart the daemon and verify it becomes healthy.
-async fn restart_daemon(install_root: &Path, client: &reqwest::Client) -> anyhow::Result<()> {
+async fn restart_daemon(
+    install_root: &Path,
+    listen: &str,
+    daemon_url: &str,
+    client: &reqwest::Client,
+) -> anyhow::Result<()> {
     let bin_dir = install_root.join("bin");
     let oored_bin = bin_dir.join("oored");
     let log_path = install_root.join("logs").join("oored.log");
@@ -3091,7 +3155,7 @@ async fn restart_daemon(install_root: &Path, client: &reqwest::Client) -> anyhow
         .with_context(|| format!("failed to open log file: {}", log_path.display()))?;
 
     let child = std::process::Command::new(&oored_bin)
-        .args(["run", "--listen", "127.0.0.1:8787"])
+        .args(["run", "--listen", listen])
         .stdout(log_file.try_clone()?)
         .stderr(log_file)
         .stdin(std::process::Stdio::null())
@@ -3104,7 +3168,7 @@ async fn restart_daemon(install_root: &Path, client: &reqwest::Client) -> anyhow
     // Poll healthz up to 15 seconds
     for _ in 0..15 {
         tokio::time::sleep(Duration::from_secs(1)).await;
-        if check_daemon_running(client).await {
+        if check_daemon_running(client, daemon_url).await {
             return Ok(());
         }
     }
@@ -3360,7 +3424,8 @@ fn database_is_open(path: &Path) -> bool {
 fn backup_restore(args: BackupRestoreArgs) -> anyhow::Result<()> {
     let client = github_client()?;
     let runtime = tokio::runtime::Runtime::new().context("failed to create Tokio runtime")?;
-    if runtime.block_on(check_daemon_running(&client)) {
+    let daemon_url = resolve_daemon_url(None)?;
+    if runtime.block_on(check_daemon_running(&client, &daemon_url)) {
         anyhow::bail!(
             "refusing restore while oored is running; stop the managed service or daemon first"
         );
@@ -3433,6 +3498,115 @@ fn launch_agent_plist(label: &str) -> anyhow::Result<PathBuf> {
         .context("could not determine home directory")?
         .join("Library/LaunchAgents")
         .join(format!("{label}.plist")))
+}
+
+fn url_from_socket_address(address: SocketAddr) -> String {
+    let ip = match address.ip() {
+        IpAddr::V4(ip) if ip.is_unspecified() => IpAddr::V4(Ipv4Addr::LOCALHOST),
+        IpAddr::V6(ip) if ip.is_unspecified() => IpAddr::V6(Ipv6Addr::LOCALHOST),
+        ip => ip,
+    };
+    format!("http://{}", SocketAddr::new(ip, address.port()))
+}
+
+fn url_from_listen_address(listen: &str) -> anyhow::Result<String> {
+    let listen = listen.trim();
+    if listen.is_empty() {
+        anyhow::bail!("service listen address is empty");
+    }
+    if let Ok(address) = listen.parse::<SocketAddr>() {
+        return Ok(url_from_socket_address(address));
+    }
+
+    let url = url::Url::parse(listen)
+        .or_else(|_| url::Url::parse(&format!("http://{listen}")))
+        .with_context(|| format!("invalid service listen address: {listen}"))?;
+    if !matches!(url.scheme(), "http" | "https") {
+        anyhow::bail!("unsupported service URL scheme: {}", url.scheme());
+    }
+    let host = url
+        .host_str()
+        .context("service listen URL is missing a host")?;
+    let port = url.port().unwrap_or(80);
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return Ok(url_from_socket_address(SocketAddr::new(ip, port)));
+    }
+    Ok(format!("http://{host}:{port}"))
+}
+
+fn daemon_url_from_listen_address(listen: &str) -> anyhow::Result<String> {
+    let address = listen
+        .trim()
+        .parse::<SocketAddr>()
+        .with_context(|| format!("invalid daemon listen address: {listen}"))?;
+    Ok(url_from_socket_address(address))
+}
+
+fn daemon_listen_address_from_url(daemon_url: &str) -> anyhow::Result<String> {
+    let url =
+        url::Url::parse(daemon_url).with_context(|| format!("invalid daemon URL: {daemon_url}"))?;
+    if url.scheme() != "http" {
+        anyhow::bail!("unmanaged daemon URL must use http: {daemon_url}");
+    }
+    if url.path() != "/" || url.query().is_some() || url.fragment().is_some() {
+        anyhow::bail!(
+            "unmanaged daemon URL must not include a path, query, or fragment: {daemon_url}"
+        );
+    }
+    let host = url
+        .host_str()
+        .context("unmanaged daemon URL is missing a host")?;
+    let ip = if host.eq_ignore_ascii_case("localhost") {
+        IpAddr::V4(Ipv4Addr::LOCALHOST)
+    } else {
+        host.parse::<IpAddr>()
+            .with_context(|| format!("unmanaged daemon URL must use an IP address: {daemon_url}"))?
+    };
+    let port = url
+        .port_or_known_default()
+        .context("unmanaged daemon URL is missing a port")?;
+    Ok(SocketAddr::new(ip, port).to_string())
+}
+
+fn plist_program_arguments(plist: &Path) -> anyhow::Result<Vec<String>> {
+    let output = std::process::Command::new("plutil")
+        .args(["-extract", "ProgramArguments", "json", "-o", "-"])
+        .arg(plist)
+        .output()
+        .with_context(|| format!("failed to read launchd plist {}", plist.display()))?;
+    if !output.status.success() {
+        anyhow::bail!("failed to read ProgramArguments from {}", plist.display());
+    }
+    serde_json::from_slice(&output.stdout)
+        .with_context(|| format!("invalid ProgramArguments in {}", plist.display()))
+}
+
+fn listen_address_from_program_arguments(program_args: &[String]) -> anyhow::Result<String> {
+    for (index, arg) in program_args.iter().enumerate() {
+        if arg == "--listen" {
+            return program_args
+                .get(index + 1)
+                .filter(|value| !value.trim().is_empty())
+                .cloned()
+                .context("--listen has no value");
+        }
+        if let Some(value) = arg.strip_prefix("--listen=")
+            && !value.trim().is_empty()
+        {
+            return Ok(value.to_string());
+        }
+    }
+    anyhow::bail!("service ProgramArguments do not include --listen")
+}
+
+fn managed_service_listen_address(label: &str) -> anyhow::Result<String> {
+    let plist = launch_agent_plist(label)?;
+    if !plist.is_file() {
+        anyhow::bail!("managed service plist is missing: {}", plist.display());
+    }
+    let program_args = plist_program_arguments(&plist)?;
+    listen_address_from_program_arguments(&program_args)
+        .with_context(|| format!("failed to find listen address in {}", plist.display()))
 }
 
 fn launchd_service_loaded(label: &str) -> bool {
@@ -3786,16 +3960,43 @@ async fn handle_update(args: UpdateArgs) -> anyhow::Result<()> {
     })?;
     println!("Created pre-update backup: {}", backup_path.display());
 
-    // 9. Preserve running service state. launchd keeps the old executable alive
-    // until it is explicitly reloaded after replacement.
-    let daemon_was_running = check_daemon_running(&client).await;
+    // 9. Preserve running service state. The managed service plist is the source
+    // of truth for its address; unmanaged daemons use the persisted CLI URL.
     let daemon_is_managed = launchd_service_loaded(DAEMON_SERVICE_LABEL);
-    let web_url = "http://127.0.0.1:4173/__oore_web_healthz";
-    let web_was_running = endpoint_is_healthy(&client, web_url).await;
+    let managed_daemon_listen = daemon_is_managed
+        .then(|| managed_service_listen_address(DAEMON_SERVICE_LABEL))
+        .transpose()?;
+    let daemon_url = match managed_daemon_listen.as_deref() {
+        Some(listen) => daemon_url_from_listen_address(listen)?,
+        None => resolve_daemon_url(None)?,
+    };
+    let daemon_was_running = check_daemon_running(&client, &daemon_url).await;
+    let unmanaged_daemon_listen = if daemon_was_running && !daemon_is_managed {
+        Some(daemon_listen_address_from_url(&daemon_url)?)
+    } else {
+        None
+    };
+    let daemon_should_be_running = daemon_is_managed || daemon_was_running;
+    let daemon_ready_url = endpoint_url(&daemon_url, "/readyz");
+
     let web_is_managed = launchd_service_loaded(WEB_SERVICE_LABEL);
-    if daemon_was_running && !daemon_is_managed {
+    let web_ready_url = web_is_managed
+        .then(|| -> anyhow::Result<String> {
+            let listen = managed_service_listen_address(WEB_SERVICE_LABEL)?;
+            Ok(endpoint_url(
+                &url_from_listen_address(&listen)?,
+                "/__oore_web_healthz",
+            ))
+        })
+        .transpose()?;
+    let web_was_running = match web_ready_url.as_deref() {
+        Some(url) => endpoint_is_healthy(&client, url).await,
+        None => false,
+    };
+
+    if let Some(listen) = &unmanaged_daemon_listen {
         println!("oored daemon is running. Stopping before update...");
-        stop_daemon(&install_root)?;
+        stop_daemon(&install_root, listen)?;
     }
 
     // 10. Atomically install the staged release and only retain it if every
@@ -3804,19 +4005,19 @@ async fn handle_update(args: UpdateArgs) -> anyhow::Result<()> {
         install_staged_release(&staged_release, &install_root, channel, &repo)?;
         if daemon_is_managed {
             restart_launchd_service(DAEMON_SERVICE_LABEL)?;
-        } else if daemon_was_running {
-            restart_daemon(&install_root, &client).await?;
+        } else if let Some(listen) = &unmanaged_daemon_listen {
+            restart_daemon(&install_root, listen, &daemon_url, &client).await?;
         }
-        if daemon_was_running {
-            wait_for_endpoint(&client, "http://127.0.0.1:8787/readyz", "oored").await?;
+        if daemon_should_be_running {
+            wait_for_endpoint(&client, &daemon_ready_url, "oored").await?;
         }
         if web_is_managed {
             restart_launchd_service(WEB_SERVICE_LABEL)?;
         } else if web_was_running {
             anyhow::bail!("refusing to replace an unmanaged local web process; install it as the launchd service first");
         }
-        if web_was_running {
-            wait_for_endpoint(&client, web_url, "oore-web").await?;
+        if let Some(url) = &web_ready_url {
+            wait_for_endpoint(&client, url, "oore-web").await?;
         }
         Ok::<(), anyhow::Error>(())
     }
@@ -3827,11 +4028,17 @@ async fn handle_update(args: UpdateArgs) -> anyhow::Result<()> {
             restore_release_snapshot(&install_root, &previous_release)?;
             if daemon_is_managed {
                 restart_launchd_service(DAEMON_SERVICE_LABEL)?;
-            } else if daemon_was_running {
-                restart_daemon(&install_root, &client).await?;
+            } else if let Some(listen) = &unmanaged_daemon_listen {
+                restart_daemon(&install_root, listen, &daemon_url, &client).await?;
             }
-            if web_is_managed && web_was_running {
+            if daemon_should_be_running {
+                wait_for_endpoint(&client, &daemon_ready_url, "rollback oored").await?;
+            }
+            if web_is_managed {
                 restart_launchd_service(WEB_SERVICE_LABEL)?;
+            }
+            if let Some(url) = &web_ready_url {
+                wait_for_endpoint(&client, url, "rollback oore-web").await?;
             }
             Ok::<(), anyhow::Error>(())
         }
@@ -3991,6 +4198,62 @@ mod tests {
         assert_eq!(
             fs::read_to_string(install.join("web-dist/index.html")).unwrap(),
             "old-web"
+        );
+    }
+
+    #[test]
+    fn managed_daemon_uses_the_plist_listen_address() {
+        let program_args = vec![
+            "/Users/me/.oore/bin/oored".to_string(),
+            "run".to_string(),
+            "--listen".to_string(),
+            "10.23.0.8:9876".to_string(),
+        ];
+
+        let listen = listen_address_from_program_arguments(&program_args).unwrap();
+        assert_eq!(listen, "10.23.0.8:9876");
+        assert_eq!(
+            daemon_url_from_listen_address(&listen).unwrap(),
+            "http://10.23.0.8:9876"
+        );
+    }
+
+    #[test]
+    fn readiness_url_uses_a_reachable_wildcard_bind_address() {
+        assert_eq!(
+            url_from_listen_address("0.0.0.0:9876").unwrap(),
+            "http://127.0.0.1:9876"
+        );
+        assert_eq!(
+            url_from_listen_address("http://web.internal:4174/ignored").unwrap(),
+            "http://web.internal:4174"
+        );
+        assert_eq!(
+            daemon_listen_address_from_url("http://10.23.0.8:9876").unwrap(),
+            "10.23.0.8:9876"
+        );
+    }
+
+    #[test]
+    fn lsof_fallback_only_selects_oored_on_the_exact_socket() {
+        let fields = "\
+p101\n\
+coored\n\
+n10.23.0.9:9876\n\
+p102\n\
+cother\n\
+n10.23.0.8:9876\n\
+p103\n\
+coored\n\
+n10.23.0.8:9876\n";
+
+        assert_eq!(
+            oored_listener_pids(fields, "10.23.0.8:9876".parse().unwrap()),
+            vec![103]
+        );
+        assert_eq!(
+            oored_listener_pids("p104\ncoored\nn*:9876\n", "0.0.0.0:9876".parse().unwrap()),
+            vec![104]
         );
     }
 }

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -12,6 +12,13 @@ Rules:
 
 ## 2026-07-12
 
+- **Split deployment reliability**:
+  - Frontend-only installs now reject occupied listen ports before changing service state and require both the auth-proxy proof and backend proof for Trusted Proxy identity forwarding.
+  - `oore-web status` verifies launcher health plus dependency-aware backend readiness through the real frontend proxy path, while the proxy now forwards `/readyz` alongside `/healthz` and `/v1/*`.
+  - `oore update` derives managed daemon and web addresses from launchd configuration, preserves custom private daemon addresses for unmanaged restarts, and verifies the real readiness endpoint before accepting an update or rollback.
+  - Linux uninstall now disables, stops, removes, and reloads the `oore-web` systemd user service instead of leaving a broken lingering unit.
+  - The Mac Studio + NetBird + Warpgate runbook now documents the deployed HAProxy topology, separate frontend/backend proofs, backend-owned owner initialization, and an unused loopback port for `oore-web`.
+  - Linear feature docs: https://linear.app/oorebuild/document/feature-guided-split-deployment-installer-9da0d4bf02f6 and https://linear.app/oorebuild/document/feature-backend-owned-setup-init-for-local-and-trusted-proxy-modes-e850cb76e746
 - Release automation now uses the configurable macOS runner with a `macos-latest` fallback for validation, autotagging, and release packaging, and bootstraps Bun plus both Rust macOS targets so an unavailable pre-provisioned self-hosted runner cannot block alpha delivery.
   - Release channels doc: https://linear.app/oorebuild/document/release-channels-alpha-beta-stable-via-woodpecker-github-releases-993db297927a
 - **Product trust hardening release**:

--- a/scripts/install-acceptance.sh
+++ b/scripts/install-acceptance.sh
@@ -41,4 +41,74 @@ should_open_browser
 OORE_NO_OPEN=1
 ! should_open_browser
 
+OORE_LOCAL_WEB_LISTEN="127.0.0.1:4173"
+is_local_web_healthy() { return 1; }
+lsof() { printf '4242\n'; }
+if port_error="$(preflight_local_web_listen 2>&1)"; then
+  echo "[install-acceptance] expected occupied listen preflight to fail" >&2
+  exit 1
+fi
+[[ "$port_error" == *"127.0.0.1:4173 is already in use"* ]]
+
+service_calls="$(mktemp)"
+trap 'rm -f "$INSTALLER_LIB" "$service_calls"' EXIT
+has_local_web_bundle() { return 0; }
+systemctl() { printf '%s\n' "$*" >> "$service_calls"; }
+if service_error="$(install_local_web_systemd_user_service 2>&1)"; then
+  echo "[install-acceptance] expected occupied listen service install to fail" >&2
+  exit 1
+fi
+[[ "$service_error" == *"127.0.0.1:4173 is already in use"* ]]
+[[ ! -s "$service_calls" ]]
+
+proof_dir="$(mktemp -d)"
+trap 'rm -f "$INSTALLER_LIB" "$service_calls"; rm -rf "$proof_dir"' EXIT
+printf 'backend-proof\n' > "$proof_dir/backend"
+OORE_TRUSTED_PROXY_SHARED_SECRET=""
+OORE_TRUSTED_PROXY_SHARED_SECRET_FILE="$proof_dir/backend"
+OORE_WEB_UPSTREAM_TRUSTED_PROXY_SHARED_SECRET=""
+OORE_WEB_UPSTREAM_TRUSTED_PROXY_SHARED_SECRET_FILE=""
+if proof_error="$(ensure_frontend_secret_files 2>&1)"; then
+  echo "[install-acceptance] expected one-proof frontend setup to fail" >&2
+  exit 1
+fi
+[[ "$proof_error" == *"require a separate auth-proxy proof"* ]]
+
+OORE_WEB_UPSTREAM_TRUSTED_PROXY_SHARED_SECRET_FILE="$proof_dir/backend"
+if proof_error="$(ensure_frontend_secret_files 2>&1)"; then
+  echo "[install-acceptance] expected same proof path to fail" >&2
+  exit 1
+fi
+[[ "$proof_error" == *"must contain different values"* ]]
+
+printf 'frontend-proof\n' > "$proof_dir/frontend"
+OORE_WEB_UPSTREAM_TRUSTED_PROXY_SHARED_SECRET_FILE="$proof_dir/frontend"
+ensure_frontend_secret_files
+
+printf 'backend-proof\n' > "$proof_dir/frontend"
+if proof_error="$(ensure_frontend_secret_files 2>&1)"; then
+  echo "[install-acceptance] expected matching proof values to fail" >&2
+  exit 1
+fi
+[[ "$proof_error" == *"must contain different values"* ]]
+
+printf ' \tbackend-proof \n\n' > "$proof_dir/frontend"
+if proof_error="$(ensure_frontend_secret_files 2>&1)"; then
+  echo "[install-acceptance] expected proofs equal after trimming to fail" >&2
+  exit 1
+fi
+[[ "$proof_error" == *"must contain different values"* ]]
+
+printf ' \t\n' > "$proof_dir/frontend"
+if proof_error="$(ensure_frontend_secret_files 2>&1)"; then
+  echo "[install-acceptance] expected whitespace-only proof to fail" >&2
+  exit 1
+fi
+[[ "$proof_error" == *"empty after trimming whitespace"* ]]
+
+printf 'frontend-proof\n' > "$proof_dir/frontend"
+ensure_frontend_secret_files
+
+bash "$ROOT_DIR/scripts/uninstall-acceptance.sh"
+
 echo "[install-acceptance] passed"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -351,6 +351,30 @@ ensure_frontend_secret_files() {
     OORE_WEB_UPSTREAM_TRUSTED_PROXY_SHARED_SECRET_FILE="$(upstream_trusted_proxy_secret_file_path)"
     write_secret_file "$OORE_WEB_UPSTREAM_TRUSTED_PROXY_SHARED_SECRET_FILE" "$OORE_WEB_UPSTREAM_TRUSTED_PROXY_SHARED_SECRET"
   fi
+
+  if [[ -n "$OORE_TRUSTED_PROXY_SHARED_SECRET_FILE" ]]; then
+    [[ -s "$OORE_TRUSTED_PROXY_SHARED_SECRET_FILE" ]] \
+      || die "Backend Trusted Proxy proof file is missing or empty: $OORE_TRUSTED_PROXY_SHARED_SECRET_FILE"
+    [[ -n "$OORE_WEB_UPSTREAM_TRUSTED_PROXY_SHARED_SECRET_FILE" ]] \
+      || die 'Trusted Proxy frontend installs require a separate auth-proxy proof. Set OORE_WEB_UPSTREAM_TRUSTED_PROXY_SHARED_SECRET or OORE_WEB_UPSTREAM_TRUSTED_PROXY_SHARED_SECRET_FILE.'
+    [[ -s "$OORE_WEB_UPSTREAM_TRUSTED_PROXY_SHARED_SECRET_FILE" ]] \
+      || die "Auth-proxy proof file is missing or empty: $OORE_WEB_UPSTREAM_TRUSTED_PROXY_SHARED_SECRET_FILE"
+    local backend_proof upstream_proof
+    backend_proof="$(< "$OORE_TRUSTED_PROXY_SHARED_SECRET_FILE")"
+    upstream_proof="$(< "$OORE_WEB_UPSTREAM_TRUSTED_PROXY_SHARED_SECRET_FILE")"
+    backend_proof="${backend_proof#"${backend_proof%%[![:space:]]*}"}"
+    backend_proof="${backend_proof%"${backend_proof##*[![:space:]]}"}"
+    upstream_proof="${upstream_proof#"${upstream_proof%%[![:space:]]*}"}"
+    upstream_proof="${upstream_proof%"${upstream_proof##*[![:space:]]}"}"
+    [[ -n "$backend_proof" ]] || die 'Backend Trusted Proxy proof file is empty after trimming whitespace.'
+    [[ -n "$upstream_proof" ]] || die 'Auth-proxy proof file is empty after trimming whitespace.'
+    if [[ "$backend_proof" == "$upstream_proof" ]]; then
+      die 'Backend and auth-proxy proof files must contain different values.'
+    fi
+    unset backend_proof upstream_proof
+  elif [[ -n "$OORE_WEB_UPSTREAM_TRUSTED_PROXY_SHARED_SECRET_FILE" ]]; then
+    die 'Auth-proxy proof requires a backend Trusted Proxy proof. Set OORE_TRUSTED_PROXY_SHARED_SECRET or OORE_TRUSTED_PROXY_SHARED_SECRET_FILE.'
+  fi
 }
 
 launchd_env_entry() {
@@ -958,7 +982,7 @@ configure_frontend_install() {
           prompt_text \
             "Auth proxy -> oore-web proof secret. Configure your auth proxy to send this in ${OORE_WEB_UPSTREAM_TRUSTED_PROXY_SECRET_HEADER} with the user email header." \
             "$OORE_WEB_UPSTREAM_TRUSTED_PROXY_SHARED_SECRET" \
-            "optional"
+            "required"
         )"
       fi
     fi
@@ -1600,11 +1624,34 @@ is_local_web_healthy() {
   curl_quick "${LOCAL_WEB_URL}/__oore_web_healthz" >/dev/null 2>&1
 }
 
+preflight_local_web_listen() {
+  # A healthy existing oore-web instance already owns this address.
+  is_local_web_healthy && return 0
+
+  local port="${OORE_LOCAL_WEB_LISTEN##*:}"
+  [[ "$port" =~ ^[0-9]+$ ]] || die "OORE_LOCAL_WEB_LISTEN must include a numeric port (got: $OORE_LOCAL_WEB_LISTEN)"
+
+  local listeners=""
+  if have_cmd lsof; then
+    listeners="$(lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null || true)"
+  elif have_cmd ss; then
+    if ss -H -ltn "sport = :$port" 2>/dev/null | grep -q .; then
+      listeners=1
+    fi
+  else
+    die "Cannot check whether $OORE_LOCAL_WEB_LISTEN is available: install lsof or ss."
+  fi
+
+  [[ -z "$listeners" ]] || die "Cannot start oore-web: $OORE_LOCAL_WEB_LISTEN is already in use. Set OORE_LOCAL_WEB_LISTEN to an available host:port."
+}
+
 start_local_web() {
   if ! has_local_web_bundle; then
     log "Bundled local web UI not found in this release."
     return 1
   fi
+
+  preflight_local_web_listen
 
   mkdir -p "$LOG_DIR"
 
@@ -1653,6 +1700,8 @@ install_local_web_launch_agent() {
     log "Cannot install launch agent: bundled local web UI is unavailable."
     return 1
   fi
+
+  preflight_local_web_listen
 
   mkdir -p "$HOME/Library/LaunchAgents" "$LOG_DIR"
   cat > "$WEB_LAUNCH_AGENT_PLIST" <<EOF
@@ -1713,6 +1762,9 @@ install_local_web_systemd_user_service() {
     log "Cannot install systemd user service: bundled web UI is unavailable."
     return 1
   fi
+
+  preflight_local_web_listen
+
   if ! have_cmd systemctl; then
     log "Cannot install systemd user service: systemctl is unavailable."
     return 1
@@ -2000,6 +2052,7 @@ print_next_steps() {
     printf 'Backend proxy target: %s\n\n' "$WEB_BACKEND_URL"
     if "$local_web_running"; then
       printf 'Frontend status: running\n'
+      printf 'Verify frontend + backend: oore-web status --url %s\n' "$LOCAL_WEB_URL"
     else
       printf 'Start the frontend:\n'
       printf '  oore-web --listen %s --backend-url %s\n' "$OORE_LOCAL_WEB_LISTEN" "$WEB_BACKEND_URL"

--- a/scripts/uninstall-acceptance.sh
+++ b/scripts/uninstall-acceptance.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+export HOME="$TEST_DIR/home"
+export XDG_CONFIG_HOME="$TEST_DIR/xdg"
+mkdir -p "$HOME"
+
+# Load uninstaller functions without running main.
+UNINSTALLER_LIB="$TEST_DIR/uninstall-lib.sh"
+sed '$d' "$ROOT_DIR/scripts/uninstall.sh" > "$UNINSTALLER_LIB"
+# shellcheck disable=SC1090
+source "$UNINSTALLER_LIB"
+
+mkdir -p "$WEB_SYSTEMD_USER_DIR"
+touch "$WEB_SYSTEMD_SERVICE_FILE"
+SYSTEMCTL_LOG="$TEST_DIR/systemctl.log"
+systemctl() { printf '%s\n' "$*" >> "$SYSTEMCTL_LOG"; }
+uname() { printf 'Linux\n'; }
+
+remove_local_web_systemd_user_service
+remove_local_web_systemd_user_service
+
+[[ ! -e "$WEB_SYSTEMD_SERVICE_FILE" ]]
+grep -q -- '--user disable --now oore-web.service' "$SYSTEMCTL_LOG"
+grep -q -- '--user daemon-reload' "$SYSTEMCTL_LOG"
+grep -q -- '--user reset-failed oore-web.service' "$SYSTEMCTL_LOG"
+
+echo "[uninstall-acceptance] passed"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -12,6 +12,9 @@ DAEMON_LAUNCH_AGENT_LABEL="build.oore.oored"
 DAEMON_LAUNCH_AGENT_PLIST="$HOME/Library/LaunchAgents/$DAEMON_LAUNCH_AGENT_LABEL.plist"
 WEB_LAUNCH_AGENT_LABEL="build.oore.oore-web"
 WEB_LAUNCH_AGENT_PLIST="$HOME/Library/LaunchAgents/$WEB_LAUNCH_AGENT_LABEL.plist"
+WEB_SYSTEMD_USER_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+WEB_SYSTEMD_SERVICE_NAME="oore-web.service"
+WEB_SYSTEMD_SERVICE_FILE="$WEB_SYSTEMD_USER_DIR/$WEB_SYSTEMD_SERVICE_NAME"
 UI_RESET=""
 UI_BOLD=""
 UI_DIM=""
@@ -287,6 +290,24 @@ remove_local_web_launch_agent() {
   fi
 }
 
+remove_local_web_systemd_user_service() {
+  [[ "$(uname -s)" == "Linux" ]] || return 0
+
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl --user disable --now "$WEB_SYSTEMD_SERVICE_NAME" >/dev/null 2>&1 || true
+  fi
+
+  if [[ -f "$WEB_SYSTEMD_SERVICE_FILE" ]]; then
+    log "Removing systemd user service: $WEB_SYSTEMD_SERVICE_FILE"
+    rm -f "$WEB_SYSTEMD_SERVICE_FILE"
+  fi
+
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl --user daemon-reload >/dev/null 2>&1 || true
+    systemctl --user reset-failed "$WEB_SYSTEMD_SERVICE_NAME" >/dev/null 2>&1 || true
+  fi
+}
+
 remove_from_path() {
   local rc_files=("$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile")
 
@@ -356,7 +377,7 @@ main() {
 
   print_uninstall_intro
 
-  if [[ ! -d "$OORE_INSTALL_ROOT" ]] && ! grep -rqF "$BIN_DIR" "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile" 2>/dev/null; then
+  if [[ ! -d "$OORE_INSTALL_ROOT" ]] && [[ ! -f "$WEB_SYSTEMD_SERVICE_FILE" ]] && ! grep -rqF "$BIN_DIR" "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.profile" 2>/dev/null; then
     log "Oore CI does not appear to be installed."
     exit 0
   fi
@@ -372,6 +393,7 @@ main() {
   stop_daemon
   stop_local_web
   remove_local_web_launch_agent
+  remove_local_web_systemd_user_service
   remove_from_path
   remove_install_dir
   remove_data_dir


### PR DESCRIPTION
## What changed
- make the Mac backend and Ubuntu frontend split deployment installable behind HAProxy/Warpgate
- require distinct backend and frontend trust proofs and fail safely on occupied ports
- add frontend readiness/status diagnostics and reliable Linux uninstall handling
- make update/rollback honor configured daemon addresses and target only the exact managed process
- replace the deployment runbook with the supported NetBird + HAProxy topology

## Verification
- `make validate`
- `make release-smoke`
- independent release-blocker review: clear

## Product docs
- Updated split deployment operations and CLI setup documentation
- Added `docs/changes.md` entry linked to the existing Linear feature docs