### PR TITLE
feat(product): harden onboarding, runner readiness, and GitLab

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3413,12 +3413,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
+ "tokio-util",
  "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -5002,6 +5004,19 @@ name = "wasm-bindgen-test-shared"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8145dd1593bf0fb137dbfa85b8be79ec560a447298955877804640e40c2d6ea"
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tokio-stream = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 openidconnect = "4"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
 url = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
 dialoguer = "0.11"

--- a/apps/docs-site/docs/guides/integrations/gitlab.md
+++ b/apps/docs-site/docs/guides/integrations/gitlab.md
@@ -5,60 +5,65 @@ description: "Connect GitLab repositories to Oore CI for webhook-triggered build
 
 # Connect GitLab
 
-This guide covers connecting a GitLab instance to Oore CI for repository access and webhook-triggered builds.
+This guide covers GitLab.com and self-managed GitLab sources, including private repository checkout and webhook-triggered builds.
 
 ## What you need
 
 - **Role**: owner or admin
 - A running Oore CI instance in `ready` state
 - A [GitLab](https://about.gitlab.com/) account (self-hosted or gitlab.com)
-- Permission to create OAuth applications in your GitLab instance
+- A GitLab personal access token, or permission to create an OAuth application
 
 ## Steps
 
-### 1. Create a GitLab OAuth application
+## Choose an authentication method
 
-1. In GitLab, go to **Admin Area > Applications** (for instance-wide) or **User Settings > Applications** (for personal)
-2. Create a new application:
-   - **Name**: `Oore CI`
-   - **Redirect URI**: `http://127.0.0.1:8787/v1/integrations/gitlab/callback`
-   - **Scopes**: `api`, `read_repository`
-   - **Confidential**: Yes
-3. Save and copy the **Application ID** and **Secret**
+Use a personal access token for the shortest setup, especially for an internal self-managed instance. Create the token with `read_user`, `read_api`, and `read_repository`. Oore encrypts the token and uses it for repository discovery and private checkout.
 
-For GitLab OAuth documentation, see [GitLab OAuth 2.0 provider](https://docs.gitlab.com/api/oauth2/).
+Use OAuth when your organization manages applications centrally. The Oore form shows the exact HTTPS callback URL to register. Select `read_api` and `read_repository`; full write-capable `api` access is not required.
 
-### 2. Start the integration in Oore CI
+## Connect GitLab
 
-1. In the web UI, go to **Settings > Integrations**
-2. Click **Connect GitLab**
-3. Enter your GitLab host URL (e.g., `https://gitlab.com` or your self-hosted URL)
-4. Enter the Application ID and Secret from step 1
+1. In the web UI, open **Sources** and choose **Connect GitLab**.
+2. Enter the root origin, such as `https://gitlab.com` or `https://gitlab.example.com`. Do not append `/api/v4` or a group path.
+3. Choose **Personal Access Token** or **OAuth Application** and follow the inline fields.
+4. Copy the generated webhook secret before saving the source.
+5. For OAuth, register the callback URL shown by Oore, save the source, then choose **Authorize on GitLab** from its details page.
 
-### 3. Authorize
+Oore returns OAuth callbacks through the browser-facing Oore URL. In split deployments this is the AWS frontend/proxy URL, not the private macOS daemon address.
 
-Oore CI redirects you to GitLab to authorize the OAuth application. After authorization, GitLab redirects back and Oore CI stores the credentials.
+## Verify repository discovery
 
-### 4. Verify
+Open the source details page and choose **Sync GitLab projects**. Oore follows GitLab pagination, so project inventories larger than 100 are included. Repositories no longer visible to the GitLab account are removed from the source inventory.
 
-Go to **Projects > New Project** and confirm your GitLab repositories appear in the source selection dropdown.
+Go to **Projects**, create a project, and confirm the repository picker identifies the GitLab host as well as the project path.
 
 ## Webhook configuration
 
 When you create a project from a GitLab repository, Oore CI needs webhooks for automatic build triggers. Configure the webhook in your GitLab project:
 
 1. In GitLab, go to **Project Settings > Webhooks**
-2. Add a webhook:
-   - **URL**: `http://<your-oore-instance>:8787/v1/webhooks/gitlab`
+2. Add a webhook using the values shown on the GitLab source screen:
+   - **URL**: `https://<your-oore-frontend>/v1/webhooks/gitlab`
    - **Trigger**: Push events, Merge request events
-   - **Secret token**: (use the token from your Oore CI integration settings)
+   - **Secret token**: the generated secret copied while connecting the source
 3. Click **Add webhook**
+
+The URL must be reachable by GitLab. In a split deployment, the frontend proxy forwards this path to the private backend. Oore derives a stable delivery identity when older/self-managed GitLab versions omit `X-Gitlab-Event-UUID`, so retries do not create duplicate builds.
+
+## Private repository checkout
+
+Runners fetch private GitLab repositories through an authenticated Oore checkout proxy. The stored GitLab token is decrypted only by the backend and is not written to build snapshots or logs.
+
+Private submodules are not yet proxied. A build can clone public submodules normally, but a private GitLab submodule currently needs its own runner-visible credentials. Oore deliberately does not apply one integration token to every repository on the GitLab host.
+
+OAuth access tokens are not refreshed automatically yet. If GitLab expires or revokes the token, re-authorize the source from its details page.
 
 ## Removing the integration
 
 1. Go to **Settings > Integrations** in Oore CI
-2. Click the GitLab integration
-3. Click **Delete**
+2. Open the GitLab source
+3. Click **Disconnect**
 
 Also revoke the OAuth application in GitLab if no longer needed.
 

--- a/apps/docs-site/docs/guides/runners/embedded-runner.md
+++ b/apps/docs-site/docs/guides/runners/embedded-runner.md
@@ -16,6 +16,8 @@ When `oored run` starts without `OORED_RUNNER_MODE=external`, the daemon:
 3. Build logs stream directly within the same process
 4. Artifacts are handled locally
 
+If the daemon is bound to a specific private address, `oored` also binds the same port on loopback so the embedded runner can heartbeat and claim work without exposing a wildcard listener.
+
 ## When to use
 
 The embedded runner is appropriate for:
@@ -29,6 +31,8 @@ The embedded runner is appropriate for:
 1. Go to **Settings > Runners** in the web UI
 2. An embedded runner should appear as `online`
 3. Trigger a test build — it should move from `queued` to `running` within seconds
+
+If the runner shows `offline` with a last heartbeat of `never`, verify `http://127.0.0.1:<daemon-port>/readyz` on the Mac and inspect the daemon log before creating projects or pipelines.
 
 ## Switching to external mode
 

--- a/apps/docs-site/docs/operations/mac-studio-netbird-warpgate.md
+++ b/apps/docs-site/docs/operations/mac-studio-netbird-warpgate.md
@@ -72,6 +72,8 @@ Replace `100.64.10.20` with the Mac NetBird address, `100.64.10.30/32` with the 
 
 Backend-only macOS installs use a system LaunchDaemon running as the installing account. The installer asks for `sudo` so the daemon starts at boot without a GUI login session.
 
+When the daemon binds a specific NetBird address, it also opens the same port on loopback for the embedded runner and local operator commands. It does not add a wildcard listener; the NetBird address remains the only non-loopback daemon address.
+
 ### 2. Create a frontend pairing code
 
 On the Mac, after backend setup is ready, create a short-lived single-use code:
@@ -130,6 +132,14 @@ backend oore_web
 Manual backend-proof transfer and a manually managed frontend proof remain an advanced fallback. Configure `OORE_TRUSTED_PROXY_SHARED_SECRET_FILE` and `OORE_WEB_UPSTREAM_TRUSTED_PROXY_SHARED_SECRET_FILE` with different mode-`0600` files only when you intentionally manage that distribution yourself.
 
 ### 5. Verify before opening access
+
+On the Mac:
+
+```bash
+curl -fsS http://127.0.0.1:8787/readyz
+```
+
+The loopback readiness request must succeed. After signing in, **Runners** must show the embedded runner as `online`; backend readiness alone is not sufficient for a testable build host.
 
 On Ubuntu:
 

--- a/apps/docs-site/docs/public/openapi.json
+++ b/apps/docs-site/docs/public/openapi.json
@@ -3744,6 +3744,130 @@
         ]
       }
     },
+    "/v1/runners/{runner_id}/jobs/{job_id}/gitlab/{git_path}": {
+      "get": {
+        "tags": [
+          "Runners"
+        ],
+        "summary": "Discover a private GitLab repository for checkout",
+        "description": "Internal Git smart-HTTP endpoint. The runner token is accepted only for\nthe repository assigned to this job; GitLab credentials remain server-side.",
+        "operationId": "gitlab_checkout_discovery",
+        "parameters": [
+          {
+            "name": "runner_id",
+            "in": "path",
+            "description": "Runner ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "job_id",
+            "in": "path",
+            "description": "Build/Job ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "git_path",
+            "in": "path",
+            "description": "Assigned repository info/refs path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "service",
+            "in": "query",
+            "description": "Must be git-upload-pack",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Git upload-pack discovery response"
+          },
+          "403": {
+            "description": "Repository path does not match the assigned job",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Runners"
+        ],
+        "summary": "Stream a private GitLab upload-pack request",
+        "operationId": "gitlab_checkout_upload_pack",
+        "parameters": [
+          {
+            "name": "runner_id",
+            "in": "path",
+            "description": "Runner ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "job_id",
+            "in": "path",
+            "description": "Build/Job ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "git_path",
+            "in": "path",
+            "description": "Assigned repository git-upload-pack path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Git upload-pack response"
+          },
+          "403": {
+            "description": "Repository path does not match the assigned job",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/v1/runners/{runner_id}/jobs/{job_id}/logs": {
       "post": {
         "tags": [

--- a/apps/web/src/lib/gitlab-url.test.ts
+++ b/apps/web/src/lib/gitlab-url.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeGitLabHostUrl } from './gitlab-url'
+
+describe('normalizeGitLabHostUrl', () => {
+  it('keeps only a normalized HTTP(S) host origin', () => {
+    expect(normalizeGitLabHostUrl(' https://gitlab.example.test/ ')).toBe(
+      'https://gitlab.example.test',
+    )
+    expect(normalizeGitLabHostUrl('http://gitlab.internal:8443')).toBe(
+      'http://gitlab.internal:8443',
+    )
+  })
+
+  it('rejects credentials and non-host URLs', () => {
+    expect(normalizeGitLabHostUrl('gitlab.example.test')).toBeNull()
+    expect(
+      normalizeGitLabHostUrl('https://user@gitlab.example.test'),
+    ).toBeNull()
+    expect(
+      normalizeGitLabHostUrl('https://gitlab.example.test/api/v4'),
+    ).toBeNull()
+  })
+})

--- a/apps/web/src/lib/gitlab-url.ts
+++ b/apps/web/src/lib/gitlab-url.ts
@@ -1,0 +1,19 @@
+export function normalizeGitLabHostUrl(value: string): string | null {
+  try {
+    const url = new URL(value.trim())
+    if (
+      !['http:', 'https:'].includes(url.protocol) ||
+      !url.hostname ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash ||
+      !/^\/+$/u.test(url.pathname)
+    ) {
+      return null
+    }
+    return url.origin
+  } catch {
+    return null
+  }
+}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -35,6 +35,7 @@ import { useBuilds } from '@/hooks/use-builds'
 import { useIntegrations } from '@/hooks/use-integrations'
 import { useHasPermission } from '@/hooks/use-permissions'
 import { useProjects } from '@/hooks/use-projects'
+import { useRunners } from '@/hooks/use-runners'
 import { useSetupStatus } from '@/hooks/use-setup'
 import { getSetupStatus } from '@/lib/api'
 import { getStatusVariant } from '@/lib/status-variants'
@@ -293,6 +294,7 @@ function ConfiguredDashboard({
     [projectsQuery.data?.projects],
   )
   const integrationsQuery = useIntegrations()
+  const runnersQuery = useRunners()
   const integrations = useMemo(
     () => integrationsQuery.data?.integrations ?? [],
     [integrationsQuery.data?.integrations],
@@ -323,7 +325,12 @@ function ConfiguredDashboard({
     integrationsResolved &&
     activeIntegrationsCount === 0
   const integrationConnectTo = '/settings/integrations'
-  const canShowRunBuild = canWriteBuilds && hasProjects
+  const noOnlineRunners =
+    !!runnersQuery.data &&
+    !runnersQuery.data.runners.some(
+      (runner) => runner.status === 'online' || runner.status === 'busy',
+    )
+  const canShowRunBuild = canWriteBuilds && hasProjects && !noOnlineRunners
 
   // Derive last build status per project from recent builds
   const lastBuildByProject = useMemo(() => {
@@ -383,6 +390,16 @@ function ConfiguredDashboard({
             >
               Dismiss
             </Button>
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {noOnlineRunners ? (
+        <Alert variant="destructive">
+          <AlertTitle>No runner is available</AlertTitle>
+          <AlertDescription>
+            Builds cannot run until a runner checks in. Verify that the Oore
+            daemon is running on the runner host.
           </AlertDescription>
         </Alert>
       ) : null}
@@ -455,7 +472,6 @@ function ConfiguredDashboard({
                         </p>
                         {canWriteIntegrations ? (
                           <Button
-                            variant="outline"
                             size="sm"
                             render={<Link to={integrationConnectTo} />}
                             nativeButton={false}
@@ -483,7 +499,7 @@ function ConfiguredDashboard({
                           ? 'Point to a local Flutter repository to get started.'
                           : 'Pick a repository from a connected source or use a local path.'}
                       </p>
-                      {canWriteProjects ? (
+                      {canWriteProjects && !noConnectedSources ? (
                         <Button
                           size="sm"
                           render={

--- a/apps/web/src/routes/projects/-create-project-dialog.tsx
+++ b/apps/web/src/routes/projects/-create-project-dialog.tsx
@@ -2,13 +2,13 @@ import { useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import z from 'zod'
-import { useNavigate } from '@tanstack/react-router'
+import { Link, useNavigate } from '@tanstack/react-router'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { Folder02Icon } from '@hugeicons/core-free-icons'
 import { toast } from 'sonner'
 
 import { useQuery } from '@tanstack/react-query'
-import type { IntegrationRepository } from '@/lib/types'
+import type { IntegrationRepository, ScmProvider } from '@/lib/types'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import LocalFolderPickerDialog from '@/components/LocalFolderPickerDialog'
@@ -59,6 +59,18 @@ interface CreateProjectDialogProps {
   onOpenChange: (open: boolean) => void
 }
 
+type SourceRepository = IntegrationRepository & {
+  integration_id: string
+  provider: ScmProvider
+  host_url: string
+}
+
+function sourceProviderLabel(provider: ScmProvider): string {
+  if (provider === 'gitlab') return 'GitLab'
+  if (provider === 'github') return 'GitHub'
+  return 'Local Git'
+}
+
 function isLoopbackHostname(hostname: string): boolean {
   return (
     hostname === 'localhost' ||
@@ -88,7 +100,7 @@ function useAvailableRepos(enabled: boolean) {
     queryFn: async () => {
       if (!baseUrl || !token) return []
       const intResp = await listIntegrations(baseUrl, token)
-      const repos: Array<IntegrationRepository> = []
+      const repos: Array<SourceRepository> = []
       for (const integration of intResp.integrations) {
         try {
           const repoResp = await listIntegrationRepos(
@@ -96,7 +108,14 @@ function useAvailableRepos(enabled: boolean) {
             token,
             integration.id,
           )
-          repos.push(...repoResp.repositories)
+          repos.push(
+            ...repoResp.repositories.map((repository) => ({
+              ...repository,
+              integration_id: integration.id,
+              provider: integration.provider,
+              host_url: integration.host_url,
+            })),
+          )
         } catch {
           // skip failed sources
         }
@@ -126,15 +145,20 @@ export default function CreateProjectDialog({
   const canBrowseLocalFs = uiIsLoopback && backendIsLoopback
 
   const [sourceKind, setSourceKind] = useState<'local' | 'repo'>('local')
-  const [sourceKindTouched, setSourceKindTouched] = useState(false)
-
   const { data: repos, isLoading: reposLoading } = useAvailableRepos(
     open && isRemoteMode && sourceKind === 'repo',
   )
   const [selectedRepoId, setSelectedRepoId] = useState<string>('')
   const [pickerOpen, setPickerOpen] = useState(false)
+
   const repoItems = useMemo(
-    () => Object.fromEntries((repos ?? []).map((r) => [r.id, r.full_name])),
+    () =>
+      Object.fromEntries(
+        (repos ?? []).map((repository) => [
+          repository.id,
+          `${repository.full_name} · ${sourceProviderLabel(repository.provider)} (${repository.host_url})`,
+        ]),
+      ),
     [repos],
   )
   const hasRepos = (repos?.length ?? 0) > 0
@@ -150,17 +174,7 @@ export default function CreateProjectDialog({
     mode: 'onBlur',
   })
 
-  // Derive effective sourceKind: fallback to 'local' if remote mode has no repos
-  const effectiveSourceKind =
-    isRemoteMode &&
-    sourceKind === 'repo' &&
-    !hasRepos &&
-    !sourceKindTouched &&
-    !reposLoading
-      ? 'local'
-      : sourceKind
-
-  // Derive effective selectedRepoId: auto-select first repo
+  const effectiveSourceKind = sourceKind
   const effectiveSelectedRepoId = selectedRepoId || repos?.[0]?.id || ''
 
   function applyLocalPath(path: string, closePicker = false) {
@@ -254,13 +268,11 @@ export default function CreateProjectDialog({
   function handleOpenChange(nextOpen: boolean) {
     if (nextOpen) {
       setSourceKind(isRemoteMode ? 'repo' : 'local')
-      setSourceKindTouched(false)
       setSelectedRepoId('')
     } else {
       form.reset()
       setSelectedRepoId('')
       setSourceKind('local')
-      setSourceKindTouched(false)
       setPickerOpen(false)
     }
     onOpenChange(nextOpen)
@@ -320,7 +332,6 @@ export default function CreateProjectDialog({
               <Tabs
                 value={effectiveSourceKind}
                 onValueChange={(v) => {
-                  setSourceKindTouched(true)
                   setSourceKind(v as 'local' | 'repo')
                 }}
               >
@@ -404,10 +415,21 @@ export default function CreateProjectDialog({
                       </SelectContent>
                     </Select>
                   ) : (
-                    <p className="text-sm text-muted-foreground">
-                      No source repositories available. Connect a source and
-                      sync repositories first.
-                    </p>
+                    <div className="space-y-3">
+                      <p className="text-sm text-muted-foreground">
+                        No source repositories are available yet. Connect a
+                        source, then sync its repositories before creating a
+                        project.
+                      </p>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        render={<Link to="/settings/integrations" />}
+                        nativeButton={false}
+                      >
+                        Connect Source
+                      </Button>
+                    </div>
                   )}
                 </TabsContent>
               </Tabs>

--- a/apps/web/src/routes/projects/index.tsx
+++ b/apps/web/src/routes/projects/index.tsx
@@ -152,11 +152,25 @@ function ProjectsListPage() {
               {runtimeMode === 'local'
                 ? 'Choose a local Git repository to create your first project.'
                 : noConnectedSources
-                  ? 'Create a project from a local repository path, or connect a source to pick from synced repositories.'
+                  ? 'Connect a source before creating your first remote project.'
                   : 'Create a project from a connected source repository to define pipelines and start builds.'}
             </p>
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-              {canWriteProjects ? (
+              {runtimeMode === 'remote' && noConnectedSources ? (
+                canWriteIntegrations ? (
+                  <Button
+                    render={<Link to={integrationConnectTo} />}
+                    nativeButton={false}
+                  >
+                    <HugeiconsIcon icon={Link04Icon} size={16} />
+                    Connect Source
+                  </Button>
+                ) : (
+                  <p className="text-xs text-muted-foreground">
+                    Ask an owner/admin to connect a source.
+                  </p>
+                )
+              ) : canWriteProjects ? (
                 <Button
                   onClick={() => setCreateOpen(true)}
                   disabled={isDemoMode}
@@ -170,23 +184,6 @@ function ProjectsListPage() {
                   Ask an owner/admin/developer to create the first project.
                 </p>
               )}
-
-              {runtimeMode === 'remote' && noConnectedSources ? (
-                canWriteIntegrations ? (
-                  <Button
-                    variant="outline"
-                    render={<Link to={integrationConnectTo} />}
-                    nativeButton={false}
-                  >
-                    <HugeiconsIcon icon={Link04Icon} size={16} />
-                    Connect Source
-                  </Button>
-                ) : (
-                  <p className="text-xs text-muted-foreground">
-                    Ask an owner/admin to connect a source.
-                  </p>
-                )
-              ) : null}
             </div>
           </CardContent>
         </Card>

--- a/apps/web/src/routes/settings/integrations/$integrationId.tsx
+++ b/apps/web/src/routes/settings/integrations/$integrationId.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, useNavigate, useSearch } from '@tanstack/react-router'
 import { HugeiconsIcon } from '@hugeicons/react'
 import {
+  Copy01Icon,
   Delete02Icon,
   InformationCircleIcon,
   LinkSquare02Icon,
@@ -74,6 +75,7 @@ function humanizeAuthMode(mode: string): string {
     github_app: 'GitHub App',
     oauth_app: 'OAuth App',
     pat: 'Personal Access Token',
+    personal_token: 'Personal Access Token',
   }
   return (
     labels[mode] ??
@@ -100,7 +102,11 @@ function IntegrationDetailPage() {
     detail?.integration.provider ??
     'Source Details'
 
-  useBreadcrumbLabel(setLabel, '/settings/integrations/$integrationId', detail?.integration.display_name ?? detail?.integration.provider)
+  useBreadcrumbLabel(
+    setLabel,
+    '/settings/integrations/$integrationId',
+    detail?.integration.display_name ?? detail?.integration.provider,
+  )
 
   useMountEffect(() => {
     if (search.installed === 'true') {
@@ -178,6 +184,20 @@ function IntegrationDetailPage() {
   const { integration } = detail
   const installations = installationsData?.installations ?? []
   const repositories = reposData?.repositories ?? []
+  const providerLabel = integration.provider === 'gitlab' ? 'GitLab' : 'GitHub'
+  const sourceDescription =
+    integration.provider === 'gitlab'
+      ? `GitLab source at ${integration.host_url}. Authorize, then sync projects to make them available in Oore.`
+      : 'GitHub App installation and repository link state for this source connection.'
+  const installationsLabel =
+    integration.provider === 'gitlab' ? 'GitLab accounts' : 'Installations'
+  const repositoriesLabel =
+    integration.provider === 'gitlab' ? 'GitLab projects' : 'Repositories'
+  const syncLabel =
+    integration.provider === 'gitlab'
+      ? 'Sync GitLab projects'
+      : 'Sync Installations'
+  const gitLabWebhookUrl = `${window.location.origin}/v1/webhooks/gitlab`
   const canSyncInstallations =
     integration.provider === 'github' || integration.provider === 'gitlab'
 
@@ -187,13 +207,13 @@ function IntegrationDetailPage() {
       <PageHeader
         title={integration.display_name ?? integration.provider}
         back={{ to: '/settings/integrations', label: 'Sources' }}
-        description="Installation and repository link state for this source connection."
+        description={sourceDescription}
         meta={
           <>
             <Badge variant={getIntegrationStatusVariant(integration.status)}>
               {integration.status}
             </Badge>
-            <Badge variant="outline">{integration.provider}</Badge>
+            <Badge variant="outline">{providerLabel}</Badge>
             <span className="font-mono">{integration.id.slice(0, 8)}</span>
           </>
         }
@@ -268,6 +288,36 @@ function IntegrationDetailPage() {
                 </TableCell>
                 <TableCell>{humanizeAuthMode(integration.auth_mode)}</TableCell>
               </TableRow>
+              {integration.provider === 'gitlab' ? (
+                <TableRow>
+                  <TableCell className="text-muted-foreground">
+                    Webhook URL
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      <code className="font-mono text-xs">
+                        {gitLabWebhookUrl}
+                      </code>
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        aria-label="Copy GitLab webhook URL"
+                        title="Copy GitLab webhook URL"
+                        onClick={() => {
+                          void navigator.clipboard
+                            .writeText(gitLabWebhookUrl)
+                            .then(
+                              () => toast.success('Webhook URL copied'),
+                              () => toast.error('Could not copy webhook URL'),
+                            )
+                        }}
+                      >
+                        <HugeiconsIcon icon={Copy01Icon} size={14} />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ) : null}
               {integration.app_id ? (
                 <TableRow>
                   <TableCell className="text-muted-foreground">
@@ -300,12 +350,19 @@ function IntegrationDetailPage() {
           integration.auth_mode === 'oauth_app' &&
           integration.status === 'inactive' ? (
             <Button
-              variant="outline"
               onClick={() =>
-                gitlabAuthorizeMutation.mutate({
-                  integration_id: integrationId,
-                  redirect_url: window.location.href,
-                })
+                gitlabAuthorizeMutation.mutate(
+                  {
+                    integration_id: integrationId,
+                    redirect_url: window.location.href,
+                  },
+                  {
+                    onError: (authorizationError) =>
+                      toast.error(
+                        `GitLab authorization failed: ${authorizationError.message}`,
+                      ),
+                  },
+                )
               }
               disabled={gitlabAuthorizeMutation.isPending}
             >
@@ -339,6 +396,24 @@ function IntegrationDetailPage() {
             </Button>
           ) : null}
 
+          {integration.provider === 'gitlab' ? (
+            <Button
+              variant="outline"
+              render={
+                <a
+                  href={integration.host_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Open GitLab in a new tab"
+                />
+              }
+              nativeButton={false}
+            >
+              <HugeiconsIcon icon={Setting07Icon} size={16} />
+              Open GitLab
+            </Button>
+          ) : null}
+
           {canSyncInstallations ? (
             <Button
               variant="outline"
@@ -346,7 +421,7 @@ function IntegrationDetailPage() {
               disabled={syncMutation.isPending}
             >
               <HugeiconsIcon icon={Refresh01Icon} size={16} />
-              {syncMutation.isPending ? 'Syncing...' : 'Sync Installations'}
+              {syncMutation.isPending ? 'Syncing...' : syncLabel}
             </Button>
           ) : null}
 
@@ -381,13 +456,17 @@ function IntegrationDetailPage() {
       <Card>
         <CardHeader>
           <CardTitle className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
-            Installations ({installations.length})
+            {installationsLabel} ({installations.length})
           </CardTitle>
         </CardHeader>
         <CardContent>
           {installations.length === 0 ? (
             <p className="text-sm text-muted-foreground">
-              No installations yet
+              No{' '}
+              {integration.provider === 'gitlab'
+                ? 'GitLab account'
+                : 'installation'}{' '}
+              yet
               {integration.provider === 'github' && integration.app_slug
                 ? ' - install your GitHub App to get started.'
                 : '.'}
@@ -420,13 +499,17 @@ function IntegrationDetailPage() {
       <Card>
         <CardHeader>
           <CardTitle className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
-            Repositories ({repositories.length})
+            {repositoriesLabel} ({repositories.length})
           </CardTitle>
         </CardHeader>
         <CardContent>
           {repositories.length === 0 ? (
             <p className="text-sm text-muted-foreground">
-              No repositories synced yet.
+              No{' '}
+              {integration.provider === 'gitlab'
+                ? 'GitLab projects'
+                : 'repositories'}{' '}
+              synced yet.
             </p>
           ) : (
             <Table>

--- a/apps/web/src/routes/settings/integrations/gitlab.tsx
+++ b/apps/web/src/routes/settings/integrations/gitlab.tsx
@@ -1,8 +1,12 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import z from 'zod'
 import { toast } from 'sonner'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { Copy01Icon, Refresh01Icon } from '@hugeicons/core-free-icons'
+import type { UseFormReturn } from 'react-hook-form'
 
 import {
   getActiveInstanceOrRedirect,
@@ -10,6 +14,7 @@ import {
 } from '@/lib/instance-context'
 import { useInstancePreferences } from '@/hooks/use-artifact-storage'
 import { useGitLabStart } from '@/hooks/use-integrations'
+import { normalizeGitLabHostUrl } from '@/lib/gitlab-url'
 import { PageMeta } from '@/lib/seo'
 import SetupHint from '@/components/setup-hint'
 import { Button } from '@/components/ui/button'
@@ -18,6 +23,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -36,7 +42,14 @@ import {
 
 const gitLabSetupSchema = z
   .object({
-    host_url: z.string().trim().min(1, 'Host URL is required'),
+    host_url: z
+      .string()
+      .trim()
+      .min(1, 'Host URL is required')
+      .refine(
+        (value) => normalizeGitLabHostUrl(value) !== null,
+        'Use an HTTP(S) host URL only, without a path, query, or credentials.',
+      ),
     auth_mode: z.enum(['personal_token', 'oauth_app']),
     webhook_secret: z.string().trim().min(1, 'Webhook secret is required'),
     access_token: z.string().optional(),
@@ -71,6 +84,11 @@ const gitLabSetupSchema = z
 
 type GitLabSetupForm = z.infer<typeof gitLabSetupSchema>
 
+function generateWebhookSecret(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(24))
+  return `oore_${Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')}`
+}
+
 export const Route = createFileRoute('/settings/integrations/gitlab')({
   staticData: { breadcrumbLabel: 'GitLab' },
   beforeLoad: () => {
@@ -86,6 +104,7 @@ function GitLabSetupPage() {
   const { data: preferences, isLoading: preferencesLoading } =
     useInstancePreferences()
   const remoteEnabled = preferences?.preferences.runtime_mode === 'remote'
+  const [webhookSecret] = useState(generateWebhookSecret)
 
   const form = useForm<GitLabSetupForm>({
     resolver: zodResolver(gitLabSetupSchema),
@@ -93,7 +112,7 @@ function GitLabSetupPage() {
     defaultValues: {
       host_url: 'https://gitlab.com',
       auth_mode: 'personal_token',
-      webhook_secret: '',
+      webhook_secret: webhookSecret,
       access_token: '',
       client_id: '',
       client_secret: '',
@@ -102,12 +121,19 @@ function GitLabSetupPage() {
 
   const authMode = form.watch('auth_mode')
   const hostUrl = form.watch('host_url')
+  const normalizedHostUrl =
+    normalizeGitLabHostUrl(hostUrl) ?? 'https://gitlab.com'
+  const proxyOrigin = window.location.origin
+  const webhookUrl = `${proxyOrigin}/v1/webhooks/gitlab`
+  const callbackUrl = `${proxyOrigin}/v1/integrations/gitlab/callback`
 
   function handleSubmit(data: GitLabSetupForm) {
     if (!remoteEnabled) return
+    const submittedHostUrl = normalizeGitLabHostUrl(data.host_url)
+    if (!submittedHostUrl) return
     startMutation.mutate(
       {
-        host_url: data.host_url.trim(),
+        host_url: submittedHostUrl,
         auth_mode: data.auth_mode,
         webhook_secret: data.webhook_secret.trim(),
         access_token:
@@ -147,12 +173,34 @@ function GitLabSetupPage() {
     )
   }
 
+  function normalizeHostUrl() {
+    const normalized = normalizeGitLabHostUrl(form.getValues('host_url'))
+    if (normalized) {
+      form.setValue('host_url', normalized, { shouldValidate: true })
+    }
+  }
+
+  function replaceWebhookSecret() {
+    form.setValue('webhook_secret', generateWebhookSecret(), {
+      shouldDirty: true,
+      shouldTouch: true,
+      shouldValidate: true,
+    })
+  }
+
+  function copyWebhookSecret() {
+    void navigator.clipboard.writeText(form.getValues('webhook_secret')).then(
+      () => toast.success('Webhook secret copied'),
+      () => toast.error('Could not copy webhook secret'),
+    )
+  }
+
   return (
     <PageLayout width="wide">
       <PageMeta title="Connect GitLab Source" noindex />
       <PageHeader
         title="Connect GitLab Source"
-        description="Connect gitlab.com or a self-managed GitLab source for repositories and webhook events."
+        description="Connect GitLab.com or a self-managed GitLab host for repository discovery and webhook-triggered builds."
         back={{ to: '/settings/integrations', label: 'Sources' }}
       />
 
@@ -183,8 +231,19 @@ function GitLabSetupPage() {
                   <FormItem>
                     <FormLabel>GitLab host URL</FormLabel>
                     <FormControl>
-                      <Input {...field} placeholder="https://gitlab.com" />
+                      <Input
+                        {...field}
+                        placeholder="https://gitlab.example.com"
+                        onBlur={() => {
+                          field.onBlur()
+                          normalizeHostUrl()
+                        }}
+                      />
                     </FormControl>
+                    <FormDescription>
+                      Host origin only. Oore normalizes a trailing slash; do not
+                      include <code>/api/v4</code> or a group path.
+                    </FormDescription>
                     <FormMessage />
                   </FormItem>
                 )}
@@ -223,116 +282,19 @@ function GitLabSetupPage() {
                 )}
               />
 
-              <FormField
-                control={form.control}
-                name="webhook_secret"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Webhook secret</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="password"
-                        {...field}
-                        placeholder="Shared secret for GitLab webhook settings"
-                      />
-                    </FormControl>
-                    <p className="text-xs text-muted-foreground">
-                      Use the same secret when creating the webhook in GitLab.
-                    </p>
-                    <SetupHint
-                      title="Where this goes in GitLab"
-                      items={[
-                        'Project Settings -> Webhooks -> Secret token.',
-                        'Use the Oore GitLab webhook URL from the connected source details page after this source is saved.',
-                      ]}
-                    />
-                    <FormMessage />
-                  </FormItem>
-                )}
+              <GitLabWebhookSecretField
+                form={form}
+                webhookUrl={webhookUrl}
+                onCopy={copyWebhookSecret}
+                onRegenerate={replaceWebhookSecret}
               />
 
-              {authMode === 'personal_token' ? (
-                <FormField
-                  control={form.control}
-                  name="access_token"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Access token</FormLabel>
-                      <FormControl>
-                        <Input
-                          type="password"
-                          {...field}
-                          placeholder="glpat-..."
-                        />
-                      </FormControl>
-                      <SetupHint
-                        title="Required GitLab PAT scopes"
-                        items={[
-                          <span>
-                            Select <code>read_user</code>,{' '}
-                            <code>read_api</code>, and{' '}
-                            <code>read_repository</code>.
-                          </span>,
-                          <span>
-                            Do not select full <code>api</code> unless you are
-                            testing a future write-capable GitLab feature.
-                          </span>,
-                          <span>
-                            Create it at{' '}
-                            <code>
-                              {hostUrl || 'https://gitlab.com'}
-                              /-/user_settings/personal_access_tokens
-                            </code>
-                            .
-                          </span>,
-                        ]}
-                      />
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              ) : (
-                <>
-                  <FormField
-                    control={form.control}
-                    name="client_id"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Client ID</FormLabel>
-                        <FormControl>
-                          <Input {...field} placeholder="Application ID" />
-                        </FormControl>
-                        <p className="text-xs text-muted-foreground">
-                          Create a GitLab OAuth application and paste its
-                          Application ID here.
-                        </p>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={form.control}
-                    name="client_secret"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Client secret</FormLabel>
-                        <FormControl>
-                          <Input
-                            type="password"
-                            {...field}
-                            placeholder="Application secret"
-                          />
-                        </FormControl>
-                        <p className="text-xs text-muted-foreground">
-                          Use the Secret from the same GitLab OAuth
-                          application.
-                        </p>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </>
-              )}
+              <GitLabCredentialsFields
+                form={form}
+                authMode={authMode}
+                hostUrl={normalizedHostUrl}
+                callbackUrl={callbackUrl}
+              />
 
               <Button
                 type="submit"
@@ -355,5 +317,167 @@ function GitLabSetupPage() {
         </CardContent>
       </Card>
     </PageLayout>
+  )
+}
+
+function GitLabWebhookSecretField({
+  form,
+  webhookUrl,
+  onCopy,
+  onRegenerate,
+}: {
+  form: UseFormReturn<GitLabSetupForm>
+  webhookUrl: string
+  onCopy: () => void
+  onRegenerate: () => void
+}) {
+  return (
+    <FormField
+      control={form.control}
+      name="webhook_secret"
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>Webhook secret</FormLabel>
+          <div className="flex gap-2">
+            <FormControl>
+              <Input type="password" {...field} />
+            </FormControl>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              onClick={onCopy}
+              aria-label="Copy webhook secret"
+              title="Copy webhook secret"
+            >
+              <HugeiconsIcon icon={Copy01Icon} size={16} />
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              onClick={onRegenerate}
+              aria-label="Generate a new webhook secret"
+              title="Generate a new webhook secret"
+            >
+              <HugeiconsIcon icon={Refresh01Icon} size={16} />
+            </Button>
+          </div>
+          <FormDescription>
+            Generated securely in this browser. Copy it into GitLab; Oore
+            encrypts it when this source is saved.
+          </FormDescription>
+          <SetupHint
+            title="Webhook setup in GitLab"
+            items={[
+              <span>
+                URL: <code>{webhookUrl}</code>
+              </span>,
+              'Project Settings -> Webhooks -> Secret token. Enable Push events (and Merge request events if your pipeline uses them).',
+            ]}
+          />
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  )
+}
+
+function GitLabCredentialsFields({
+  form,
+  authMode,
+  hostUrl,
+  callbackUrl,
+}: {
+  form: UseFormReturn<GitLabSetupForm>
+  authMode: GitLabSetupForm['auth_mode']
+  hostUrl: string
+  callbackUrl: string
+}) {
+  if (authMode === 'personal_token') {
+    return (
+      <FormField
+        control={form.control}
+        name="access_token"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Access token</FormLabel>
+            <FormControl>
+              <Input type="password" {...field} placeholder="glpat-..." />
+            </FormControl>
+            <SetupHint
+              title="Required GitLab PAT scopes"
+              items={[
+                <span>
+                  Select <code>read_user</code>, <code>read_api</code>, and{' '}
+                  <code>read_repository</code>.
+                </span>,
+                <span>
+                  Do not select full <code>api</code> unless you are testing a
+                  future write-capable GitLab feature.
+                </span>,
+                <span>
+                  Create it at{' '}
+                  <code>{hostUrl}/-/user_settings/personal_access_tokens</code>.
+                </span>,
+              ]}
+            />
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    )
+  }
+
+  return (
+    <>
+      <FormField
+        control={form.control}
+        name="client_id"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Client ID</FormLabel>
+            <FormControl>
+              <Input {...field} placeholder="Application ID" />
+            </FormControl>
+            <FormDescription>
+              Create an OAuth application on {hostUrl} and paste its Application
+              ID here.
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={form.control}
+        name="client_secret"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Client secret</FormLabel>
+            <FormControl>
+              <Input
+                type="password"
+                {...field}
+                placeholder="Application secret"
+              />
+            </FormControl>
+            <FormDescription>
+              Use the Secret from the same GitLab OAuth application.
+            </FormDescription>
+            <SetupHint
+              title="OAuth callback"
+              items={[
+                <span>
+                  Register this redirect URI in GitLab:{' '}
+                  <code>{callbackUrl}</code>
+                </span>,
+                'Save this source, then choose Authorize on GitLab from its source details page.',
+              ]}
+            />
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </>
   )
 }

--- a/apps/web/src/routes/settings/integrations/index.tsx
+++ b/apps/web/src/routes/settings/integrations/index.tsx
@@ -178,8 +178,8 @@ function IntegrationsPage() {
             </CardHeader>
             <CardContent className="space-y-3">
               <p className="text-sm text-muted-foreground">
-                Connect gitlab.com or self-managed GitLab through OAuth or
-                personal access token.
+                Connect GitLab.com or a self-managed GitLab host through a
+                personal access token or OAuth application.
               </p>
               <SetupHint
                 title="Personal access token scopes"
@@ -195,7 +195,6 @@ function IntegrationsPage() {
                 ]}
               />
               <Button
-                variant="outline"
                 render={<Link to="/settings/integrations/gitlab" />}
                 nativeButton={false}
               >

--- a/apps/web/src/routes/setup/oidc.tsx
+++ b/apps/web/src/routes/setup/oidc.tsx
@@ -247,7 +247,7 @@ function OidcConfigStep() {
           Configure the OpenID Connect provider for authentication. You will
           need a client ID (and optionally secret) from your identity provider.
         </p>
-        <p className="text-xs text-amber-600 dark:text-amber-400">
+        <p className="text-xs text-warning">
           You can edit this until owner verification is completed. After owner
           verification, setup can only move forward to finalize.
         </p>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -153,13 +153,13 @@
   --color-foreground: var(--foreground);
   --color-background: var(--background);
   --color-surface: var(--surface);
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
+  --radius-sm: var(--radius);
+  --radius-md: var(--radius);
   --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
-  --radius-2xl: calc(var(--radius) + 8px);
-  --radius-3xl: calc(var(--radius) + 12px);
-  --radius-4xl: calc(var(--radius) + 16px);
+  --radius-xl: var(--radius);
+  --radius-2xl: var(--radius);
+  --radius-3xl: var(--radius);
+  --radius-4xl: var(--radius);
 }
 
 @keyframes route-slide {

--- a/crates/oore-runner/src/lib.rs
+++ b/crates/oore-runner/src/lib.rs
@@ -1706,6 +1706,24 @@ fi
     anyhow::bail!("Build has neither commit_sha nor branch — cannot checkout source")
 }
 
+fn add_checkout_proxy_config(
+    checkout: &mut CheckoutInvocation,
+    proxy_url: &str,
+    runner_token: &str,
+) {
+    checkout.env.extend([
+        ("GIT_CONFIG_COUNT".to_string(), "1".to_string()),
+        (
+            "GIT_CONFIG_KEY_0".to_string(),
+            format!("http.{proxy_url}.extraHeader"),
+        ),
+        (
+            "GIT_CONFIG_VALUE_0".to_string(),
+            format!("Authorization: Bearer {runner_token}"),
+        ),
+    ]);
+}
+
 async fn execute_build(
     job: &ClaimedJob,
     client: &reqwest::Client,
@@ -1749,13 +1767,23 @@ async fn execute_build(
         );
     }
 
+    let proxy_path = snapshot.get("checkout_proxy_path").and_then(|v| v.as_str());
+    let effective_repo_url = proxy_path
+        .map(|path| format!("{}{}", daemon_url.trim_end_matches('/'), path))
+        .unwrap_or_else(|| repo_url.to_string());
+
     let start = now_unix();
-    let checkout =
-        match build_checkout_invocation(repo_url, job.commit_sha.as_deref(), job.branch.as_deref())
-        {
-            Ok(checkout) => checkout,
-            Err(e) => return (steps, Err(e)),
-        };
+    let mut checkout = match build_checkout_invocation(
+        &effective_repo_url,
+        job.commit_sha.as_deref(),
+        job.branch.as_deref(),
+    ) {
+        Ok(checkout) => checkout,
+        Err(e) => return (steps, Err(e)),
+    };
+    if proxy_path.is_some() {
+        add_checkout_proxy_config(&mut checkout, &effective_repo_url, &config.runner_token);
+    }
 
     let _ = append_runner_log_line(
         client,
@@ -3192,6 +3220,31 @@ mod tests {
                 .preview_command
                 .contains("git submodule update --init --recursive")
         );
+    }
+
+    #[test]
+    fn checkout_proxy_scopes_runner_token_to_daemon_url() {
+        let mut checkout =
+            build_checkout_invocation("http://127.0.0.1:8787/proxy/repo.git", None, Some("main"))
+                .expect("checkout invocation");
+        add_checkout_proxy_config(
+            &mut checkout,
+            "http://127.0.0.1:8787/proxy/repo.git",
+            "runner-secret",
+        );
+
+        assert!(checkout.env.contains(&(
+            "GIT_CONFIG_KEY_0".to_string(),
+            "http.http://127.0.0.1:8787/proxy/repo.git.extraHeader".to_string(),
+        )));
+        assert!(
+            !checkout
+                .env
+                .iter()
+                .any(|(_, value)| value == "http.extraHeader")
+        );
+        assert!(!checkout.preview_command.contains("runner-secret"));
+        assert!(!checkout.shell_script.contains("runner-secret"));
     }
 
     #[test]

--- a/crates/oored/src/bin/openapi_export.rs
+++ b/crates/oored/src/bin/openapi_export.rs
@@ -135,6 +135,8 @@ use utoipa::OpenApi;
         paths::update_runner,
         paths::runner_heartbeat,
         paths::claim_job,
+        paths::gitlab_checkout_discovery,
+        paths::gitlab_checkout_upload_pack,
         paths::update_job_status,
         paths::get_job_status,
         // ── Build Logs ──
@@ -1605,6 +1607,40 @@ mod paths {
         )
     )]
     pub(super) async fn claim_job() {}
+
+    /// Discover a private GitLab repository for checkout
+    ///
+    /// Internal Git smart-HTTP endpoint. The runner token is accepted only for
+    /// the repository assigned to this job; GitLab credentials remain server-side.
+    #[utoipa::path(get, path = "/v1/runners/{runner_id}/jobs/{job_id}/gitlab/{git_path}", tag = "Runners",
+        params(
+            ("runner_id" = String, Path, description = "Runner ID"),
+            ("job_id" = String, Path, description = "Build/Job ID"),
+            ("git_path" = String, Path, description = "Assigned repository info/refs path"),
+            ("service" = String, Query, description = "Must be git-upload-pack"),
+        ),
+        security(("bearer_auth" = [])),
+        responses(
+            (status = 200, description = "Git upload-pack discovery response"),
+            (status = 403, description = "Repository path does not match the assigned job", body = ApiError),
+        )
+    )]
+    pub(super) async fn gitlab_checkout_discovery() {}
+
+    /// Stream a private GitLab upload-pack request
+    #[utoipa::path(post, path = "/v1/runners/{runner_id}/jobs/{job_id}/gitlab/{git_path}", tag = "Runners",
+        params(
+            ("runner_id" = String, Path, description = "Runner ID"),
+            ("job_id" = String, Path, description = "Build/Job ID"),
+            ("git_path" = String, Path, description = "Assigned repository git-upload-pack path"),
+        ),
+        security(("bearer_auth" = [])),
+        responses(
+            (status = 200, description = "Git upload-pack response"),
+            (status = 403, description = "Repository path does not match the assigned job", body = ApiError),
+        )
+    )]
+    pub(super) async fn gitlab_checkout_upload_pack() {}
 
     /// Update job status
     ///

--- a/crates/oored/src/integrations/gitlab.rs
+++ b/crates/oored/src/integrations/gitlab.rs
@@ -2,15 +2,17 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use axum::Json;
-use axum::extract::{Query, State};
-use axum::http::StatusCode;
+use axum::body::Body;
+use axum::extract::{Path, Query, RawQuery, State};
+use axum::http::{HeaderMap, Method, StatusCode};
 use axum::response::{Html, IntoResponse, Redirect, Response};
+use base64::Engine;
 use oore_contract::{
     ApiError, GitLabAuthorizeRequest, GitLabAuthorizeResponse, GitLabCompleteResponse,
     GitLabStartRequest, Integration, IntegrationInstallation,
 };
 use serde::{Deserialize, Serialize};
-use sqlx::Row;
+use sqlx::{QueryBuilder, Row, Sqlite};
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
@@ -19,6 +21,7 @@ use crate::AppState;
 use crate::crypto;
 use crate::extractors::AuthUser;
 use crate::rbac::check_permission;
+use crate::runners::RunnerAuth;
 use crate::store::write_audit_log;
 use crate::util::{api_err, now_unix};
 
@@ -32,6 +35,66 @@ fn build_http_client() -> Result<reqwest::Client, reqwest::Error> {
         .timeout(Duration::from_secs(15))
         .redirect(reqwest::redirect::Policy::none())
         .build()
+}
+
+fn normalize_gitlab_host_url(raw: &str) -> Result<String, (StatusCode, Json<ApiError>)> {
+    let parsed = url::Url::parse(raw.trim()).map_err(|_| {
+        api_err(
+            StatusCode::BAD_REQUEST,
+            "invalid_input",
+            "host_url must be an http or https origin",
+        )
+    })?;
+    if !matches!(parsed.scheme(), "http" | "https")
+        || parsed.host_str().is_none()
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+        || !matches!(parsed.path(), "" | "/")
+    {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "invalid_input",
+            "host_url must be an http or https origin without credentials, a path, query, or fragment",
+        ));
+    }
+    Ok(parsed.origin().ascii_serialization())
+}
+
+fn oauth_callback_url(redirect_url: &str) -> Result<String, (StatusCode, Json<ApiError>)> {
+    let parsed = url::Url::parse(redirect_url).map_err(|_| {
+        api_err(
+            StatusCode::BAD_REQUEST,
+            "invalid_redirect_url",
+            "redirect_url is not a valid URL",
+        )
+    })?;
+    Ok(format!(
+        "{}/v1/integrations/gitlab/callback",
+        parsed.origin().ascii_serialization()
+    ))
+}
+
+fn git_checkout_request_allowed(
+    method: &Method,
+    git_path: &str,
+    query: Option<&str>,
+    content_type: Option<&str>,
+    full_name: &str,
+) -> bool {
+    match *method {
+        Method::GET => {
+            git_path == format!("{full_name}.git/info/refs")
+                && query == Some("service=git-upload-pack")
+        }
+        Method::POST => {
+            git_path == format!("{full_name}.git/git-upload-pack")
+                && query.is_none()
+                && content_type == Some("application/x-git-upload-pack-request")
+        }
+        _ => false,
+    }
 }
 
 /// Sync a GitLab integration by refreshing repositories for all installations.
@@ -181,22 +244,7 @@ pub async fn gitlab_start(
     };
     require_remote_mode(&pool).await?;
 
-    // Validate host URL
-    let host_url = req.host_url.trim_end_matches('/').to_string();
-    if host_url.is_empty() {
-        return Err(api_err(
-            StatusCode::BAD_REQUEST,
-            "invalid_input",
-            "host_url is required",
-        ));
-    }
-    if url::Url::parse(&host_url).is_err() {
-        return Err(api_err(
-            StatusCode::BAD_REQUEST,
-            "invalid_input",
-            "host_url is not a valid URL",
-        ));
-    }
+    let host_url = normalize_gitlab_host_url(&req.host_url)?;
 
     if req.webhook_secret.trim().is_empty() {
         return Err(api_err(
@@ -554,36 +602,6 @@ async fn sync_gitlab_projects(
 ) -> Result<(), (StatusCode, Json<ApiError>)> {
     let api_base = format!("{}/api/v4", host_url);
 
-    let mut req_builder = client
-        .get(format!(
-            "{api_base}/projects?membership=true&per_page=100&simple=true"
-        ))
-        .header("User-Agent", "oore-ci");
-
-    if use_bearer_auth {
-        req_builder = req_builder.header("Authorization", format!("Bearer {token}"));
-    } else {
-        req_builder = req_builder.header("PRIVATE-TOKEN", token);
-    }
-
-    let resp = req_builder.send().await.map_err(|e| {
-        error!(error = %e, "GitLab projects API failed");
-        api_err(
-            StatusCode::BAD_GATEWAY,
-            "gitlab_api_error",
-            "Failed to list GitLab projects",
-        )
-    })?;
-
-    if !resp.status().is_success() {
-        let status = resp.status();
-        return Err(api_err(
-            StatusCode::BAD_GATEWAY,
-            "gitlab_api_error",
-            format!("GitLab returned {status}"),
-        ));
-    }
-
     #[derive(serde::Deserialize)]
     struct GitLabProject {
         id: i64,
@@ -593,12 +611,65 @@ async fn sync_gitlab_projects(
         web_url: Option<String>,
     }
 
-    let projects: Vec<GitLabProject> = resp.json().await.map_err(|e| {
-        error!(error = %e, "failed to parse GitLab projects");
+    let mut projects = Vec::new();
+    let mut page = 1usize;
+    loop {
+        let mut req_builder = client
+            .get(format!(
+                "{api_base}/projects?membership=true&per_page=100&simple=true&page={page}"
+            ))
+            .header("User-Agent", "oore-ci");
+
+        if use_bearer_auth {
+            req_builder = req_builder.header("Authorization", format!("Bearer {token}"));
+        } else {
+            req_builder = req_builder.header("PRIVATE-TOKEN", token);
+        }
+
+        let resp = req_builder.send().await.map_err(|e| {
+            error!(error = %e, page, "GitLab projects API failed");
+            api_err(
+                StatusCode::BAD_GATEWAY,
+                "gitlab_api_error",
+                "Failed to list GitLab projects",
+            )
+        })?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            return Err(api_err(
+                StatusCode::BAD_GATEWAY,
+                "gitlab_api_error",
+                format!("GitLab returned {status}"),
+            ));
+        }
+
+        let next_page = resp
+            .headers()
+            .get("x-next-page")
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.parse::<usize>().ok())
+            .filter(|next| *next > page);
+        let mut response_projects: Vec<GitLabProject> = resp.json().await.map_err(|e| {
+            error!(error = %e, page, "failed to parse GitLab projects");
+            api_err(
+                StatusCode::BAD_GATEWAY,
+                "gitlab_parse_error",
+                "Failed to parse GitLab response",
+            )
+        })?;
+        projects.append(&mut response_projects);
+
+        let Some(next_page) = next_page else { break };
+        page = next_page;
+    }
+
+    let mut tx = pool.begin().await.map_err(|e| {
+        error!(error = %e, "failed to start GitLab repository sync transaction");
         api_err(
-            StatusCode::BAD_GATEWAY,
-            "gitlab_parse_error",
-            "Failed to parse GitLab response",
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to sync projects",
         )
     })?;
 
@@ -620,7 +691,7 @@ async fn sync_gitlab_projects(
         .bind(is_private as i32)
         .bind(&project.web_url)
         .bind(now)
-        .execute(pool)
+        .execute(&mut *tx)
         .await
         .map_err(|e| {
             error!(error = %e, project = %project.path_with_namespace, "failed to upsert GitLab project");
@@ -628,8 +699,217 @@ async fn sync_gitlab_projects(
         })?;
     }
 
+    let external_ids: Vec<String> = projects.iter().map(|p| p.id.to_string()).collect();
+    for prefix in [
+        "UPDATE projects SET repository_id = NULL WHERE repository_id IN (SELECT id FROM integration_repositories WHERE installation_id = ",
+        "DELETE FROM integration_repositories WHERE installation_id = ",
+    ] {
+        let mut query = QueryBuilder::<Sqlite>::new(prefix);
+        query.push_bind(installation_id);
+        if !external_ids.is_empty() {
+            query.push(" AND external_id NOT IN (");
+            let mut separated = query.separated(", ");
+            for external_id in &external_ids {
+                separated.push_bind(external_id);
+            }
+            separated.push_unseparated(")");
+        }
+        if prefix.starts_with("UPDATE") {
+            query.push(")");
+        }
+        query.build().execute(&mut *tx).await.map_err(|e| {
+            error!(error = %e, "failed to remove stale GitLab projects");
+            api_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "store_error",
+                "Failed to sync projects",
+            )
+        })?;
+    }
+
+    tx.commit().await.map_err(|e| {
+        error!(error = %e, "failed to commit GitLab repository sync");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to sync projects",
+        )
+    })?;
+
     info!(project_count = projects.len(), "GitLab projects synced");
     Ok(())
+}
+
+/// Stream Git smart-HTTP through the daemon so runner jobs can clone private
+/// repositories without SCM credentials entering build snapshots or logs.
+pub async fn proxy_git_checkout(
+    State(state): State<Arc<AppState>>,
+    Path((runner_id, job_id, git_path)): Path<(String, String, String)>,
+    runner_auth: RunnerAuth,
+    method: Method,
+    RawQuery(query): RawQuery,
+    headers: HeaderMap,
+    body: Body,
+) -> Result<Response, (StatusCode, Json<ApiError>)> {
+    if runner_auth.runner_id != runner_id {
+        return Err(api_err(
+            StatusCode::FORBIDDEN,
+            "runner_mismatch",
+            "Runner token does not match the requested runner ID",
+        ));
+    }
+    if !matches!(method, Method::GET | Method::POST)
+        || git_path
+            .split('/')
+            .any(|part| part.is_empty() || matches!(part, "." | ".."))
+        || git_path.contains('\\')
+    {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "invalid_git_request",
+            "Invalid Git checkout request",
+        ));
+    }
+
+    let pool = {
+        let store = state.store.lock().await;
+        store.pool().clone()
+    };
+    let row = sqlx::query(
+        "SELECT i.host_url, r.full_name, c.encrypted_value \
+         FROM builds b \
+         JOIN projects p ON p.id = b.project_id \
+         JOIN integration_repositories r ON r.id = p.repository_id \
+         JOIN integration_installations inst ON inst.id = r.installation_id \
+         JOIN integrations i ON i.id = inst.integration_id \
+         JOIN integration_credentials c ON c.integration_id = i.id \
+         WHERE b.id = ?1 AND b.runner_id = ?2 AND i.provider = 'gitlab' \
+         AND i.status = 'active' AND c.credential_type = 'access_token'",
+    )
+    .bind(&job_id)
+    .bind(&runner_id)
+    .fetch_optional(&pool)
+    .await
+    .map_err(|e| {
+        error!(error = %e, job_id = %job_id, "failed to resolve GitLab checkout");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to resolve checkout",
+        )
+    })?
+    .ok_or_else(|| {
+        api_err(
+            StatusCode::NOT_FOUND,
+            "checkout_not_found",
+            "GitLab checkout not found",
+        )
+    })?;
+
+    let host_url: String = row.get("host_url");
+    let full_name: String = row.get("full_name");
+    let encrypted_token: String = row.get("encrypted_value");
+
+    if !git_checkout_request_allowed(
+        &method,
+        &git_path,
+        query.as_deref(),
+        headers
+            .get("content-type")
+            .and_then(|value| value.to_str().ok()),
+        &full_name,
+    ) {
+        return Err(api_err(
+            StatusCode::FORBIDDEN,
+            "checkout_path_forbidden",
+            "Git checkout request does not match the assigned repository",
+        ));
+    }
+
+    let token = crypto::decrypt(&encrypted_token, &state.encryption_key).map_err(|e| {
+        error!(error = %e, job_id = %job_id, "failed to decrypt GitLab checkout token");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "encryption_error",
+            "Failed to authorize checkout",
+        )
+    })?;
+
+    let mut upstream = url::Url::parse(&host_url).map_err(|_| {
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "invalid_host",
+            "GitLab host is invalid",
+        )
+    })?;
+    upstream
+        .path_segments_mut()
+        .map_err(|_| {
+            api_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "invalid_host",
+                "GitLab host is invalid",
+            )
+        })?
+        .extend(git_path.split('/'));
+    upstream.set_query(query.as_deref());
+
+    let basic = base64::engine::general_purpose::STANDARD.encode(format!("oauth2:{token}"));
+    let client = build_http_client().map_err(|e| {
+        error!(error = %e, "failed to build GitLab checkout client");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "http_client_error",
+            "Failed to create checkout client",
+        )
+    })?;
+    let mut request = client
+        .request(method, upstream)
+        .header("Authorization", format!("Basic {basic}"))
+        .header("User-Agent", "oore-ci");
+    if headers.get("content-type").is_some() {
+        request = request.body(reqwest::Body::wrap_stream(body.into_data_stream()));
+    }
+    for name in ["accept", "content-type", "git-protocol"] {
+        if let Some(value) = headers.get(name) {
+            request = request.header(name, value);
+        }
+    }
+
+    let response = request.send().await.map_err(|e| {
+        error!(error = %e, job_id = %job_id, "GitLab checkout proxy failed");
+        api_err(
+            StatusCode::BAD_GATEWAY,
+            "gitlab_checkout_failed",
+            "GitLab checkout failed",
+        )
+    })?;
+    if response.status().is_redirection() {
+        return Err(api_err(
+            StatusCode::BAD_GATEWAY,
+            "gitlab_redirect_rejected",
+            "GitLab checkout host redirected unexpectedly",
+        ));
+    }
+
+    let status = response.status();
+    let response_headers = response.headers().clone();
+    let mut downstream = Response::builder().status(status);
+    for name in ["content-type", "cache-control", "etag", "expires", "pragma"] {
+        if let Some(value) = response_headers.get(name) {
+            downstream = downstream.header(name, value);
+        }
+    }
+    downstream
+        .body(Body::from_stream(response.bytes_stream()))
+        .map_err(|e| {
+            error!(error = %e, "failed to build GitLab checkout response");
+            api_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "response_error",
+                "Failed to stream checkout",
+            )
+        })
 }
 
 // ── GitLab OAuth flow ────────────────────────────────────────────
@@ -639,6 +919,8 @@ async fn sync_gitlab_projects(
 struct GitLabOAuthState {
     integration_id: String,
     redirect_url: String,
+    #[serde(default)]
+    callback_url: String,
     created_at: i64,
 }
 
@@ -653,7 +935,16 @@ fn seal_gitlab_state(state: &GitLabOAuthState, key: &[u8]) -> Result<String, any
 fn open_gitlab_state(token: &str, key: &[u8]) -> Result<GitLabOAuthState, String> {
     let decoded = urlencoding::decode(token).map_err(|e| format!("url decode: {e}"))?;
     let json = crypto::decrypt(&decoded, key).map_err(|e| format!("decrypt: {e}"))?;
-    let state: GitLabOAuthState = serde_json::from_str(&json).map_err(|e| format!("parse: {e}"))?;
+    let mut state: GitLabOAuthState =
+        serde_json::from_str(&json).map_err(|e| format!("parse: {e}"))?;
+
+    if state.callback_url.is_empty() {
+        let parsed = url::Url::parse(&state.redirect_url).map_err(|e| format!("redirect: {e}"))?;
+        state.callback_url = format!(
+            "{}/v1/integrations/gitlab/callback",
+            parsed.origin().ascii_serialization()
+        );
+    }
 
     let now = now_unix();
     if now - state.created_at > STATE_MAX_AGE_SECS {
@@ -805,22 +1096,15 @@ pub async fn gitlab_authorize(
         )
     })?;
 
-    // Build callback URL
-    let public_url = state
-        .public_url
-        .read()
-        .await
-        .clone()
-        .unwrap_or_else(|| "http://127.0.0.1:8787".to_string());
-    let callback_url = format!(
-        "{}/v1/integrations/gitlab/callback",
-        public_url.trim_end_matches('/')
-    );
+    // The browser reaches the callback through the validated frontend proxy,
+    // not necessarily through the daemon's own public URL.
+    let callback_url = oauth_callback_url(&req.redirect_url)?;
 
     // Seal the state token
     let oauth_state = GitLabOAuthState {
         integration_id: req.integration_id.clone(),
         redirect_url: req.redirect_url,
+        callback_url: callback_url.clone(),
         created_at: now_unix(),
     };
 
@@ -835,7 +1119,7 @@ pub async fn gitlab_authorize(
 
     // Build the authorize URL
     let authorize_url = format!(
-        "{}/oauth/authorize?client_id={}&redirect_uri={}&response_type=code&state={}&scope=api+read_user",
+        "{}/oauth/authorize?client_id={}&redirect_uri={}&response_type=code&state={}&scope=read_api+read_repository",
         host_url,
         urlencoding::encode(&client_id),
         urlencoding::encode(&callback_url),
@@ -940,7 +1224,14 @@ pub async fn gitlab_callback(
     }
 
     // Exchange code for tokens
-    match exchange_gitlab_code(&state, &code, &oauth_state.integration_id).await {
+    match exchange_gitlab_code(
+        &state,
+        &code,
+        &oauth_state.integration_id,
+        &oauth_state.callback_url,
+    )
+    .await
+    {
         Ok(()) => {
             info!(
                 integration_id = %oauth_state.integration_id,
@@ -980,6 +1271,7 @@ async fn exchange_gitlab_code(
     app_state: &Arc<AppState>,
     code: &str,
     integration_id: &str,
+    callback_url: &str,
 ) -> Result<(), String> {
     // ── Phase 1: Read credentials from DB (short lock) ──────────
     let (host_url, client_id, client_secret, pool) = {
@@ -1026,17 +1318,6 @@ async fn exchange_gitlab_code(
     };
 
     // ── Phase 2: Outbound HTTP — token exchange (no lock held) ──
-    let public_url = app_state
-        .public_url
-        .read()
-        .await
-        .clone()
-        .unwrap_or_else(|| "http://127.0.0.1:8787".to_string());
-    let callback_url = format!(
-        "{}/v1/integrations/gitlab/callback",
-        public_url.trim_end_matches('/')
-    );
-
     let http_client =
         build_http_client().map_err(|e| format!("failed to build HTTP client: {e}"))?;
 
@@ -1055,7 +1336,7 @@ async fn exchange_gitlab_code(
             ("client_id", client_id.as_str()),
             ("client_secret", client_secret.as_str()),
             ("code", code),
-            ("redirect_uri", &callback_url),
+            ("redirect_uri", callback_url),
             ("grant_type", "authorization_code"),
         ])
         .header("User-Agent", "oore-ci")
@@ -1065,8 +1346,7 @@ async fn exchange_gitlab_code(
 
     if !token_resp.status().is_success() {
         let status = token_resp.status();
-        let body = token_resp.text().await.unwrap_or_default();
-        error!(status = %status, body = %body, "GitLab token exchange failed");
+        error!(status = %status, "GitLab token exchange failed");
         return Err(format!("GitLab returned {status}"));
     }
 
@@ -1222,7 +1502,174 @@ async fn exchange_gitlab_code(
 
 #[cfg(test)]
 mod tests {
-    use super::validate_redirect_origin;
+    use super::{
+        build_http_client, git_checkout_request_allowed, normalize_gitlab_host_url,
+        oauth_callback_url, sync_gitlab_projects, validate_redirect_origin,
+    };
+    use axum::Json;
+    use axum::extract::Query;
+    use axum::http::Method;
+    use axum::routing::get;
+    use std::collections::HashMap;
+
+    #[test]
+    fn gitlab_host_accepts_http_and_https_origins() {
+        assert_eq!(
+            normalize_gitlab_host_url("https://gitlab.example.com/").unwrap(),
+            "https://gitlab.example.com"
+        );
+        assert_eq!(
+            normalize_gitlab_host_url("http://gitlab.internal:8080").unwrap(),
+            "http://gitlab.internal:8080"
+        );
+    }
+
+    #[test]
+    fn gitlab_host_rejects_non_origins() {
+        for host in [
+            "ftp://gitlab.example.com",
+            "https://user:pass@gitlab.example.com",
+            "https://gitlab.example.com/gitlab",
+            "https://gitlab.example.com?x=1",
+            "https://gitlab.example.com/#x",
+        ] {
+            assert!(normalize_gitlab_host_url(host).is_err(), "accepted {host}");
+        }
+    }
+
+    #[test]
+    fn oauth_callback_uses_frontend_origin() {
+        assert_eq!(
+            oauth_callback_url("https://oore.example.com/settings/integrations?tab=gitlab")
+                .unwrap(),
+            "https://oore.example.com/v1/integrations/gitlab/callback"
+        );
+    }
+
+    #[test]
+    fn checkout_proxy_only_allows_assigned_repository_upload_pack() {
+        assert!(git_checkout_request_allowed(
+            &Method::GET,
+            "group/app.git/info/refs",
+            Some("service=git-upload-pack"),
+            None,
+            "group/app",
+        ));
+        assert!(git_checkout_request_allowed(
+            &Method::POST,
+            "group/app.git/git-upload-pack",
+            None,
+            Some("application/x-git-upload-pack-request"),
+            "group/app",
+        ));
+        assert!(!git_checkout_request_allowed(
+            &Method::GET,
+            "group/other.git/info/refs",
+            Some("service=git-upload-pack"),
+            None,
+            "group/app",
+        ));
+        assert!(!git_checkout_request_allowed(
+            &Method::GET,
+            "group/app.git/info/refs",
+            Some("service=git-receive-pack"),
+            None,
+            "group/app",
+        ));
+    }
+
+    #[tokio::test]
+    async fn project_sync_paginates_and_removes_stale_repositories() {
+        let app = axum::Router::new().route(
+            "/api/v4/projects",
+            get(|Query(params): Query<HashMap<String, String>>| async move {
+                let page = params.get("page").map(String::as_str).unwrap_or("1");
+                let projects: Vec<_> = if page == "1" {
+                    (1..=100)
+                        .map(|id| {
+                            serde_json::json!({
+                                "id": id,
+                                "path_with_namespace": format!("group/repo-{id}"),
+                                "default_branch": "main",
+                                "visibility": "private",
+                                "web_url": format!("https://gitlab.example/group/repo-{id}"),
+                            })
+                        })
+                        .collect()
+                } else {
+                    vec![serde_json::json!({
+                        "id": 101,
+                        "path_with_namespace": "group/repo-101",
+                        "default_branch": "main",
+                        "visibility": "private",
+                        "web_url": "https://gitlab.example/group/repo-101",
+                    })]
+                };
+                let mut headers = axum::http::HeaderMap::new();
+                if page == "1" {
+                    headers.insert("x-next-page", "2".parse().unwrap());
+                }
+                (headers, Json(projects))
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let host = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query(
+            "CREATE TABLE integration_repositories (
+                id TEXT PRIMARY KEY, installation_id TEXT NOT NULL, external_id TEXT NOT NULL,
+                full_name TEXT NOT NULL, default_branch TEXT, is_private INTEGER NOT NULL,
+                html_url TEXT, created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL,
+                UNIQUE(installation_id, external_id)
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query("CREATE TABLE projects (id TEXT PRIMARY KEY, repository_id TEXT)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO integration_repositories VALUES ('stale', 'install', 'stale', 'group/stale', 'main', 1, NULL, 1, 1)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO projects VALUES ('project', 'stale')")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        sync_gitlab_projects(
+            &build_http_client().unwrap(),
+            &pool,
+            &host,
+            "token",
+            "install",
+            false,
+            2,
+        )
+        .await
+        .unwrap();
+
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM integration_repositories WHERE installation_id = 'install'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let linked: Option<String> =
+            sqlx::query_scalar("SELECT repository_id FROM projects WHERE id = 'project'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(count, 101);
+        assert!(linked.is_none());
+        server.abort();
+    }
 
     #[test]
     fn redirect_origin_accepts_default_localhost_origin() {

--- a/crates/oored/src/integrations/webhooks.rs
+++ b/crates/oored/src/integrations/webhooks.rs
@@ -7,6 +7,7 @@ use axum::http::{HeaderMap, StatusCode};
 use oore_contract::ApiError;
 use ring::hmac;
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 use sqlx::Row;
 use tracing::{error, info, warn};
 use uuid::Uuid;
@@ -442,7 +443,7 @@ pub async fn gitlab_webhook(
             )
         })?;
 
-    let event_uuid = headers
+    let mut event_uuid = headers
         .get("x-gitlab-event-uuid")
         .and_then(|v| v.to_str().ok())
         .unwrap_or("")
@@ -500,22 +501,30 @@ pub async fn gitlab_webhook(
         )
     })?;
 
-    // Idempotency check
-    if !event_uuid.is_empty() {
-        let existing: bool = sqlx::query_scalar(
-            "SELECT COUNT(*) > 0 FROM integration_webhooks \
-             WHERE integration_id = ?1 AND provider_delivery_id = ?2",
-        )
-        .bind(&integration_id)
-        .bind(&event_uuid)
-        .fetch_one(&pool)
-        .await
-        .unwrap_or(false);
+    if event_uuid.is_empty() {
+        let mut hasher = Sha256::new();
+        hasher.update(integration_id.as_bytes());
+        hasher.update([0]);
+        hasher.update(event_type.as_bytes());
+        hasher.update([0]);
+        hasher.update(&body);
+        event_uuid = format!("sha256:{}", hex::encode(hasher.finalize()));
+    }
 
-        if existing {
-            info!(event_uuid = %event_uuid, "duplicate GitLab webhook delivery, returning OK");
-            return Ok(Json(serde_json::json!({ "ok": true, "duplicate": true })));
-        }
+    // Idempotency check
+    let existing: bool = sqlx::query_scalar(
+        "SELECT COUNT(*) > 0 FROM integration_webhooks \
+         WHERE integration_id = ?1 AND provider_delivery_id = ?2",
+    )
+    .bind(&integration_id)
+    .bind(&event_uuid)
+    .fetch_one(&pool)
+    .await
+    .unwrap_or(false);
+
+    if existing {
+        info!(event_uuid = %event_uuid, "duplicate GitLab webhook delivery, returning OK");
+        return Ok(Json(serde_json::json!({ "ok": true, "duplicate": true })));
     }
 
     let now = now_unix();
@@ -540,11 +549,7 @@ pub async fn gitlab_webhook(
 
     // Store webhook record
     let webhook_id = Uuid::new_v4().to_string();
-    let delivery_id = if event_uuid.is_empty() {
-        webhook_id.clone()
-    } else {
-        event_uuid.clone()
-    };
+    let delivery_id = event_uuid.clone();
 
     sqlx::query(
         "INSERT INTO integration_webhooks (id, integration_id, provider_delivery_id, event_type, payload, status, received_at) \

--- a/crates/oored/src/lib.rs
+++ b/crates/oored/src/lib.rs
@@ -2376,6 +2376,11 @@ async fn build_router_inner(
         )
         .route("/v1/runners/{runner_id}/claim", post(runners::claim_job))
         .route(
+            "/v1/runners/{runner_id}/jobs/{job_id}/gitlab/{*git_path}",
+            get(integrations::gitlab::proxy_git_checkout)
+                .post(integrations::gitlab::proxy_git_checkout),
+        )
+        .route(
             "/v1/runners/{runner_id}/jobs/{job_id}/status",
             post(runners::update_job_status),
         )

--- a/crates/oored/src/main.rs
+++ b/crates/oored/src/main.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::{ffi::OsStr, fs};
@@ -10,7 +10,7 @@ use oored::build_router;
 use oored::crypto;
 use oored::observability;
 use oored::store::SetupStore;
-use tracing::info;
+use tracing::{error, info};
 
 // ── CLI ──────────────────────────────────────────────────────────
 
@@ -136,19 +136,40 @@ async fn run_server(args: RunArgs) -> anyhow::Result<()> {
         "encryption key ready"
     );
 
-    // Start embedded local runner in default mode so single-host installations
-    // can execute queued builds without a separate `oore runner start` process.
-    let daemon_url = format!("http://127.0.0.1:{}", addr.port());
-    let _embedded_runner =
-        oored::embedded_runner::start_if_enabled(store.pool().clone(), daemon_url)
-            .await
-            .context("failed to initialize embedded runner")?;
-
+    let runner_pool = store.pool().clone();
     let app = build_router(store, runtime_key.key, metrics_handle).await;
 
     info!(listen = %addr, "starting oored daemon");
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
+    if let Some(loopback_addr) = loopback_companion_addr(addr) {
+        let loopback_listener = tokio::net::TcpListener::bind(loopback_addr)
+            .await
+            .with_context(|| {
+                format!("failed to bind loopback companion address: {loopback_addr}")
+            })?;
+        let loopback_app = app.clone();
+
+        info!(listen = %loopback_addr, "also listening on loopback for local runner and CLI access");
+        tokio::spawn(async move {
+            if let Err(error) = axum::serve(
+                loopback_listener,
+                loopback_app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            {
+                error!(%error, "loopback oored listener stopped");
+            }
+        });
+    }
+
+    // The embedded runner always reaches the daemon through loopback. Keep a
+    // loopback listener alongside a private (for example, NetBird) bind.
+    let daemon_url = embedded_runner_url(addr);
+    let _embedded_runner = oored::embedded_runner::start_if_enabled(runner_pool, daemon_url)
+        .await
+        .context("failed to initialize embedded runner")?;
+
     axum::serve(
         listener,
         app.into_make_service_with_connect_info::<SocketAddr>(),
@@ -160,6 +181,22 @@ async fn run_server(args: RunArgs) -> anyhow::Result<()> {
     observability::shutdown_tracing();
 
     Ok(())
+}
+
+fn loopback_companion_addr(addr: SocketAddr) -> Option<SocketAddr> {
+    match addr.ip() {
+        ip if ip.is_loopback() || ip.is_unspecified() => None,
+        IpAddr::V4(_) => Some(SocketAddr::from(([127, 0, 0, 1], addr.port()))),
+        IpAddr::V6(_) => Some(SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], addr.port()))),
+    }
+}
+
+fn embedded_runner_url(addr: SocketAddr) -> String {
+    let loopback = match addr.ip() {
+        IpAddr::V4(_) => IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+        IpAddr::V6(_) => IpAddr::V6(std::net::Ipv6Addr::LOCALHOST),
+    };
+    format!("http://{}", SocketAddr::new(loopback, addr.port()))
 }
 
 fn read_trimmed_file(path: &std::path::Path) -> Option<String> {
@@ -616,5 +653,24 @@ mod tests {
         );
         assert!(parse_env_assignment("1BAD=value").is_err());
         assert!(parse_env_assignment("MISSING_VALUE").is_err());
+    }
+
+    #[test]
+    fn adds_loopback_companion_only_for_specific_non_loopback_binds() {
+        let netbird: SocketAddr = "100.107.193.1:8787".parse().unwrap();
+        let loopback: SocketAddr = "127.0.0.1:8787".parse().unwrap();
+        let wildcard: SocketAddr = "0.0.0.0:8787".parse().unwrap();
+
+        assert_eq!(
+            loopback_companion_addr(netbird),
+            Some("127.0.0.1:8787".parse().unwrap())
+        );
+        assert_eq!(loopback_companion_addr(loopback), None);
+        assert_eq!(loopback_companion_addr(wildcard), None);
+        assert_eq!(embedded_runner_url(netbird), "http://127.0.0.1:8787");
+        assert_eq!(
+            embedded_runner_url("[fd00::1]:8787".parse().unwrap()),
+            "http://[::1]:8787"
+        );
     }
 }

--- a/crates/oored/src/runners.rs
+++ b/crates/oored/src/runners.rs
@@ -315,10 +315,45 @@ pub async fn claim_job(
     let pipeline_id: String = build_row.get("pipeline_id");
     let build_number: i64 = build_row.get("build_number");
     let config_snapshot_str: String = build_row.get("config_snapshot");
-    let config_snapshot: serde_json::Value =
+    let mut config_snapshot: serde_json::Value =
         serde_json::from_str(&config_snapshot_str).unwrap_or_default();
     let commit_sha: Option<String> = build_row.get("commit_sha");
     let branch: Option<String> = build_row.get("branch");
+
+    let source_row = sqlx::query(
+        "SELECT i.provider, r.full_name \
+         FROM projects p \
+         JOIN integration_repositories r ON r.id = p.repository_id \
+         JOIN integration_installations inst ON inst.id = r.installation_id \
+         JOIN integrations i ON i.id = inst.integration_id \
+         WHERE p.id = ?1",
+    )
+    .bind(&project_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| {
+        error!(error = %e, project_id = %project_id, "failed to resolve runner checkout source");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to resolve checkout",
+        )
+    })?;
+    if let Some(source) = source_row
+        && source.get::<String, _>("provider") == "gitlab"
+        && let Some(snapshot) = config_snapshot.as_object_mut()
+    {
+        let full_name: String = source.get("full_name");
+        let encoded_name = full_name
+            .split('/')
+            .map(|part| urlencoding::encode(part).into_owned())
+            .collect::<Vec<_>>()
+            .join("/");
+        snapshot.insert(
+            "checkout_proxy_path".to_string(),
+            format!("/v1/runners/{runner_id}/jobs/{build_id}/gitlab/{encoded_name}.git").into(),
+        );
+    }
 
     let actor_str = format!("runner:{runner_id}");
 

--- a/crates/oored/tests/runner_integration.rs
+++ b/crates/oored/tests/runner_integration.rs
@@ -7,8 +7,8 @@ mod common;
 use axum::body::Body;
 use axum::http::{self, Request, StatusCode};
 use common::{
-    body_json, connect_pool, create_test_app, seed_github_integration, seed_project_chain,
-    seed_test_user,
+    body_json, connect_pool, create_test_app, seed_github_integration, seed_gitlab_integration,
+    seed_project_chain, seed_test_user,
 };
 use sqlx::Row;
 use tower::ServiceExt;
@@ -363,6 +363,44 @@ async fn test_runner_claim_and_execute() {
 
     let json = body_json(resp.into_body()).await;
     assert_eq!(json["build"]["status"].as_str().unwrap(), "succeeded");
+}
+
+#[tokio::test]
+async fn test_gitlab_claim_uses_credential_free_checkout_proxy() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let db_path = tmp.path().join("test.db");
+    let app = create_test_app(&db_path).await;
+    let pool = connect_pool(&db_path).await;
+    let user_id = seed_test_user(&pool).await;
+    let session_token = create_session_token(&pool, &user_id).await;
+    let integration_id = seed_gitlab_integration(&pool, &user_id, "webhook-secret").await;
+    let (project_id, pipeline_id) =
+        seed_project_chain(&pool, &integration_id, &user_id, "internal/mobile/app").await;
+    let build_id = create_build(&pool, &project_id, &pipeline_id).await;
+    let (runner_id, runner_token) = register_runner(&app, &session_token, "gitlab-runner").await;
+
+    let request = Request::post(format!("/v1/runners/{runner_id}/claim"))
+        .header(
+            http::header::AUTHORIZATION,
+            format!("Bearer {runner_token}"),
+        )
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(Body::from(r#"{"protocol_version":2}"#))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response.into_body()).await;
+    let snapshot = &json["job"]["config_snapshot"];
+
+    assert_eq!(
+        snapshot["checkout_proxy_path"],
+        format!("/v1/runners/{runner_id}/jobs/{build_id}/gitlab/internal/mobile/app.git")
+    );
+    assert!(snapshot.get("checkout_rewrite_from").is_none());
+    assert!(
+        !json.to_string().contains(&runner_token),
+        "runner token must not be embedded in the claimed job"
+    );
 }
 
 #[tokio::test]

--- a/crates/oored/tests/webhook_integration.rs
+++ b/crates/oored/tests/webhook_integration.rs
@@ -393,6 +393,50 @@ async fn test_gitlab_webhook_idempotency() {
 }
 
 #[tokio::test]
+async fn test_gitlab_webhook_idempotency_without_event_uuid() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let db_path = tmp.path().join("test.db");
+    let app = common::create_test_app(&db_path).await;
+    let pool = common::connect_pool(&db_path).await;
+    common::set_runtime_mode(&pool, "remote").await;
+
+    let user_id = common::seed_test_user(&pool).await;
+    let secret = "gl-test-fallback-idemp";
+    let integration_id = common::seed_gitlab_integration(&pool, &user_id, secret).await;
+    let (project_id, _) =
+        common::seed_project_chain(&pool, &integration_id, &user_id, "group/fallback-proj").await;
+    let body = serde_json::to_vec(&common::gitlab_push_payload(
+        "group/fallback-proj",
+        "main",
+        "gl-sha-fallback",
+    ))
+    .unwrap();
+
+    for expected_duplicate in [false, true] {
+        let request = Request::post("/v1/webhooks/gitlab")
+            .header("content-type", "application/json")
+            .header("x-gitlab-token", secret)
+            .header("x-gitlab-event", "Push Hook")
+            .body(Body::from(body.clone()))
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), 200);
+        let json = common::body_json(response.into_body()).await;
+        assert_eq!(
+            json["duplicate"].as_bool().unwrap_or(false),
+            expected_duplicate
+        );
+        if !expected_duplicate {
+            common::wait_for_builds(&pool, &project_id, 1, 2000).await;
+        }
+    }
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    let builds = common::wait_for_builds(&pool, &project_id, 1, 500).await;
+    assert_eq!(builds.len(), 1);
+}
+
+#[tokio::test]
 async fn test_gitlab_webhook_secret_rotation_refreshes_cache_without_restart() {
     let tmp = tempfile::TempDir::new().unwrap();
     let db_path = tmp.path().join("test.db");

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -12,6 +12,12 @@ Rules:
 
 ## 2026-07-12
 
+- **Build-ready split runtime, consistent onboarding, and first-class GitLab**:
+  - Private-address daemon installs now keep a loopback companion listener for the embedded runner without adding a wildcard/public bind, so backend readiness and runner readiness agree.
+  - The dashboard and project/source flows now expose build-blocking runner state, preserve the required first-run action order, and avoid remote local-path dead ends.
+  - Shared UI tokens and core onboarding/source screens now use consistent shape, color, heading, and action hierarchy.
+  - GitLab.com and self-managed GitLab flows now provide split-proxy-safe OAuth/webhook guidance, hardened host validation, private checkout support, complete repository sync, and retry-safe webhook identity.
+  - Linear feature doc: https://linear.app/oorebuild/document/feature-product-readiness-consistent-onboarding-and-first-class-gitlab-6e925460f155
 - **Verified launchd service installation**:
   - macOS service installation now retries modern `launchctl bootstrap`, requires `kickstart` and service lookup to succeed, and reports the real launchctl error instead of accepting the legacy `load` command's unreliable exit status.
   - Linear feature doc: https://linear.app/oorebuild/document/feature-guided-split-deployment-installer-9da0d4bf02f6


### PR DESCRIPTION
## Summary
- make private-address daemon installs reachable by the embedded runner without adding a wildcard bind
- correct onboarding hierarchy and remove remote project dead ends while surfacing no-runner blockers
- make GitLab.com and self-managed GitLab production-ready with strict host validation, split-proxy OAuth guidance, paginated reconciliation, retry-safe webhooks, and repository-scoped private checkout
- align core source/onboarding UI with the shared token and action hierarchy

## Security
- provider tokens stay backend-only and out of build payloads/logs
- runner auth is scoped to the exact assigned-repository checkout proxy
- cross-repository and write proxy paths are rejected
- private submodules and OAuth refresh remain documented follow-ups

## Validation
- `make validate`
- authenticated Chrome baseline captured for post-release comparison

## Docs
- Linear feature doc: https://linear.app/oorebuild/document/feature-product-readiness-consistent-onboarding-and-first-class-gitlab-6e925460f155