### PR TITLE
ci(release): build macOS targets in parallel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,8 +62,37 @@ jobs:
           make build-demo
           make deploy-demo-only
 
+  rust:
+    name: Build Rust (${{ matrix.arch }})
+    runs-on: ${{ vars.RUNNER_MACOS || 'macos-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            target: aarch64-apple-darwin
+          - arch: x86_64
+            target: x86_64-apple-darwin
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build Rust
+        run: |
+          rustup target add "${{ matrix.target }}"
+          cargo build --release -p oored -p oore --target "${{ matrix.target }}"
+          mkdir -p dist/rust
+          cp "target/${{ matrix.target }}/release/oored" dist/rust/oored
+          cp "target/${{ matrix.target }}/release/oore" dist/rust/oore
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: rust-${{ matrix.arch }}
+          path: dist/rust
+          if-no-files-found: error
+
   release:
     name: Build & publish assets
+    needs: rust
     runs-on: ${{ vars.RUNNER_MACOS || 'macos-latest' }}
     permissions:
       contents: write
@@ -75,24 +104,21 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
-      - name: Setup Rust targets
-        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
-
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/download-artifact@v6
         with:
-          cache-bin: false
-          cache-on-failure: true
+          name: rust-arm64
+          path: dist/rust/arm64
+
+      - uses: actions/download-artifact@v6
+        with:
+          name: rust-x86_64
+          path: dist/rust/x86_64
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
       - name: Build web
         run: make build-web
-
-      - name: Cross-compile Rust
-        run: |
-          cargo build --release -p oored -p oore --target aarch64-apple-darwin
-          cargo build --release -p oored -p oore --target x86_64-apple-darwin
 
       - name: Compile standalone web server
         run: |
@@ -120,15 +146,15 @@ jobs:
           mkdir -p "$stage_web_darwin_arm/bin" "$stage_web_darwin_x64/bin"
           mkdir -p "$stage_web_linux_arm/bin" "$stage_web_linux_x64/bin"
 
-          cp "target/aarch64-apple-darwin/release/oored" "$stage_arm/bin/oored"
-          cp "target/aarch64-apple-darwin/release/oore"  "$stage_arm/bin/oore"
+          cp "dist/rust/arm64/oored" "$stage_arm/bin/oored"
+          cp "dist/rust/arm64/oore"  "$stage_arm/bin/oore"
           cp "dist/oore-web-arm64" "$stage_arm/bin/oore-web"
           cp -R "apps/web/dist" "$stage_arm/web-dist"
           cp "LICENSE" "$stage_arm/LICENSE"
           printf '%s\n' "$ver" > "$stage_arm/VERSION"
 
-          cp "target/x86_64-apple-darwin/release/oored" "$stage_x64/bin/oored"
-          cp "target/x86_64-apple-darwin/release/oore"  "$stage_x64/bin/oore"
+          cp "dist/rust/x86_64/oored" "$stage_x64/bin/oored"
+          cp "dist/rust/x86_64/oore"  "$stage_x64/bin/oore"
           cp "dist/oore-web-x86_64" "$stage_x64/bin/oore-web"
           cp -R "apps/web/dist" "$stage_x64/web-dist"
           cp "LICENSE" "$stage_x64/LICENSE"

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -13,7 +13,7 @@ Rules:
 ## 2026-07-12
 
 - **CI and release latency**:
-  - Rust validation and release builds now reuse dependency artifacts, release-branch path filtering compares only the current push, and Pages deployment runs independently from binary packaging.
+  - Rust validation reuses dependency artifacts, release-branch path filtering compares only the current push, Pages deployment runs independently from binary packaging, and macOS ARM64/x86_64 release binaries build in parallel.
   - Release channels doc: https://linear.app/oorebuild/document/release-channels-alpha-beta-stable-via-woodpecker-github-releases-993db297927a
 - **Installer explicit-role and timeout fix**:
   - Explicit macOS `backend` and `frontend` roles are no longer overwritten by the simple all-in-one default.


### PR DESCRIPTION
## Change
- build ARM64 and x86_64 Rust release binaries on parallel macOS runners
- pass binaries to the packaging job with workflow artifacts
- remove ineffective tag-scoped Rust caching from release builds

## Measured motivation
- Pages now deploy in 1m14s
- serial release assets still took 17m53s

## Verification
- `actionlint .github/workflows/release.yml .github/workflows/validate.yml`
- `make release-smoke`
- `make validate`