### PR TITLE
fix(installer): replace running binaries atomically

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -12,6 +12,10 @@ Rules:
 
 ## 2026-07-12
 
+- **Atomic installer executable upgrades**:
+  - The installer now stages each executable beside its destination and atomically renames it into place, so reinstalling over a running macOS LaunchDaemon does not mutate its live executable inode and trigger `Killed: 9` during service replacement.
+  - Installer acceptance coverage asserts that replacement changes the destination inode while preserving executable permissions and content.
+  - Linear feature doc: https://linear.app/oorebuild/document/feature-guided-split-deployment-installer-9da0d4bf02f6
 - **Frontend Trusted Proxy pairing**:
   - `oore frontend invite` now creates a short-lived, single-use pairing code for a ready Trusted Proxy backend. A frontend-only installer can exchange `OORE_FRONTEND_PAIRING_CODE` through the private, CIDR-restricted `/v1/frontend/pair` capability, save the backend proof, and generate a separate local HAProxy-to-`oore-web` proof.
   - The split-role, installer, Mac Studio + NetBird + Warpgate, CLI, and OpenAPI documentation now describe pairing as the normal path while keeping manual proof files as an advanced fallback.

--- a/scripts/install-acceptance.sh
+++ b/scripts/install-acceptance.sh
@@ -36,6 +36,17 @@ configure_frontend_install
 [[ "$OORE_LOCAL_WEB_LISTEN" == "127.0.0.1:4173" ]]
 [[ "$OORE_LOCAL_WEB_MODE" == "login" ]]
 
+atomic_dir="$(mktemp -d)"
+printf 'old' > "$atomic_dir/oored"
+printf 'new' > "$atomic_dir/source"
+old_inode="$(ls -di "$atomic_dir/oored" | awk '{print $1}')"
+install_executable "$atomic_dir/source" "$atomic_dir/oored"
+new_inode="$(ls -di "$atomic_dir/oored" | awk '{print $1}')"
+[[ "$new_inode" != "$old_inode" ]]
+[[ -x "$atomic_dir/oored" ]]
+[[ "$(< "$atomic_dir/oored")" == "new" ]]
+rm -rf "$atomic_dir"
+
 service_call="$(mktemp)"
 service_bin_dir="$(mktemp -d)"
 printf '#!/bin/sh\nprintf "%%s\\n" "$*" >> "$SERVICE_CALL"\n' > "$service_bin_dir/oored"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1392,6 +1392,14 @@ verify_archive_checksum() {
   log "Checksum verified for $archive_name."
 }
 
+install_executable() {
+  local source="$1"
+  local destination="$2"
+  local staged="${destination}.install.$$"
+  install -m 0755 "$source" "$staged"
+  mv -f "$staged" "$destination"
+}
+
 install_binaries() {
   local archive_name
   local extract_dir="$TMP_DIR/extract"
@@ -1412,13 +1420,11 @@ install_binaries() {
 
   mkdir -p "$BIN_DIR" "$LOG_DIR"
   if is_daemon_install; then
-    cp "$extract_dir/bin/oored" "$BIN_DIR/oored"
-    cp "$extract_dir/bin/oore" "$BIN_DIR/oore"
-    chmod +x "$BIN_DIR/oored" "$BIN_DIR/oore"
+    install_executable "$extract_dir/bin/oored" "$BIN_DIR/oored"
+    install_executable "$extract_dir/bin/oore" "$BIN_DIR/oore"
   fi
   if is_web_install; then
-    cp "$extract_dir/bin/oore-web" "$WEB_BINARY"
-    chmod +x "$WEB_BINARY"
+    install_executable "$extract_dir/bin/oore-web" "$WEB_BINARY"
     rm -rf "$WEB_DIST_DIR"
     cp -R "$extract_dir/web-dist" "$WEB_DIST_DIR"
   else


### PR DESCRIPTION
## What changed

- stage executables beside their destination and atomically rename them into place
- avoid mutating the executable inode held by a running macOS LaunchDaemon
- assert inode replacement, mode, and content in installer acceptance coverage

## Validation

- bash -n scripts/install.sh
- bash scripts/install-acceptance.sh
- make validate
- canonical Linear feature doc updated