### PR TITLE
fix(installer): preserve explicit macOS roles

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -12,6 +12,10 @@ Rules:
 
 ## 2026-07-12
 
+- **Installer explicit-role and timeout fix**:
+  - Explicit macOS `backend` and `frontend` roles are no longer overwritten by the simple all-in-one default.
+  - Release discovery and downloads now have bounded connection and transfer timeouts instead of hanging indefinitely on a broken network path.
+  - Linear feature doc: https://linear.app/oorebuild/document/feature-guided-split-deployment-installer-9da0d4bf02f6
 - **Split deployment reliability**:
   - Frontend-only installs now reject occupied listen ports before changing service state and require both the auth-proxy proof and backend proof for Trusted Proxy identity forwarding.
   - `oore-web status` verifies launcher health plus dependency-aware backend readiness through the real frontend proxy path, while the proxy now forwards `/readyz` alongside `/healthz` and `/v1/*`.

--- a/scripts/install-acceptance.sh
+++ b/scripts/install-acceptance.sh
@@ -16,6 +16,10 @@ RELEASE_OS=darwin
 configure_install_mode
 [[ "$OORE_INSTALL_MODE" == "all" ]]
 
+OORE_INSTALL_MODE=backend
+configure_install_mode
+[[ "$OORE_INSTALL_MODE" == "backend" ]]
+
 OORE_DAEMON_LISTEN=""
 OORE_DAEMON_URL="http://127.0.0.1:8787"
 DAEMON_URL="$OORE_DAEMON_URL"
@@ -31,6 +35,29 @@ OORE_LOCAL_WEB_LISTEN=""
 configure_frontend_install
 [[ "$OORE_LOCAL_WEB_LISTEN" == "127.0.0.1:4173" ]]
 [[ "$OORE_LOCAL_WEB_MODE" == "login" ]]
+
+curl_args="$(mktemp)"
+OORE_CHANNEL=alpha
+OORE_VERSION=latest
+OORE_RELEASES_LIST_URL=https://example.invalid/releases
+TMP_DIR="$(mktemp -d)"
+curl() {
+  printf '%s\n' "$*" > "$curl_args"
+  local previous=""
+  for argument in "$@"; do
+    if [[ "$previous" == "--output" ]]; then
+      printf '[{"tag_name":"v1.0.0-alpha.1","draft":false,"prerelease":true}]\n' > "$argument"
+      break
+    fi
+    previous="$argument"
+  done
+}
+resolve_release_tag
+[[ "$RELEASE_TAG" == "v1.0.0-alpha.1" ]]
+grep -q -- '--connect-timeout 10 --max-time 60' "$curl_args"
+unset -f curl
+rm -rf "$TMP_DIR"
+rm -f "$curl_args"
 
 OORE_NONINTERACTIVE=1
 OORE_OPEN_BROWSER=""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -769,7 +769,7 @@ normalize_runtime_config() {
 configure_install_mode() {
   normalize_install_mode
 
-  if [[ "$OORE_ADVANCED" -eq 0 && "$RELEASE_OS" == "darwin" ]]; then
+  if [[ "$OORE_ADVANCED" -eq 0 && "$RELEASE_OS" == "darwin" && "$OORE_INSTALL_MODE" == "auto" ]]; then
     OORE_INSTALL_MODE="all"
     return 0
   fi
@@ -1161,7 +1161,7 @@ resolve_release_tag() {
   if [[ "$OORE_VERSION" == "latest" ]]; then
     if [[ "$OORE_CHANNEL" == "stable" ]]; then
       local manifest_file="$TMP_DIR/latest.json"
-      if curl -fsSL --retry 3 --output "$manifest_file" "$OORE_RELEASE_MANIFEST_URL"; then
+      if curl -fsSL --retry 3 --connect-timeout 10 --max-time 60 --output "$manifest_file" "$OORE_RELEASE_MANIFEST_URL"; then
         # GitHub API returns "tag_name": "vX.Y.Z"
         tag="$(sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$manifest_file" | head -n1)"
         [[ -n "$tag" ]] || die "Unable to parse tag from release manifest: $OORE_RELEASE_MANIFEST_URL"
@@ -1169,7 +1169,7 @@ resolve_release_tag() {
         # GitHub returns 404 when there are no releases yet.
         local list_file="$TMP_DIR/releases.json"
         log "No stable release manifest found. Falling back to release list."
-        curl -fsSL --retry 3 --output "$list_file" "$OORE_RELEASES_LIST_URL" \
+        curl -fsSL --retry 3 --connect-timeout 10 --max-time 60 --output "$list_file" "$OORE_RELEASES_LIST_URL" \
           || die "Unable to fetch release list: $OORE_RELEASES_LIST_URL"
 
         tag="$(resolve_latest_stable_tag_from_list "$list_file" || true)"
@@ -1177,7 +1177,7 @@ resolve_release_tag() {
       fi
     else
       local list_file="$TMP_DIR/releases.json"
-      curl -fsSL --retry 3 --output "$list_file" "$OORE_RELEASES_LIST_URL" \
+      curl -fsSL --retry 3 --connect-timeout 10 --max-time 60 --output "$list_file" "$OORE_RELEASES_LIST_URL" \
         || die "Unable to fetch release list: $OORE_RELEASES_LIST_URL"
 
       tag="$(resolve_latest_channel_tag_from_list "$list_file" "$OORE_CHANNEL" || true)"
@@ -1231,9 +1231,9 @@ download_release_assets() {
   local checksum_url="$base_url/$checksum_name"
 
   log "Downloading release assets for $RELEASE_TAG ($OORE_INSTALL_MODE/$RELEASE_OS/$RELEASE_ARCH)..."
-  curl -fsSL --retry 3 --output "$TMP_DIR/$archive_name" "$archive_url" \
+  curl -fsSL --retry 3 --connect-timeout 10 --max-time 600 --output "$TMP_DIR/$archive_name" "$archive_url" \
     || die "Failed to download release archive: $archive_url"
-  curl -fsSL --retry 3 --output "$TMP_DIR/$checksum_name" "$checksum_url" \
+  curl -fsSL --retry 3 --connect-timeout 10 --max-time 60 --output "$TMP_DIR/$checksum_name" "$checksum_url" \
     || die "Failed to download checksum file: $checksum_url"
 }
 


### PR DESCRIPTION
## Fix
- preserve explicit backend/frontend roles on macOS
- retain the requested private daemon listen address
- bound release discovery and download network waits
- add acceptance coverage for both regressions

## Verification
- `make validate`