### PR TITLE
fix(installer): support headless macOS backend

### DIFF
--- a/apps/docs-site/docs/operations/mac-studio-netbird-warpgate.md
+++ b/apps/docs-site/docs/operations/mac-studio-netbird-warpgate.md
@@ -76,6 +76,8 @@ The installer creates the backend proof at:
 ~/.oore/trusted-proxy-shared-secret
 ```
 
+Backend-only macOS installs use a system LaunchDaemon running as the installing account. The installer asks for `sudo` so the daemon starts at boot without a GUI login session.
+
 Transfer that file to the Ubuntu service account through your approved secret-delivery path. Do not paste it into shell history or store it in the repository.
 
 ### 2. Prepare the Ubuntu proof files

--- a/apps/docs-site/docs/reference/cli/index.md
+++ b/apps/docs-site/docs/reference/cli/index.md
@@ -47,7 +47,7 @@ In default mode, `oored` starts an embedded local runner automatically. Set `OOR
 ### `oored install-service`
 
 ```bash
-oored install-service [--listen <addr>] [--state-file <path>] [--label <label>] [--env KEY=VALUE] [--no-start]
+oored install-service [--listen <addr>] [--state-file <path>] [--label <label>] [--env KEY=VALUE] [--no-start] [--system --user <name>]
 ```
 
 Installs `oored` as a macOS launchd user service. The default service label is
@@ -61,6 +61,8 @@ Installs `oored` as a macOS launchd user service. The default service label is
 | `--label` | `build.oore.oored` | none | Override the launchd service label and plist name |
 | `--env KEY=VALUE` | none | none | Add or override an environment variable in the launchd plist. Repeat for multiple variables |
 | `--no-start` | `false` | none | Write the plist without bootstrapping the service |
+| `--system` | `false` | none | Install a boot-time LaunchDaemon; requires root |
+| `--user` | none | none | Account that runs the LaunchDaemon; required with `--system` |
 
 The service uses the currently running `oored` executable, keeps the daemon alive
 with launchd, writes logs to `~/.oore/logs/oored.log`, and preserves the same
@@ -87,13 +89,14 @@ Useful launchd checks:
 
 ```bash
 launchctl print gui/$(id -u)/build.oore.oored
+sudo launchctl print system/build.oore.oored
 tail -f ~/.oore/logs/oored.log
 ```
 
 ### `oored uninstall-service`
 
 ```bash
-oored uninstall-service [--label <label>]
+oored uninstall-service [--label <label>] [--system]
 ```
 
 Stops and removes the launchd user service. This deletes the plist but leaves

--- a/apps/site/public/uninstall
+++ b/apps/site/public/uninstall
@@ -236,8 +236,15 @@ stop_daemon() {
 }
 
 remove_daemon_launch_agent() {
+  local install_mode=""
+  [[ -f "$OORE_INSTALL_ROOT/INSTALL_MODE" ]] && install_mode="$(cat "$OORE_INSTALL_ROOT/INSTALL_MODE")"
+
   if [[ -x "$BIN_DIR/oored" ]]; then
-    "$BIN_DIR/oored" uninstall-service >/dev/null 2>&1 || true
+    if [[ "$install_mode" == "backend" ]]; then
+      sudo "$BIN_DIR/oored" uninstall-service --system >/dev/null 2>&1 || true
+    else
+      "$BIN_DIR/oored" uninstall-service >/dev/null 2>&1 || true
+    fi
   fi
 
   if command -v launchctl >/dev/null 2>&1; then

--- a/crates/oore/src/main.rs
+++ b/crates/oore/src/main.rs
@@ -3500,6 +3500,14 @@ fn launch_agent_plist(label: &str) -> anyhow::Result<PathBuf> {
         .join(format!("{label}.plist")))
 }
 
+fn managed_service_plist(label: &str) -> anyhow::Result<(PathBuf, bool)> {
+    let system_plist = PathBuf::from("/Library/LaunchDaemons").join(format!("{label}.plist"));
+    if system_plist.is_file() {
+        return Ok((system_plist, true));
+    }
+    Ok((launch_agent_plist(label)?, false))
+}
+
 fn url_from_socket_address(address: SocketAddr) -> String {
     let ip = match address.ip() {
         IpAddr::V4(ip) if ip.is_unspecified() => IpAddr::V4(Ipv4Addr::LOCALHOST),
@@ -3600,7 +3608,7 @@ fn listen_address_from_program_arguments(program_args: &[String]) -> anyhow::Res
 }
 
 fn managed_service_listen_address(label: &str) -> anyhow::Result<String> {
-    let plist = launch_agent_plist(label)?;
+    let (plist, _) = managed_service_plist(label)?;
     if !plist.is_file() {
         anyhow::bail!("managed service plist is missing: {}", plist.display());
     }
@@ -3613,12 +3621,20 @@ fn launchd_service_loaded(label: &str) -> bool {
     if !cfg!(target_os = "macos") {
         return false;
     }
-    let Ok(uid) = std::process::Command::new("id").arg("-u").output() else {
+    let Ok((_, system)) = managed_service_plist(label) else {
         return false;
     };
-    let uid = String::from_utf8_lossy(&uid.stdout).trim().to_string();
+    let service = if system {
+        format!("system/{label}")
+    } else {
+        let Ok(uid) = std::process::Command::new("id").arg("-u").output() else {
+            return false;
+        };
+        let uid = String::from_utf8_lossy(&uid.stdout).trim().to_string();
+        format!("gui/{uid}/{label}")
+    };
     std::process::Command::new("launchctl")
-        .args(["print", &format!("gui/{uid}/{label}")])
+        .args(["print", &service])
         .output()
         .map(|output| output.status.success())
         .unwrap_or(false)
@@ -3628,28 +3644,36 @@ fn restart_launchd_service(label: &str) -> anyhow::Result<()> {
     if !cfg!(target_os = "macos") {
         anyhow::bail!("managed service restart is supported on macOS only");
     }
-    let plist = launch_agent_plist(label)?;
+    let (plist, system) = managed_service_plist(label)?;
     if !plist.is_file() {
         anyhow::bail!("managed service plist is missing: {}", plist.display());
     }
-    let uid = std::process::Command::new("id")
-        .arg("-u")
-        .output()
-        .context("failed to determine current user id")?;
-    let uid = String::from_utf8_lossy(&uid.stdout).trim().to_string();
-    let service = format!("gui/{uid}/{label}");
-    let domain = format!("gui/{uid}");
-    let _ = std::process::Command::new("launchctl")
+    let (service, domain) = if system {
+        (format!("system/{label}"), "system".to_string())
+    } else {
+        let uid = std::process::Command::new("id")
+            .arg("-u")
+            .output()
+            .context("failed to determine current user id")?;
+        let uid = String::from_utf8_lossy(&uid.stdout).trim().to_string();
+        (format!("gui/{uid}/{label}"), format!("gui/{uid}"))
+    };
+    let command = if system { "sudo" } else { "launchctl" };
+    let prefix: &[&str] = if system { &["launchctl"] } else { &[] };
+    let _ = std::process::Command::new(command)
+        .args(prefix)
         .args(["bootout", &service])
         .status();
-    let status = std::process::Command::new("launchctl")
+    let status = std::process::Command::new(command)
+        .args(prefix)
         .args(["bootstrap", &domain, &plist.display().to_string()])
         .status()
         .context("failed to bootstrap launchd service")?;
     if !status.success() {
         anyhow::bail!("failed to bootstrap managed service {label}");
     }
-    let _ = std::process::Command::new("launchctl")
+    let _ = std::process::Command::new(command)
+        .args(prefix)
         .args(["kickstart", "-k", &service])
         .status();
     Ok(())

--- a/crates/oored/src/main.rs
+++ b/crates/oored/src/main.rs
@@ -62,6 +62,14 @@ struct InstallServiceArgs {
     /// Write the launchd plist without starting the service.
     #[arg(long)]
     no_start: bool,
+
+    /// Install a boot-time LaunchDaemon instead of a GUI-session LaunchAgent.
+    #[arg(long)]
+    system: bool,
+
+    /// User account that runs a system LaunchDaemon.
+    #[arg(long, requires = "system")]
+    user: Option<String>,
 }
 
 #[derive(Debug, clap::Args)]
@@ -69,6 +77,10 @@ struct UninstallServiceArgs {
     /// launchd label to remove.
     #[arg(long, default_value = "build.oore.oored")]
     label: String,
+
+    /// Remove the boot-time LaunchDaemon instead of the user LaunchAgent.
+    #[arg(long)]
+    system: bool,
 }
 
 // ── Server bootstrap ─────────────────────────────────────────────
@@ -203,6 +215,11 @@ fn launch_agent_plist_path(label: &str) -> anyhow::Result<PathBuf> {
     Ok(launch_agent_dir()?.join(format!("{label}.plist")))
 }
 
+fn launch_daemon_plist_path(label: &str) -> anyhow::Result<PathBuf> {
+    validate_launchd_label(label)?;
+    Ok(PathBuf::from("/Library/LaunchDaemons").join(format!("{label}.plist")))
+}
+
 fn xml_escape(raw: &str) -> String {
     let mut escaped = String::with_capacity(raw.len());
     for ch in raw.chars() {
@@ -281,6 +298,7 @@ fn render_launchd_plist(
     env: &BTreeMap<String, String>,
     log_path: &Path,
     working_dir: &Path,
+    user: Option<&str>,
 ) -> String {
     let mut out = String::from(
         r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -293,6 +311,12 @@ fn render_launchd_plist(
         "    <key>Label</key>\n    <string>{}</string>\n",
         xml_escape(label)
     ));
+    if let Some(user) = user {
+        out.push_str(&format!(
+            "    <key>UserName</key>\n    <string>{}</string>\n",
+            xml_escape(user)
+        ));
+    }
     out.push_str("    <key>ProgramArguments</key>\n    <array>\n");
     for arg in program_args {
         out.push_str(&format!("      <string>{}</string>\n", xml_escape(arg)));
@@ -355,14 +379,31 @@ fn install_service(args: InstallServiceArgs) -> anyhow::Result<()> {
     }
 
     validate_launchd_label(&args.label)?;
-    let install_root = resolve_install_root()?;
     let bin = std::env::current_exe().context("failed to resolve current executable")?;
+    let install_root = if args.system {
+        if current_uid()? != "0" {
+            anyhow::bail!("system service installation requires root; rerun with sudo");
+        }
+        bin.parent()
+            .and_then(Path::parent)
+            .map(Path::to_path_buf)
+            .context("failed to derive install root from oored binary")?
+    } else {
+        resolve_install_root()?
+    };
     let log_dir = install_root.join("logs");
     let log_path = log_dir.join("oored.log");
-    let plist_path = launch_agent_plist_path(&args.label)?;
+    let plist_path = if args.system {
+        launch_daemon_plist_path(&args.label)?
+    } else {
+        launch_agent_plist_path(&args.label)?
+    };
 
     fs::create_dir_all(&log_dir).context("failed to create oored log directory")?;
-    fs::create_dir_all(launch_agent_dir()?).context("failed to create LaunchAgents directory")?;
+    if !args.system {
+        fs::create_dir_all(launch_agent_dir()?)
+            .context("failed to create LaunchAgents directory")?;
+    }
 
     let mut program_args = vec![
         bin.display().to_string(),
@@ -376,13 +417,27 @@ fn install_service(args: InstallServiceArgs) -> anyhow::Result<()> {
     }
 
     let env = service_environment(&args.env)?;
-    let plist = render_launchd_plist(&args.label, &program_args, &env, &log_path, &install_root);
+    let service_user = args.user.as_deref();
+    if args.system && service_user.is_none() {
+        anyhow::bail!("--user is required with --system");
+    }
+    let plist = render_launchd_plist(
+        &args.label,
+        &program_args,
+        &env,
+        &log_path,
+        &install_root,
+        service_user,
+    );
     fs::write(&plist_path, plist)
         .with_context(|| format!("failed to write {}", plist_path.display()))?;
 
-    let uid = current_uid()?;
-    let service = format!("gui/{uid}/{}", args.label);
-    let domain = format!("gui/{uid}");
+    let (service, domain) = if args.system {
+        (format!("system/{}", args.label), "system".to_string())
+    } else {
+        let uid = current_uid()?;
+        (format!("gui/{uid}/{}", args.label), format!("gui/{uid}"))
+    };
 
     if args.no_start {
         println!("Installed launchd service plist: {}", plist_path.display());
@@ -417,9 +472,20 @@ fn uninstall_service(args: UninstallServiceArgs) -> anyhow::Result<()> {
     }
 
     validate_launchd_label(&args.label)?;
-    let plist_path = launch_agent_plist_path(&args.label)?;
-    let uid = current_uid()?;
-    let service = format!("gui/{uid}/{}", args.label);
+    if args.system && current_uid()? != "0" {
+        anyhow::bail!("system service removal requires root; rerun with sudo");
+    }
+    let plist_path = if args.system {
+        launch_daemon_plist_path(&args.label)?
+    } else {
+        launch_agent_plist_path(&args.label)?
+    };
+    let service = if args.system {
+        format!("system/{}", args.label)
+    } else {
+        let uid = current_uid()?;
+        format!("gui/{uid}/{}", args.label)
+    };
 
     let _ = launchctl(&["bootout", &service]);
     let _ = launchctl(&["remove", &args.label]);
@@ -482,6 +548,7 @@ mod tests {
             &env,
             Path::new("/tmp/oore<log>.log"),
             Path::new("/tmp/oore&root"),
+            None,
         );
 
         assert!(plist.contains("<string>build.oore.oored</string>"));
@@ -489,6 +556,17 @@ mod tests {
         assert!(plist.contains("https://ci.example.com?a=1&amp;b=2"));
         assert!(plist.contains("/tmp/oore&lt;log&gt;.log"));
         assert!(plist.contains("/tmp/oore&amp;root"));
+        assert!(!plist.contains("<key>UserName</key>"));
+
+        let system_plist = render_launchd_plist(
+            "build.oore.oored",
+            &args,
+            &env,
+            Path::new("/tmp/oore.log"),
+            Path::new("/Users/appbuilder/.oore"),
+            Some("appbuilder"),
+        );
+        assert!(system_plist.contains("<key>UserName</key>\n    <string>appbuilder</string>"));
     }
 
     #[test]

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -12,6 +12,9 @@ Rules:
 
 ## 2026-07-12
 
+- **Headless macOS backend service**:
+  - Backend-only installs now use a boot-time system LaunchDaemon running as the installing account, so SSH-only Mac build hosts do not require an active GUI login session.
+  - Linear feature doc: https://linear.app/oorebuild/document/feature-guided-split-deployment-installer-9da0d4bf02f6
 - **CI and release latency**:
   - Rust validation reuses dependency artifacts, release-branch path filtering compares only the current push, Pages deployment runs independently from binary packaging, and macOS ARM64/x86_64 release binaries build in parallel.
   - Release channels doc: https://linear.app/oorebuild/document/release-channels-alpha-beta-stable-via-woodpecker-github-releases-993db297927a

--- a/scripts/install-acceptance.sh
+++ b/scripts/install-acceptance.sh
@@ -36,6 +36,22 @@ configure_frontend_install
 [[ "$OORE_LOCAL_WEB_LISTEN" == "127.0.0.1:4173" ]]
 [[ "$OORE_LOCAL_WEB_MODE" == "login" ]]
 
+service_call="$(mktemp)"
+OORE_INSTALL_MODE=backend
+OORE_DAEMON_LISTEN=100.64.0.10:8787
+OORE_PUBLIC_URL=""
+OORE_CORS_ORIGINS=""
+DAEMON_URL=http://100.64.0.10:8787
+DAEMON_LOG=/tmp/oored.log
+BIN_DIR=/Users/appbuilder/.oore/bin
+sudo() { printf '%s\n' "$*" > "$service_call"; }
+id() { [[ "${1:-}" == "-un" ]] && printf 'appbuilder\n' || command id "$@"; }
+curl_quick() { return 0; }
+install_daemon_service
+grep -q -- '/oored install-service --system --user appbuilder --listen 100.64.0.10:8787 --env HOME=' "$service_call"
+unset -f sudo id curl_quick
+rm -f "$service_call"
+
 curl_args="$(mktemp)"
 OORE_CHANNEL=alpha
 OORE_VERSION=latest

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1471,6 +1471,16 @@ start_daemon() {
 
 install_daemon_service() {
   local cmd=("$BIN_DIR/oored" "install-service" "--listen" "$OORE_DAEMON_LISTEN")
+  local retry_cmd="$BIN_DIR/oored install-service --listen $OORE_DAEMON_LISTEN"
+
+  if [[ "$OORE_INSTALL_MODE" == "backend" ]]; then
+    ensure_dependency sudo
+    local service_user
+    service_user="$(id -un)"
+    cmd=(sudo "$BIN_DIR/oored" "install-service" "--system" "--user" "$service_user" "--listen" "$OORE_DAEMON_LISTEN")
+    cmd+=("--env" "HOME=$HOME")
+    retry_cmd="sudo $BIN_DIR/oored install-service --system --user $service_user --listen $OORE_DAEMON_LISTEN --env HOME=$HOME"
+  fi
 
   if [[ -n "$OORE_PUBLIC_URL" ]]; then
     cmd+=("--env" "OORE_PUBLIC_URL=$OORE_PUBLIC_URL")
@@ -1484,7 +1494,7 @@ install_daemon_service() {
     report_component_failure \
       "oored launchd service" \
       "$DAEMON_LOG" \
-      "$BIN_DIR/oored install-service --listen $OORE_DAEMON_LISTEN" \
+      "$retry_cmd" \
       "$DAEMON_URL/healthz"
     return 1
   fi
@@ -1504,7 +1514,7 @@ install_daemon_service() {
     report_component_failure \
       "oored launchd service" \
       "$DAEMON_LOG" \
-      "$BIN_DIR/oored install-service --listen $OORE_DAEMON_LISTEN" \
+      "$retry_cmd" \
       "$DAEMON_URL/healthz"
     return 1
   fi

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -236,8 +236,15 @@ stop_daemon() {
 }
 
 remove_daemon_launch_agent() {
+  local install_mode=""
+  [[ -f "$OORE_INSTALL_ROOT/INSTALL_MODE" ]] && install_mode="$(cat "$OORE_INSTALL_ROOT/INSTALL_MODE")"
+
   if [[ -x "$BIN_DIR/oored" ]]; then
-    "$BIN_DIR/oored" uninstall-service >/dev/null 2>&1 || true
+    if [[ "$install_mode" == "backend" ]]; then
+      sudo "$BIN_DIR/oored" uninstall-service --system >/dev/null 2>&1 || true
+    else
+      "$BIN_DIR/oored" uninstall-service >/dev/null 2>&1 || true
+    fi
   fi
 
   if command -v launchctl >/dev/null 2>&1; then


### PR DESCRIPTION
## Fix
- install backend-only macOS services as boot-time LaunchDaemons
- run the daemon under the installing account without requiring a GUI session
- teach update and uninstall flows about the system service
- keep all-in-one desktop installs on their existing LaunchAgent path

## Verification
- `make validate`
- focused oored/oore service tests
- installer and uninstall acceptance tests