### PR TITLE
fix(installer): migrate legacy backend service

### DIFF
--- a/apps/site/public/uninstall
+++ b/apps/site/public/uninstall
@@ -242,9 +242,8 @@ remove_daemon_launch_agent() {
   if [[ -x "$BIN_DIR/oored" ]]; then
     if [[ "$install_mode" == "backend" ]]; then
       sudo "$BIN_DIR/oored" uninstall-service --system >/dev/null 2>&1 || true
-    else
-      "$BIN_DIR/oored" uninstall-service >/dev/null 2>&1 || true
     fi
+    "$BIN_DIR/oored" uninstall-service >/dev/null 2>&1 || true
   fi
 
   if command -v launchctl >/dev/null 2>&1; then

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -14,6 +14,7 @@ Rules:
 
 - **Headless macOS backend service**:
   - Backend-only installs now use a boot-time system LaunchDaemon running as the installing account, so SSH-only Mac build hosts do not require an active GUI login session.
+  - Reinstall and uninstall remove any legacy user LaunchAgent left by an earlier backend installation attempt.
   - Linear feature doc: https://linear.app/oorebuild/document/feature-guided-split-deployment-installer-9da0d4bf02f6
 - **CI and release latency**:
   - Rust validation reuses dependency artifacts, release-branch path filtering compares only the current push, Pages deployment runs independently from binary packaging, and macOS ARM64/x86_64 release binaries build in parallel.

--- a/scripts/install-acceptance.sh
+++ b/scripts/install-acceptance.sh
@@ -37,19 +37,25 @@ configure_frontend_install
 [[ "$OORE_LOCAL_WEB_MODE" == "login" ]]
 
 service_call="$(mktemp)"
+service_bin_dir="$(mktemp -d)"
+printf '#!/bin/sh\nprintf "%%s\\n" "$*" >> "$SERVICE_CALL"\n' > "$service_bin_dir/oored"
+chmod +x "$service_bin_dir/oored"
+export SERVICE_CALL="$service_call"
 OORE_INSTALL_MODE=backend
 OORE_DAEMON_LISTEN=100.64.0.10:8787
 OORE_PUBLIC_URL=""
 OORE_CORS_ORIGINS=""
 DAEMON_URL=http://100.64.0.10:8787
 DAEMON_LOG=/tmp/oored.log
-BIN_DIR=/Users/appbuilder/.oore/bin
-sudo() { printf '%s\n' "$*" > "$service_call"; }
+BIN_DIR="$service_bin_dir"
+sudo() { printf '%s\n' "$*" >> "$service_call"; }
 id() { [[ "${1:-}" == "-un" ]] && printf 'appbuilder\n' || command id "$@"; }
 curl_quick() { return 0; }
 install_daemon_service
+grep -q -- '^uninstall-service$' "$service_call"
 grep -q -- '/oored install-service --system --user appbuilder --listen 100.64.0.10:8787 --env HOME=' "$service_call"
 unset -f sudo id curl_quick
+rm -rf "$service_bin_dir"
 rm -f "$service_call"
 
 curl_args="$(mktemp)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1477,6 +1477,7 @@ install_daemon_service() {
     ensure_dependency sudo
     local service_user
     service_user="$(id -un)"
+    "$BIN_DIR/oored" uninstall-service >/dev/null 2>&1 || true
     cmd=(sudo "$BIN_DIR/oored" "install-service" "--system" "--user" "$service_user" "--listen" "$OORE_DAEMON_LISTEN")
     cmd+=("--env" "HOME=$HOME")
     retry_cmd="sudo $BIN_DIR/oored install-service --system --user $service_user --listen $OORE_DAEMON_LISTEN --env HOME=$HOME"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -242,9 +242,8 @@ remove_daemon_launch_agent() {
   if [[ -x "$BIN_DIR/oored" ]]; then
     if [[ "$install_mode" == "backend" ]]; then
       sudo "$BIN_DIR/oored" uninstall-service --system >/dev/null 2>&1 || true
-    else
-      "$BIN_DIR/oored" uninstall-service >/dev/null 2>&1 || true
     fi
+    "$BIN_DIR/oored" uninstall-service >/dev/null 2>&1 || true
   fi
 
   if command -v launchctl >/dev/null 2>&1; then


### PR DESCRIPTION
## Fix
- remove a stale backend LaunchAgent before installing the headless LaunchDaemon
- remove both service forms during uninstall
- cover interrupted-install recovery in acceptance tests

## Verification
- `make validate`