### PR TITLE
feat: improve runtime controls and interface consistency

### DIFF
--- a/FRONTEND_PRODUCT_PLAN.md
+++ b/FRONTEND_PRODUCT_PLAN.md
@@ -86,3 +86,16 @@ Release evidence: `v0.1.29-alpha.30` passed the release workflow and was verifie
 ## Separate security track
 
 Remote-mode HttpOnly cookie sessions require frontend/backend architecture work and are not part of the UI overhaul. Track and design this separately rather than mixing an authentication migration into visual and performance changes.
+
+## Milestone 7 — State boundaries and runtime administration
+
+- [x] Keep server state in TanStack Query and form state in React Hook Form instead of duplicating either in Zustand.
+- [x] Move cross-component command-palette state into the shared Zustand UI store.
+- [x] Collapse coupled build-log stream flags into one reducer with deterministic cleanup.
+- [x] Remove mirrored pipeline-form dirty state and group related disclosure state.
+- [x] Show frontend and backend release versions independently.
+- [x] Let owners update managed frontend and backend services from the web UI.
+- [x] Report the installed version for embedded and detached runners.
+- [ ] Add detached-runner remote updates after runner-only packaging and a managed runner service/supervisor contract exist.
+
+**Gate:** shared, server, form, and lifecycle state each have one clear owner; runtime updates remain owner-only and unavailable for unmanaged processes; frontend/backend restart through their existing service managers.

--- a/apps/docs-site/docs/getting-started/install.md
+++ b/apps/docs-site/docs/getting-started/install.md
@@ -1,6 +1,6 @@
 ---
 status: implemented
-description: "Install Oore CI backend or frontend roles with a single command."
+description: 'Install Oore CI backend or frontend roles with a single command.'
 ---
 
 # Install Oore CI
@@ -69,13 +69,13 @@ The advanced installer is role-based:
 
 Install roles describe where binaries run. Setup modes describe how the backend will authenticate users after first-run setup.
 
-| Shape | Install role | Setup mode | Use when |
-|---|---|---|---|
-| Single Mac, local evaluation | `all` | `Local Only` | You only access the daemon from loopback on the same machine. No OIDC, proxy, or local passwords. |
-| Single Mac, remote browser access | `all` or `backend` | `Remote OIDC` | Users reach the backend through HTTPS and sign in with any OIDC-compatible identity provider. |
-| Single Mac behind an identity proxy | `all` or `backend` | `Remote Trusted Proxy` | Your proxy already authenticates users and forwards a trusted identity header. |
-| Split frontend/backend | `backend` on macOS plus `frontend` on Linux/macOS | Usually `Remote Trusted Proxy` or `Remote OIDC` | A browser-facing `oore-web` host proxies API calls to the macOS backend over a controlled network path. |
-| Hosted UI | `backend` on macOS | `Remote OIDC` or `Remote Trusted Proxy` | `ci.oore.build` serves only the frontend app; your macOS backend still owns setup, auth, data, builds, and signing keys. |
+| Shape                               | Install role                                      | Setup mode                                      | Use when                                                                                                                 |
+| ----------------------------------- | ------------------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Single Mac, local evaluation        | `all`                                             | `Local Only`                                    | You only access the daemon from loopback on the same machine. No OIDC, proxy, or local passwords.                        |
+| Single Mac, remote browser access   | `all` or `backend`                                | `Remote OIDC`                                   | Users reach the backend through HTTPS and sign in with any OIDC-compatible identity provider.                            |
+| Single Mac behind an identity proxy | `all` or `backend`                                | `Remote Trusted Proxy`                          | Your proxy already authenticates users and forwards a trusted identity header.                                           |
+| Split frontend/backend              | `backend` on macOS plus `frontend` on Linux/macOS | Usually `Remote Trusted Proxy` or `Remote OIDC` | A browser-facing `oore-web` host proxies API calls to the macOS backend over a controlled network path.                  |
+| Hosted UI                           | `backend` on macOS                                | `Remote OIDC` or `Remote Trusted Proxy`         | `ci.oore.build` serves only the frontend app; your macOS backend still owns setup, auth, data, builds, and signing keys. |
 
 The advanced installer:
 
@@ -249,6 +249,12 @@ Override channel explicitly:
 oore update --channel alpha
 ```
 
+For a macOS system service, the updater explains why administrator access is needed and asks `sudo` to authorize the service restart before replacing installed files. Password input is hidden by macOS and is never stored by Oore.
+
+Owners can also check the frontend and backend versions independently from **Settings → Preferences**. When a newer release exists, the page can update a frontend installed as a managed systemd/launchd service and a backend installed as the managed macOS LaunchDaemon. Unmanaged processes remain command-line updates because Oore has no service manager to restart them safely.
+
+Runner inventory reports each runner's installed version. Remote runner updates are not available yet: detached runners currently use the `oore` CLI process and do not have a runner-only package or managed service contract.
+
 ## Next step: choose setup path
 
 Before using the hosted UI, ensure your backend is HTTPS-reachable from the browser network path.
@@ -266,39 +272,39 @@ Continue with [Set Up Your Instance](/getting-started/first-instance). If you pl
 
 ## Installer environment variables
 
-| Variable | Default | Description |
-|---|---|---|
-| `OORE_VERSION` | `latest` | Release selector (`latest` or tag like `v0.2.0`) |
-| `OORE_CHANNEL` | `stable` | Channel selector when `OORE_VERSION=latest`: `stable`, `beta`, or `alpha` |
-| `OORE_INSTALL_MODE` | `auto` | Advanced install mode: `auto`, `all`, `backend`, or `frontend`; use it with `--advanced`; `full` is accepted as a legacy alias for `all` |
-| `OORE_INSTALL_ROOT` | `~/.oore` | Installation directory |
-| `OORE_GITHUB_REPO` | `devaryakjha/oore.build` | GitHub repository used to resolve `latest` and download assets |
-| `OORE_RELEASE_BASE_URL` | `https://github.com/<repo>/releases/download` | Base URL that contains `<tag>/` release assets |
-| `OORE_RELEASE_MANIFEST_URL` | `https://api.github.com/repos/<repo>/releases/latest` | Metadata URL used when `OORE_VERSION=latest` |
-| `OORE_RELEASES_LIST_URL` | `https://api.github.com/repos/<repo>/releases?per_page=100` | Release list URL used when `OORE_VERSION=latest` and `OORE_CHANNEL` is `alpha` or `beta` |
-| `OORE_NONINTERACTIVE` | `0` | Disable prompts when set to `1` |
-| `OORE_OPEN_BROWSER` | interactive local install only | Open the local web root after a default macOS install; set `true` to opt in for non-interactive installs |
-| `OORE_DAEMON_LISTEN` | from `OORE_DAEMON_URL` | Daemon listen address for `all` and `backend` installs, for example `127.0.0.1:8787` for same-host reverse proxy or `10.0.0.20:8787` for a private frontend host |
-| `OORE_START_DAEMON` | unset | Non-interactive daemon startup behavior (`true` or `false`) |
-| `OORE_INSTALL_DAEMON_SERVICE` | unset | Non-interactive launchd service install/start behavior for `all` and `backend` macOS installs (`true` or `false`) |
-| `OORE_PUBLIC_URL` | unset | Browser-visible HTTPS URL passed to the daemon service as External Access fallback |
-| `OORE_CORS_ORIGINS` | `OORE_PUBLIC_URL` when set | Comma-separated allowed browser origins passed to the daemon service |
-| `OORE_DAEMON_URL` | `http://127.0.0.1:8787` | Daemon URL used by backend setup helpers |
-| `OORE_WEB_BACKEND_URL` | `OORE_DAEMON_URL` | Backend URL proxied by `oore-web`, useful for frontend-only hosts |
-| `OORE_FRONTEND_PAIRING_CODE` | unset | Short-lived, single-use code from `oore frontend invite`; exchanges over the private backend path for the backend proof and generates a separate local upstream proof |
-| `OORE_SETUP_OWNER_EMAIL` | unset | Initial owner email to prefill in Trusted Proxy setup |
-| `OORE_SETUP_PROXY_PRESET` | `generic` | Trusted Proxy setup prefill: `generic`, `warpgate`, or `custom` |
-| `OORE_SETUP_USER_EMAIL_HEADER` | unset | Custom Trusted Proxy email header when `OORE_SETUP_PROXY_PRESET=custom` |
-| `OORE_TRUSTED_PROXY_SHARED_SECRET` | unset | Trusted Proxy backend shared secret; installer persists it to a restrictive file when needed |
-| `OORE_TRUSTED_PROXY_SHARED_SECRET_FILE` | `~/.oore/trusted-proxy-shared-secret` when generated | File containing the backend shared secret for `oore setup init` and `oore-web` |
-| `OORE_TRUSTED_PROXY_CIDRS` | unset | Comma-separated trusted proxy/frontend peer CIDRs allowed to send identity to the backend |
-| `OORE_WEB_TRUSTED_PROXY_USER_EMAIL_HEADER` | preset-derived | Identity header `oore-web` may forward only after upstream proof |
-| `OORE_WEB_UPSTREAM_TRUSTED_PROXY_SHARED_SECRET` | unset | Auth proxy to `oore-web` proof secret; installer persists it to a restrictive file when needed |
-| `OORE_WEB_UPSTREAM_TRUSTED_PROXY_SHARED_SECRET_FILE` | `~/.oore/oore-web-upstream-trusted-proxy-secret` when generated | File containing the auth proxy to `oore-web` proof secret |
-| `OORE_WEB_UPSTREAM_TRUSTED_PROXY_SECRET_HEADER` | `x-oore-web-trusted-proxy-secret` | Header your auth proxy sends to prove the identity header is proxy-set |
-| `OORE_LOCAL_WEB_MODE` | unset | Non-interactive local web behavior for localhost backends: `off`, `run`, or `login` (launch-at-login) |
-| `OORE_LOCAL_WEB_LISTEN` | `127.0.0.1:4173` | Bind address for `oore-web` |
-| `OORE_ENABLE_LINGER` | unset | Enable systemd lingering for Linux frontend service installs (`true` or `false`) |
+| Variable                                             | Default                                                         | Description                                                                                                                                                           |
+| ---------------------------------------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `OORE_VERSION`                                       | `latest`                                                        | Release selector (`latest` or tag like `v0.2.0`)                                                                                                                      |
+| `OORE_CHANNEL`                                       | `stable`                                                        | Channel selector when `OORE_VERSION=latest`: `stable`, `beta`, or `alpha`                                                                                             |
+| `OORE_INSTALL_MODE`                                  | `auto`                                                          | Advanced install mode: `auto`, `all`, `backend`, or `frontend`; use it with `--advanced`; `full` is accepted as a legacy alias for `all`                              |
+| `OORE_INSTALL_ROOT`                                  | `~/.oore`                                                       | Installation directory                                                                                                                                                |
+| `OORE_GITHUB_REPO`                                   | `devaryakjha/oore.build`                                        | GitHub repository used to resolve `latest` and download assets                                                                                                        |
+| `OORE_RELEASE_BASE_URL`                              | `https://github.com/<repo>/releases/download`                   | Base URL that contains `<tag>/` release assets                                                                                                                        |
+| `OORE_RELEASE_MANIFEST_URL`                          | `https://api.github.com/repos/<repo>/releases/latest`           | Metadata URL used when `OORE_VERSION=latest`                                                                                                                          |
+| `OORE_RELEASES_LIST_URL`                             | `https://api.github.com/repos/<repo>/releases?per_page=100`     | Release list URL used when `OORE_VERSION=latest` and `OORE_CHANNEL` is `alpha` or `beta`                                                                              |
+| `OORE_NONINTERACTIVE`                                | `0`                                                             | Disable prompts when set to `1`                                                                                                                                       |
+| `OORE_OPEN_BROWSER`                                  | interactive local install only                                  | Open the local web root after a default macOS install; set `true` to opt in for non-interactive installs                                                              |
+| `OORE_DAEMON_LISTEN`                                 | from `OORE_DAEMON_URL`                                          | Daemon listen address for `all` and `backend` installs, for example `127.0.0.1:8787` for same-host reverse proxy or `10.0.0.20:8787` for a private frontend host      |
+| `OORE_START_DAEMON`                                  | unset                                                           | Non-interactive daemon startup behavior (`true` or `false`)                                                                                                           |
+| `OORE_INSTALL_DAEMON_SERVICE`                        | unset                                                           | Non-interactive launchd service install/start behavior for `all` and `backend` macOS installs (`true` or `false`)                                                     |
+| `OORE_PUBLIC_URL`                                    | unset                                                           | Browser-visible HTTPS URL passed to the daemon service as External Access fallback                                                                                    |
+| `OORE_CORS_ORIGINS`                                  | `OORE_PUBLIC_URL` when set                                      | Comma-separated allowed browser origins passed to the daemon service                                                                                                  |
+| `OORE_DAEMON_URL`                                    | `http://127.0.0.1:8787`                                         | Daemon URL used by backend setup helpers                                                                                                                              |
+| `OORE_WEB_BACKEND_URL`                               | `OORE_DAEMON_URL`                                               | Backend URL proxied by `oore-web`, useful for frontend-only hosts                                                                                                     |
+| `OORE_FRONTEND_PAIRING_CODE`                         | unset                                                           | Short-lived, single-use code from `oore frontend invite`; exchanges over the private backend path for the backend proof and generates a separate local upstream proof |
+| `OORE_SETUP_OWNER_EMAIL`                             | unset                                                           | Initial owner email to prefill in Trusted Proxy setup                                                                                                                 |
+| `OORE_SETUP_PROXY_PRESET`                            | `generic`                                                       | Trusted Proxy setup prefill: `generic`, `warpgate`, or `custom`                                                                                                       |
+| `OORE_SETUP_USER_EMAIL_HEADER`                       | unset                                                           | Custom Trusted Proxy email header when `OORE_SETUP_PROXY_PRESET=custom`                                                                                               |
+| `OORE_TRUSTED_PROXY_SHARED_SECRET`                   | unset                                                           | Trusted Proxy backend shared secret; installer persists it to a restrictive file when needed                                                                          |
+| `OORE_TRUSTED_PROXY_SHARED_SECRET_FILE`              | `~/.oore/trusted-proxy-shared-secret` when generated            | File containing the backend shared secret for `oore setup init` and `oore-web`                                                                                        |
+| `OORE_TRUSTED_PROXY_CIDRS`                           | unset                                                           | Comma-separated trusted proxy/frontend peer CIDRs allowed to send identity to the backend                                                                             |
+| `OORE_WEB_TRUSTED_PROXY_USER_EMAIL_HEADER`           | preset-derived                                                  | Identity header `oore-web` may forward only after upstream proof                                                                                                      |
+| `OORE_WEB_UPSTREAM_TRUSTED_PROXY_SHARED_SECRET`      | unset                                                           | Auth proxy to `oore-web` proof secret; installer persists it to a restrictive file when needed                                                                        |
+| `OORE_WEB_UPSTREAM_TRUSTED_PROXY_SHARED_SECRET_FILE` | `~/.oore/oore-web-upstream-trusted-proxy-secret` when generated | File containing the auth proxy to `oore-web` proof secret                                                                                                             |
+| `OORE_WEB_UPSTREAM_TRUSTED_PROXY_SECRET_HEADER`      | `x-oore-web-trusted-proxy-secret`                               | Header your auth proxy sends to prove the identity header is proxy-set                                                                                                |
+| `OORE_LOCAL_WEB_MODE`                                | unset                                                           | Non-interactive local web behavior for localhost backends: `off`, `run`, or `login` (launch-at-login)                                                                 |
+| `OORE_LOCAL_WEB_LISTEN`                              | `127.0.0.1:4173`                                                | Bind address for `oore-web`                                                                                                                                           |
+| `OORE_ENABLE_LINGER`                                 | unset                                                           | Enable systemd lingering for Linux frontend service installs (`true` or `false`)                                                                                      |
 
 ## Troubleshooting
 

--- a/apps/docs-site/docs/public/openapi.json
+++ b/apps/docs-site/docs/public/openapi.json
@@ -5654,6 +5654,108 @@
         ]
       }
     },
+    "/v1/system/update": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Get backend update state",
+        "description": "Reports whether the backend is managed by the supported macOS launchd\nservice and whether an update is currently running. Requires owner role.",
+        "operationId": "get_runtime_update_status",
+        "responses": {
+          "200": {
+            "description": "Backend update state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuntimeUpdateStatus"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Owner role required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Start a backend update",
+        "description": "Runs the installed updater and hands restart control to the managed\nmacOS launchd service. Requires owner role.",
+        "operationId": "start_runtime_update",
+        "responses": {
+          "202": {
+            "description": "Backend update started",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuntimeUpdateStatus"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Owner role required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Managed updater unavailable or already running",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/v1/users": {
       "get": {
         "tags": [
@@ -9611,6 +9713,36 @@
           "local",
           "remote"
         ]
+      },
+      "RuntimeUpdatePhase": {
+        "type": "string",
+        "enum": [
+          "idle",
+          "updating",
+          "restarting",
+          "failed"
+        ]
+      },
+      "RuntimeUpdateStatus": {
+        "type": "object",
+        "required": [
+          "phase",
+          "managed_service"
+        ],
+        "properties": {
+          "error": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "managed_service": {
+            "type": "boolean"
+          },
+          "phase": {
+            "$ref": "#/components/schemas/RuntimeUpdatePhase"
+          }
+        }
       },
       "ScmProvider": {
         "type": "string",

--- a/apps/web/src/components/AddInstanceDialog.tsx
+++ b/apps/web/src/components/AddInstanceDialog.tsx
@@ -201,6 +201,8 @@ export default function AddInstanceDialog({
                       : ''
                   }
                   onClick={() => setValue('icon', entry.key)}
+                  aria-label={`Select ${entry.label} icon`}
+                  aria-pressed={selectedIcon === entry.key}
                   title={entry.label}
                 >
                   <HugeiconsIcon icon={entry.icon} />

--- a/apps/web/src/components/EditInstanceDialog.tsx
+++ b/apps/web/src/components/EditInstanceDialog.tsx
@@ -148,6 +148,8 @@ export default function EditInstanceDialog({
                       : ''
                   }
                   onClick={() => setValue('icon', entry.key)}
+                  aria-label={`Select ${entry.label} icon`}
+                  aria-pressed={selectedIcon === entry.key}
                   title={entry.label}
                 >
                   <HugeiconsIcon icon={entry.icon} />

--- a/apps/web/src/components/InstanceSwitcher.tsx
+++ b/apps/web/src/components/InstanceSwitcher.tsx
@@ -104,12 +104,13 @@ export default function InstanceSwitcher() {
                   <span className="truncate flex-1">{inst.label}</span>
                   <button
                     type="button"
-                    className="ml-auto opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-foreground"
+                    className="ml-auto text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
                     onClick={(e) => {
                       e.stopPropagation()
                       requestAnimationFrame(() => setEditingInstance(inst))
                     }}
                     title={`Edit ${inst.label}`}
+                    aria-label={`Edit ${inst.label}`}
                   >
                     <HugeiconsIcon icon={PencilEdit02Icon} size={14} />
                   </button>

--- a/apps/web/src/components/build-details/artifacts-panel.tsx
+++ b/apps/web/src/components/build-details/artifacts-panel.tsx
@@ -324,7 +324,7 @@ export function ArtifactsPanel({
                     size={14}
                     className="mr-1.5"
                   />
-                  Copy Link
+                  Copy link
                 </Button>
               </DialogFooter>
             </div>

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import { HugeiconsIcon } from '@hugeicons/react'
 import {
@@ -23,6 +23,7 @@ import {
 } from '@/components/ui/command'
 import { useProjects } from '@/hooks/use-projects'
 import { useAuthStore } from '@/stores/auth-store'
+import { useUiStore } from '@/stores/ui-store'
 import { useHasPermission } from '@/hooks/use-permissions'
 
 interface PaletteItem {
@@ -34,7 +35,9 @@ interface PaletteItem {
 }
 
 export default function CommandPalette() {
-  const [open, setOpen] = useState(false)
+  const open = useUiStore((state) => state.commandPaletteOpen)
+  const setOpen = useUiStore((state) => state.setCommandPaletteOpen)
+  const toggleOpen = useUiStore((state) => state.toggleCommandPalette)
   const navigate = useNavigate()
   const authUser = useAuthStore((s) => s.user)
 
@@ -49,7 +52,7 @@ export default function CommandPalette() {
     function handleKeyDown(e: KeyboardEvent) {
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
         e.preventDefault()
-        setOpen((prev) => !prev)
+        toggleOpen()
       }
     }
     window.addEventListener('keydown', handleKeyDown)
@@ -61,7 +64,7 @@ export default function CommandPalette() {
       setOpen(false)
       void navigate({ to })
     },
-    [navigate],
+    [navigate, setOpen],
   )
 
   const navItems = useMemo<Array<PaletteItem>>(

--- a/apps/web/src/components/page-header.tsx
+++ b/apps/web/src/components/page-header.tsx
@@ -18,7 +18,7 @@ export default function PageHeader({
   meta,
 }: PageHeaderProps) {
   return (
-    <header className="space-y-3 pb-6">
+    <header className="space-y-3">
       {back && (
         <Link
           to={back.to}

--- a/apps/web/src/components/pipeline-form.tsx
+++ b/apps/web/src/components/pipeline-form.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useReducer, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { HugeiconsIcon } from '@hugeicons/react'
@@ -9,7 +9,6 @@ import {
 } from '@hugeicons/core-free-icons'
 
 import type { PipelineFormValues } from '@/lib/pipeline-schema'
-import { useMountEffect } from '@/hooks/use-mount-effect'
 import { useWindowEvent } from '@/hooks/use-window-event'
 import { Button } from '@/components/ui/button'
 import {
@@ -144,6 +143,67 @@ const CONFIG_SOURCES: Record<string, string> = {
   explicit: 'Use a specific config file path',
 }
 
+interface PipelineSections {
+  config: boolean
+  triggers: boolean
+  commands: boolean
+  platformArgs: boolean
+  env: boolean
+  artifacts: boolean
+  iosSigning: boolean
+  signing: boolean
+}
+
+type PipelineSectionsAction =
+  | {
+      type: 'set'
+      section: keyof PipelineSections
+      open: boolean
+    }
+  | {
+      type: 'reveal'
+      sections: Partial<Record<keyof PipelineSections, boolean>>
+    }
+
+function pipelineSectionsReducer(
+  state: PipelineSections,
+  action: PipelineSectionsAction,
+): PipelineSections {
+  if (action.type === 'set') {
+    return { ...state, [action.section]: action.open }
+  }
+
+  const next = { ...state }
+  for (const [section, shouldOpen] of Object.entries(action.sections)) {
+    if (shouldOpen) next[section as keyof PipelineSections] = true
+  }
+  return next
+}
+
+function initialPipelineSections({
+  initialValues,
+  retrySigning,
+}: Pick<
+  PipelineFormProps,
+  'initialValues' | 'retrySigning'
+>): PipelineSections {
+  return {
+    config: true,
+    triggers: true,
+    commands: false,
+    platformArgs: false,
+    env: false,
+    artifacts: false,
+    iosSigning: !!initialValues.ios_signing_enabled || retrySigning === 'ios',
+    signing:
+      retrySigning === 'android' ||
+      !!(
+        initialValues.android_signing_release_enabled ||
+        initialValues.android_signing_debug_enabled
+      ),
+  }
+}
+
 const ANDROID_GRADLE_SIGNING_SNIPPET = `android {
     signingConfigs {
         release {
@@ -234,30 +294,15 @@ export default function PipelineForm({
   const [iosProfileFiles, setIosProfileFiles] = useState<
     Record<string, File | null>
   >({})
-  const [isDirty, setIsDirty] = useState(false)
-
-  const [configOpen, setConfigOpen] = useState(true)
-  const [triggersOpen, setTriggersOpen] = useState(true)
-  const [commandsOpen, setCommandsOpen] = useState(false)
-  const [platformArgsOpen, setPlatformArgsOpen] = useState(false)
-  const [envOpen, setEnvOpen] = useState(false)
-  const [artifactsOpen, setArtifactsOpen] = useState(false)
-  const [iosSigningOpen, setIosSigningOpen] = useState(
-    () => !!initialValues.ios_signing_enabled || retrySigning === 'ios',
+  const [isAuxiliaryDirty, setIsAuxiliaryDirty] = useState(false)
+  const [sections, dispatchSections] = useReducer(
+    pipelineSectionsReducer,
+    { initialValues, retrySigning },
+    initialPipelineSections,
   )
-  const [signingOpen, setSigningOpen] = useState(
-    () =>
-      retrySigning === 'android' ||
-      !!(
-        initialValues.android_signing_release_enabled ||
-        initialValues.android_signing_debug_enabled
-      ),
-  )
-
-  useMountEffect(() => {
-    const subscription = form.watch(() => setIsDirty(true))
-    return () => subscription.unsubscribe()
-  })
+  const isDirty = form.formState.isDirty || isAuxiliaryDirty
+  const setSectionOpen = (section: keyof typeof sections) => (open: boolean) =>
+    dispatchSections({ type: 'set', section, open })
 
   useWindowEvent('beforeunload', (event) => {
     if (isDirty) event.preventDefault()
@@ -269,7 +314,7 @@ export default function PipelineForm({
         ? prev.filter((entry) => entry !== event)
         : [...prev, event],
     )
-    setIsDirty(true)
+    setIsAuxiliaryDirty(true)
   }
 
   async function handleFormSubmit(data: PipelineFormValues) {
@@ -291,31 +336,28 @@ export default function PipelineForm({
     const valid = await form.trigger()
     if (!valid) {
       const errors = form.formState.errors
-      if (
-        errors.name ||
-        errors.config_mode ||
-        errors.config_path ||
-        errors.flutter_version
-      ) {
-        setConfigOpen(true)
-      }
-      if (errors.max_concurrent || errors.branches) {
-        setTriggersOpen(true)
-      }
-      if (
-        errors.pre_build_commands ||
-        errors.build_commands ||
-        errors.post_build_commands
-      ) {
-        setCommandsOpen(true)
-      }
-      if (
-        errors.ios_signing_enabled ||
-        errors.ios_signing_team_id ||
-        errors.ios_signing_bundle_ids
-      ) {
-        setIosSigningOpen(true)
-      }
+      dispatchSections({
+        type: 'reveal',
+        sections: {
+          config: !!(
+            errors.name ||
+            errors.config_mode ||
+            errors.config_path ||
+            errors.flutter_version
+          ),
+          triggers: !!(errors.max_concurrent || errors.branches),
+          commands: !!(
+            errors.pre_build_commands ||
+            errors.build_commands ||
+            errors.post_build_commands
+          ),
+          iosSigning: !!(
+            errors.ios_signing_enabled ||
+            errors.ios_signing_team_id ||
+            errors.ios_signing_bundle_ids
+          ),
+        },
+      })
     }
   }
 
@@ -365,14 +407,17 @@ export default function PipelineForm({
         </Card>
 
         {/* Configuration section */}
-        <Collapsible open={configOpen} onOpenChange={setConfigOpen}>
+        <Collapsible
+          open={sections.config}
+          onOpenChange={setSectionOpen('config')}
+        >
           <Card>
             <CollapsibleTrigger className="w-full cursor-pointer">
               <CardHeader>
                 <SectionHeader
                   title="Configuration"
                   summary={`${platforms.length} platform${platforms.length !== 1 ? 's' : ''}, ${configMode === 'explicit' ? 'explicit config' : 'auto-detect'}`}
-                  open={configOpen}
+                  open={sections.config}
                 />
               </CardHeader>
             </CollapsibleTrigger>
@@ -527,7 +572,10 @@ export default function PipelineForm({
         </Collapsible>
 
         {/* Triggers section */}
-        <Collapsible open={triggersOpen} onOpenChange={setTriggersOpen}>
+        <Collapsible
+          open={sections.triggers}
+          onOpenChange={setSectionOpen('triggers')}
+        >
           <Card>
             <CollapsibleTrigger className="w-full cursor-pointer">
               <CardHeader>
@@ -538,7 +586,7 @@ export default function PipelineForm({
                       ? `manual only, cancel previous: ${cancelPrevious ? 'on' : 'off'}`
                       : `${selectedEvents.length} event${selectedEvents.length !== 1 ? 's' : ''}, cancel previous: ${cancelPrevious ? 'on' : 'off'}`
                   }
-                  open={triggersOpen}
+                  open={sections.triggers}
                 />
               </CardHeader>
             </CollapsibleTrigger>
@@ -598,7 +646,7 @@ export default function PipelineForm({
                       checked={cancelPrevious}
                       onCheckedChange={(checked) => {
                         setCancelPrevious(!!checked)
-                        setIsDirty(true)
+                        setIsAuxiliaryDirty(true)
                       }}
                     />
                     Cancel previous builds on same branch
@@ -624,7 +672,10 @@ export default function PipelineForm({
         </Collapsible>
 
         {/* Build Commands section */}
-        <Collapsible open={commandsOpen} onOpenChange={setCommandsOpen}>
+        <Collapsible
+          open={sections.commands}
+          onOpenChange={setSectionOpen('commands')}
+        >
           <Card>
             <CollapsibleTrigger className="w-full cursor-pointer">
               <CardHeader>
@@ -635,7 +686,7 @@ export default function PipelineForm({
                       ? `${totalCmdCount} custom command${totalCmdCount !== 1 ? 's' : ''}`
                       : 'Using defaults'
                   }
-                  open={commandsOpen}
+                  open={sections.commands}
                 />
               </CardHeader>
             </CollapsibleTrigger>
@@ -736,14 +787,17 @@ export default function PipelineForm({
         </Collapsible>
 
         {/* Platform Build Args section */}
-        <Collapsible open={platformArgsOpen} onOpenChange={setPlatformArgsOpen}>
+        <Collapsible
+          open={sections.platformArgs}
+          onOpenChange={setSectionOpen('platformArgs')}
+        >
           <Card>
             <CollapsibleTrigger className="w-full cursor-pointer">
               <CardHeader>
                 <SectionHeader
                   title="Platform Build Args"
                   summary="Per-platform args + command overrides"
-                  open={platformArgsOpen}
+                  open={sections.platformArgs}
                 />
               </CardHeader>
             </CollapsibleTrigger>
@@ -880,7 +934,7 @@ export default function PipelineForm({
         </Collapsible>
 
         {/* Environment Variables section */}
-        <Collapsible open={envOpen} onOpenChange={setEnvOpen}>
+        <Collapsible open={sections.env} onOpenChange={setSectionOpen('env')}>
           <Card>
             <CollapsibleTrigger className="w-full cursor-pointer">
               <CardHeader>
@@ -891,7 +945,7 @@ export default function PipelineForm({
                       ? `${envVarCount} env var${envVarCount !== 1 ? 's' : ''} configured`
                       : 'None configured'
                   }
-                  open={envOpen}
+                  open={sections.env}
                 />
               </CardHeader>
             </CollapsibleTrigger>
@@ -939,7 +993,10 @@ export default function PipelineForm({
         </Collapsible>
 
         {/* Artifacts section */}
-        <Collapsible open={artifactsOpen} onOpenChange={setArtifactsOpen}>
+        <Collapsible
+          open={sections.artifacts}
+          onOpenChange={setSectionOpen('artifacts')}
+        >
           <Card>
             <CollapsibleTrigger className="w-full cursor-pointer">
               <CardHeader>
@@ -950,7 +1007,7 @@ export default function PipelineForm({
                       ? artifactPatterns.join(', ')
                       : 'Using platform defaults'
                   }
-                  open={artifactsOpen}
+                  open={sections.artifacts}
                 />
               </CardHeader>
             </CollapsibleTrigger>
@@ -981,7 +1038,10 @@ export default function PipelineForm({
 
         {/* Android Signing section */}
         {values.platform_android ? (
-          <Collapsible open={signingOpen} onOpenChange={setSigningOpen}>
+          <Collapsible
+            open={sections.signing}
+            onOpenChange={setSectionOpen('signing')}
+          >
             <Card>
               <CollapsibleTrigger className="w-full cursor-pointer">
                 <CardHeader>
@@ -1000,7 +1060,7 @@ export default function PipelineForm({
                             .join(' + ') + ' enabled'
                         : 'Not configured'
                     }
-                    open={signingOpen}
+                    open={sections.signing}
                   />
                 </CardHeader>
               </CollapsibleTrigger>
@@ -1259,7 +1319,10 @@ export default function PipelineForm({
 
         {/* iOS Signing section */}
         {values.platform_ios ? (
-          <Collapsible open={iosSigningOpen} onOpenChange={setIosSigningOpen}>
+          <Collapsible
+            open={sections.iosSigning}
+            onOpenChange={setSectionOpen('iosSigning')}
+          >
             <Card>
               <CollapsibleTrigger className="w-full cursor-pointer">
                 <CardHeader>
@@ -1270,7 +1333,7 @@ export default function PipelineForm({
                         ? `${iosSigningMode} mode`
                         : 'Not configured'
                     }
-                    open={iosSigningOpen}
+                    open={sections.iosSigning}
                   />
                 </CardHeader>
               </CollapsibleTrigger>

--- a/apps/web/src/components/project-card.tsx
+++ b/apps/web/src/components/project-card.tsx
@@ -22,8 +22,8 @@ export default function ProjectCard({
   onTriggerBuild,
 }: ProjectCardProps) {
   return (
-    <Card className="group relative">
-      <CardContent className="space-y-3">
+    <Card className="group relative h-full">
+      <CardContent className="flex h-full flex-col gap-3">
         <div className="flex items-start justify-between gap-2">
           <div className="min-w-0">
             <Link
@@ -78,7 +78,7 @@ export default function ProjectCard({
         <Button
           size="sm"
           variant="outline"
-          className="w-full"
+          className="mt-auto w-full"
           onClick={() => onTriggerBuild(project.id)}
         >
           <HugeiconsIcon icon={PlayIcon} />

--- a/apps/web/src/components/ui/alert-dialog.tsx
+++ b/apps/web/src/components/ui/alert-dialog.tsx
@@ -141,11 +141,13 @@ function AlertDialogDescription({
 
 function AlertDialogAction({
   className,
+  variant = 'destructive',
   ...props
 }: React.ComponentProps<typeof Button>) {
   return (
     <Button
       data-slot="alert-dialog-action"
+      variant={variant}
       className={cn(className)}
       {...props}
     />

--- a/apps/web/src/hooks/use-log-stream.ts
+++ b/apps/web/src/hooks/use-log-stream.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useReducer, useRef } from 'react'
 
 import type { BuildLogChunk } from '@/lib/types'
 import { createStreamToken, getBuildLogs } from '@/lib/api'
@@ -21,16 +21,27 @@ interface UseLogStreamOptions {
 const POLL_INTERVAL_MS = 2500
 const POLL_BACKFILL_WINDOW = 500
 
+type StreamState = UseLogStreamResult
+type StreamAction = Partial<StreamState> | 'reset'
+
+const initialStreamState: StreamState = {
+  logs: [],
+  isStreaming: false,
+  isDone: false,
+  error: null,
+}
+
+function streamReducer(state: StreamState, action: StreamAction): StreamState {
+  return action === 'reset' ? initialStreamState : { ...state, ...action }
+}
+
 export function useLogStream(
   buildId: string,
   enabled: boolean,
   options?: UseLogStreamOptions,
 ): UseLogStreamResult {
   const onDone = options?.onDone
-  const [logs, setLogs] = useState<Array<BuildLogChunk>>([])
-  const [isStreaming, setIsStreaming] = useState(false)
-  const [isDone, setIsDone] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [stream, updateStream] = useReducer(streamReducer, initialStreamState)
 
   const instance = useActiveInstance()
   const baseUrl = resolveInstanceApiBaseUrl(instance)
@@ -56,7 +67,7 @@ export function useLogStream(
 
     orderedLogsRef.current = merged.logs
     lastSequenceRef.current = merged.lastSequence
-    setLogs(merged.logs)
+    updateStream({ logs: merged.logs })
   }, [])
 
   const pollOnce = useCallback(async () => {
@@ -104,15 +115,10 @@ export function useLogStream(
   }, [stopPolling])
 
   useEffect(() => {
-    if (!enabled || !baseUrl || !token) {
-      cleanup()
-      return
-    }
+    cleanup()
+    if (!enabled || !baseUrl || !token) return cleanup
 
-    setLogs([])
-    setIsStreaming(false)
-    setIsDone(false)
-    setError(null)
+    updateStream('reset')
     logsBySequenceRef.current = new Map()
     orderedLogsRef.current = []
     lastSequenceRef.current = -1
@@ -129,7 +135,9 @@ export function useLogStream(
         streamToken = response.token
       } catch {
         if (!abort.signal.aborted) {
-          setError('Live stream unavailable. Using polling fallback.')
+          updateStream({
+            error: 'Live stream unavailable. Using polling fallback.',
+          })
         }
         return
       }
@@ -147,8 +155,7 @@ export function useLogStream(
         es.addEventListener('open', () => {
           // SSE is healthy, so suspend polling reconciliation until disconnect.
           stopPolling()
-          setIsStreaming(true)
-          setError(null)
+          updateStream({ isStreaming: true, error: null })
         })
 
         es.addEventListener('log', (event: MessageEvent) => {
@@ -161,8 +168,7 @@ export function useLogStream(
         })
 
         es.addEventListener('done', () => {
-          setIsStreaming(false)
-          setIsDone(true)
+          updateStream({ isStreaming: false, isDone: true })
           es.close()
           eventSourceRef.current = null
           void pollOnce()
@@ -173,14 +179,18 @@ export function useLogStream(
         es.addEventListener('error', () => {
           es.close()
           eventSourceRef.current = null
-          setIsStreaming(false)
-          setError('Live stream disconnected. Continuing with polling.')
+          updateStream({
+            isStreaming: false,
+            error: 'Live stream disconnected. Continuing with polling.',
+          })
           startPolling()
         })
       } catch {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- abort may happen concurrently
         if (!abort.signal.aborted) {
-          setError('Failed to connect live stream. Using polling fallback.')
+          updateStream({
+            error: 'Failed to connect live stream. Using polling fallback.',
+          })
         }
       }
     })()
@@ -199,5 +209,5 @@ export function useLogStream(
     onDone,
   ])
 
-  return { logs, isStreaming, isDone, error }
+  return stream
 }

--- a/apps/web/src/hooks/use-runtime-updates.ts
+++ b/apps/web/src/hooks/use-runtime-updates.ts
@@ -1,0 +1,121 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import type { RuntimeReleaseStatus, RuntimeUpdateStatus } from '@/lib/types'
+import { getBackendUpdateStatus, startBackendUpdate } from '@/lib/api'
+import { resolveInstanceApiBaseUrl } from '@/lib/instance-url'
+import { useAuthStore } from '@/stores/auth-store'
+import { useActiveInstance } from '@/stores/instance-store'
+
+interface BackendRelease {
+  version?: string
+  channel?: string | null
+  github_repo?: string | null
+}
+
+async function localUpdateRequest<T>(
+  token: string,
+  method: 'GET' | 'POST',
+  search?: URLSearchParams,
+): Promise<T> {
+  const response = await fetch(
+    `/__oore_web_update${search ? `?${search}` : ''}`,
+    {
+      method,
+      headers: { Authorization: `Bearer ${token}` },
+      cache: 'no-store',
+    },
+  )
+  if (!response.ok) {
+    const body = (await response.json().catch(() => null)) as {
+      error?: string
+    } | null
+    throw new Error(body?.error || `Update request failed (${response.status})`)
+  }
+  return (await response.json()) as T
+}
+
+export function useRuntimeUpdates(backend: BackendRelease) {
+  const queryClient = useQueryClient()
+  const instance = useActiveInstance()
+  const baseUrl = resolveInstanceApiBaseUrl(instance)
+  const token = useAuthStore((state) => state.token)
+  const isOwner = useAuthStore((state) => state.user?.role === 'owner')
+  const instanceKey = instance?.id ?? '__none__'
+
+  const frontendRelease = useQuery({
+    queryKey: [instanceKey, 'runtime-update', 'frontend-release'],
+    queryFn: () => localUpdateRequest<RuntimeReleaseStatus>(token!, 'GET'),
+    enabled: !!token && isOwner,
+    staleTime: 60_000,
+    refetchInterval: (query) =>
+      query.state.data?.phase === 'updating' ||
+      query.state.data?.phase === 'restarting'
+        ? 2_000
+        : false,
+  })
+
+  const backendRelease = useQuery({
+    queryKey: [
+      instanceKey,
+      'runtime-update',
+      'backend-release',
+      backend.version,
+      backend.channel,
+      backend.github_repo,
+    ],
+    queryFn: () =>
+      localUpdateRequest<RuntimeReleaseStatus>(
+        token!,
+        'GET',
+        new URLSearchParams({
+          current: backend.version!,
+          channel: backend.channel!,
+          repo: backend.github_repo!,
+        }),
+      ),
+    enabled:
+      !!token &&
+      isOwner &&
+      !!backend.version &&
+      !!backend.channel &&
+      !!backend.github_repo,
+    staleTime: 60_000,
+  })
+
+  const backendUpdate = useQuery({
+    queryKey: [instanceKey, 'runtime-update', 'backend-state'],
+    queryFn: () => getBackendUpdateStatus(baseUrl!, token!),
+    enabled: !!baseUrl && !!token && isOwner,
+    refetchInterval: (query) =>
+      query.state.data?.phase === 'updating' ||
+      query.state.data?.phase === 'restarting'
+        ? 2_000
+        : false,
+  })
+
+  const startFrontendUpdate = useMutation({
+    mutationFn: () => localUpdateRequest<RuntimeUpdateStatus>(token!, 'POST'),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: [instanceKey, 'runtime-update'],
+      })
+    },
+  })
+
+  const startBackendUpdateMutation = useMutation({
+    mutationFn: () => startBackendUpdate(baseUrl!, token!),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: [instanceKey, 'runtime-update'],
+      })
+    },
+  })
+
+  return {
+    frontendRelease,
+    backendRelease,
+    backendUpdate,
+    startFrontendUpdate,
+    startBackendUpdate: startBackendUpdateMutation,
+  }
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -71,6 +71,7 @@ import type {
   RetentionCleanupSummaryResponse,
   RetentionPolicyResponse,
   RevokeApiTokenResponse,
+  RuntimeUpdateStatus,
   SetupCompleteResponse,
   SetupLocalOwnerCreateResponse,
   SetupOidcStartResponse,
@@ -339,6 +340,25 @@ export function getMe(
   token: string,
 ): Promise<UserProfileResponse> {
   return request<UserProfileResponse>(baseUrl, '/v1/users/me', {
+    headers: authHeaders(token),
+  })
+}
+
+export function getBackendUpdateStatus(
+  baseUrl: string,
+  token: string,
+): Promise<RuntimeUpdateStatus> {
+  return request<RuntimeUpdateStatus>(baseUrl, '/v1/system/update', {
+    headers: authHeaders(token),
+  })
+}
+
+export function startBackendUpdate(
+  baseUrl: string,
+  token: string,
+): Promise<RuntimeUpdateStatus> {
+  return request<RuntimeUpdateStatus>(baseUrl, '/v1/system/update', {
+    method: 'POST',
     headers: authHeaders(token),
   })
 }

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -198,6 +198,20 @@ export interface LogoutResponse {
   ok: boolean
 }
 
+export interface RuntimeUpdateStatus {
+  phase: 'idle' | 'updating' | 'restarting' | 'failed'
+  error?: string | null
+  managed_service: boolean
+}
+
+export interface RuntimeReleaseStatus extends RuntimeUpdateStatus {
+  version: string
+  latest_version: string
+  channel: string
+  github_repo: string
+  update_available: boolean
+}
+
 // ── Structured API error ────────────────────────────────────────
 
 export interface ApiError {
@@ -211,10 +225,7 @@ export interface ApiError {
 export type ScmProvider = 'github' | 'gitlab' | 'local_git'
 
 export type IntegrationAuthMode =
-  | 'github_app'
-  | 'oauth_app'
-  | 'personal_token'
-  | 'local_path'
+  'github_app' | 'oauth_app' | 'personal_token' | 'local_path'
 
 export type IntegrationStatus = 'active' | 'inactive' | 'error'
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -36,6 +36,7 @@ import { useSessionMonitor } from '@/hooks/use-session-monitor'
 import { syncSetupStoreContext } from '@/lib/instance-context'
 import { queryClient } from '@/lib/query-client'
 import { useAuthStore } from '@/stores/auth-store'
+import { useUiStore } from '@/stores/ui-store'
 import { useInstanceStore } from '@/stores/instance-store'
 import { READ_ONLY_REASON, isDemoMode } from '@/lib/demo-mode'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -176,6 +177,7 @@ function RootLayout() {
   const activeInstanceId = useInstanceStore((s) => s.activeInstanceId)
   const authToken = useAuthStore((s) => s.token)
   const authUser = useAuthStore((s) => s.user)
+  const openCommandPalette = useUiStore((s) => s.setCommandPaletteOpen)
 
   // Show sidebar+header only when: not on setup/login AND instance+auth exist
   const showAppChrome =
@@ -215,14 +217,8 @@ function RootLayout() {
                 <div className="ml-auto">
                   <button
                     type="button"
-                    onClick={() =>
-                      window.dispatchEvent(
-                        new KeyboardEvent('keydown', {
-                          key: 'k',
-                          metaKey: true,
-                        }),
-                      )
-                    }
+                    aria-label="Search"
+                    onClick={() => openCommandPalette(true)}
                     className="inline-flex h-8 items-center gap-2 rounded-sm border bg-muted/50 px-2.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
                   >
                     <HugeiconsIcon icon={Search01Icon} size={14} />

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -4,6 +4,7 @@ import { HugeiconsIcon } from '@hugeicons/react'
 import {
   Add01Icon,
   ArrowRight01Icon,
+  Link04Icon,
   Loading03Icon,
   PlayIcon,
 } from '@hugeicons/core-free-icons'
@@ -453,7 +454,7 @@ function ConfiguredDashboard({
         ) : projects.length === 0 ? (
           <Card>
             <CardHeader>
-              <CardTitle className="text-sm font-medium">
+              <CardTitle className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
                 Getting Started
               </CardTitle>
             </CardHeader>
@@ -477,6 +478,7 @@ function ConfiguredDashboard({
                             render={<Link to={integrationConnectTo} />}
                             nativeButton={false}
                           >
+                            <HugeiconsIcon icon={Link04Icon} />
                             Connect source
                           </Button>
                         ) : (

--- a/apps/web/src/routes/projects/$projectId/index.tsx
+++ b/apps/web/src/routes/projects/$projectId/index.tsx
@@ -42,6 +42,14 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@/components/ui/empty'
+import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
@@ -462,21 +470,29 @@ function ProjectDetailPage() {
                   )
                 })()}
                 {builds.length === 0 ? (
-                  <div className="space-y-2 py-6 text-center">
-                    <p className="text-sm text-muted-foreground">
-                      {canTriggerBuild
-                        ? 'No builds yet.'
-                        : 'No builds yet. Builds will appear here once triggered by a developer.'}
-                    </p>
+                  <Empty className="p-8">
+                    <EmptyHeader>
+                      <EmptyMedia variant="icon">
+                        <HugeiconsIcon icon={PlayIcon} />
+                      </EmptyMedia>
+                      <EmptyTitle>No builds yet</EmptyTitle>
+                      <EmptyDescription>
+                        {canTriggerBuild
+                          ? 'Run this project’s first pipeline to see its status, output, and artifacts here.'
+                          : 'Builds will appear here once triggered by a developer.'}
+                      </EmptyDescription>
+                    </EmptyHeader>
                     {canTriggerBuild &&
                     pipelines.length > 0 &&
                     projectHasSource ? (
-                      <Button size="sm" onClick={() => openTriggerBuild()}>
-                        <HugeiconsIcon icon={PlayIcon} />
-                        Trigger first build
-                      </Button>
+                      <EmptyContent>
+                        <Button size="sm" onClick={() => openTriggerBuild()}>
+                          <HugeiconsIcon icon={PlayIcon} />
+                          Run first build
+                        </Button>
+                      </EmptyContent>
                     ) : null}
-                  </div>
+                  </Empty>
                 ) : (
                   <Table>
                     <TableHeader>
@@ -626,10 +642,7 @@ function ProjectDetailPage() {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDelete}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
+            <AlertDialogAction onClick={handleDelete}>
               {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/apps/web/src/routes/projects/$projectId/pipelines/$pipelineId.tsx
+++ b/apps/web/src/routes/projects/$projectId/pipelines/$pipelineId.tsx
@@ -49,6 +49,14 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@/components/ui/empty'
+import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
@@ -562,15 +570,26 @@ function PipelineDetailPage() {
         <CardContent>
           <h3 className="pb-3 text-sm font-medium">Recent builds</h3>
           {builds.length === 0 ? (
-            <div className="space-y-2 py-3">
-              <p className="text-sm text-muted-foreground">No builds yet.</p>
-              {canTriggerBuild && projectHasSource ? (
-                <Button size="sm" onClick={() => setTriggerBuildOpen(true)}>
+            <Empty className="p-8">
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
                   <HugeiconsIcon icon={PlayIcon} />
-                  Trigger first build
-                </Button>
+                </EmptyMedia>
+                <EmptyTitle>No builds yet</EmptyTitle>
+                <EmptyDescription>
+                  Run this pipeline to see its status, output, and artifacts
+                  here.
+                </EmptyDescription>
+              </EmptyHeader>
+              {canTriggerBuild && projectHasSource ? (
+                <EmptyContent>
+                  <Button size="sm" onClick={() => setTriggerBuildOpen(true)}>
+                    <HugeiconsIcon icon={PlayIcon} />
+                    Run first build
+                  </Button>
+                </EmptyContent>
               ) : null}
-            </div>
+            </Empty>
           ) : (
             <Table>
               <TableHeader>
@@ -651,10 +670,7 @@ function PipelineDetailPage() {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDelete}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
+            <AlertDialogAction onClick={handleDelete}>
               {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/apps/web/src/routes/projects/-create-project-dialog.tsx
+++ b/apps/web/src/routes/projects/-create-project-dialog.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import z from 'zod'
 import { Link, useNavigate } from '@tanstack/react-router'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { Folder02Icon } from '@hugeicons/core-free-icons'
+import { Folder02Icon, Link04Icon } from '@hugeicons/core-free-icons'
 import { toast } from 'sonner'
 
 import type { ScmProvider } from '@/lib/types'
@@ -383,6 +383,7 @@ export default function CreateProjectDialog({
                         render={<Link to="/settings/integrations" />}
                         nativeButton={false}
                       >
+                        <HugeiconsIcon icon={Link04Icon} />
                         Connect source
                       </Button>
                     </div>

--- a/apps/web/src/routes/settings/api-tokens.tsx
+++ b/apps/web/src/routes/settings/api-tokens.tsx
@@ -4,6 +4,8 @@ import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import z from 'zod'
 import { toast } from 'sonner'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { Add01Icon, Copy01Icon, Tick02Icon } from '@hugeicons/core-free-icons'
 
 import type { ApiTokenSummary, CreateApiTokenResponse } from '@/lib/types'
 import {
@@ -378,6 +380,7 @@ function TokenCreatedDialog({
               {response?.token}
             </code>
             <Button variant="outline" size="sm" onClick={handleCopy}>
+              <HugeiconsIcon icon={copied ? Tick02Icon : Copy01Icon} />
               {copied ? 'Copied' : 'Copy'}
             </Button>
           </div>
@@ -444,7 +447,10 @@ function ApiTokensPage() {
         description="Create and manage API tokens for programmatic access to your CI instance."
         actions={
           canWrite ? (
-            <Button onClick={() => setCreateOpen(true)}>Create token</Button>
+            <Button onClick={() => setCreateOpen(true)}>
+              <HugeiconsIcon icon={Add01Icon} />
+              Create token
+            </Button>
           ) : undefined
         }
       />
@@ -523,7 +529,7 @@ function ApiTokensPage() {
           </CardHeader>
           <CardContent>
             {tokens.length === 0 ? (
-              <p className="py-6 text-sm text-muted-foreground">
+              <p className="text-sm text-muted-foreground">
                 No API tokens yet. Create one to get started.
               </p>
             ) : (

--- a/apps/web/src/routes/settings/audit-log.tsx
+++ b/apps/web/src/routes/settings/audit-log.tsx
@@ -60,9 +60,7 @@ const RESOURCE_TYPE_OPTIONS: Record<string, string> = {
 
 export const Route = createFileRoute('/settings/audit-log')({
   staticData: { breadcrumbLabel: 'Audit Log' },
-  validateSearch: (
-    search: Record<string, unknown>,
-  ): { page?: number } => ({
+  validateSearch: (search: Record<string, unknown>): { page?: number } => ({
     page: Number(search.page) > 1 ? Number(search.page) : undefined,
   }),
   beforeLoad: () => {
@@ -123,7 +121,7 @@ function AuditLogPage() {
         description="Activity trail of user and system actions for compliance and security auditing."
       />
 
-      <div className="flex items-center gap-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
         <Select
           value={resourceTypeFilter}
           onValueChange={(v) => {
@@ -132,7 +130,7 @@ function AuditLogPage() {
           }}
           items={RESOURCE_TYPE_OPTIONS}
         >
-          <SelectTrigger className="w-40">
+          <SelectTrigger className="w-full sm:w-40">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -150,7 +148,7 @@ function AuditLogPage() {
             setActionFilter(e.target.value)
             void navigate({ search: { page: 1 } })
           }}
-          className="max-w-xs"
+          className="w-full sm:max-w-xs"
         />
         <Input
           type="date"
@@ -159,7 +157,7 @@ function AuditLogPage() {
             setFromDate(e.target.value)
             void navigate({ search: { page: 1 } })
           }}
-          className="w-36"
+          className="w-full sm:w-36"
           aria-label="From date"
         />
         <Input
@@ -169,7 +167,7 @@ function AuditLogPage() {
             setToDate(e.target.value)
             void navigate({ search: { page: 1 } })
           }}
-          className="w-36"
+          className="w-full sm:w-36"
           aria-label="To date"
         />
         {hasFilters ? (
@@ -222,7 +220,7 @@ function AuditLogPage() {
           </CardHeader>
           <CardContent>
             {entries.length === 0 ? (
-              <p className="py-6 text-sm text-muted-foreground">
+              <p className="text-sm text-muted-foreground">
                 No audit log entries found.
               </p>
             ) : (
@@ -252,9 +250,7 @@ function AuditLogPage() {
                         <Badge variant="outline">{entry.action}</Badge>
                       </TableCell>
                       <TableCell>
-                        <Badge variant="secondary">
-                          {entry.resource_type}
-                        </Badge>
+                        <Badge variant="secondary">{entry.resource_type}</Badge>
                       </TableCell>
                       <TableCell className="font-mono text-[11px] text-muted-foreground">
                         {entry.resource_id

--- a/apps/web/src/routes/settings/integrations/index.tsx
+++ b/apps/web/src/routes/settings/integrations/index.tsx
@@ -3,7 +3,7 @@ import { HugeiconsIcon } from '@hugeicons/react'
 import {
   Delete02Icon,
   InformationCircleIcon,
-  LinkSquare02Icon,
+  Link04Icon,
 } from '@hugeicons/core-free-icons'
 import { toast } from 'sonner'
 import { useMountEffect } from '@/hooks/use-mount-effect'
@@ -141,13 +141,13 @@ function IntegrationsPage() {
         </Card>
       ) : (
         <section className="grid gap-4 md:grid-cols-2">
-          <Card>
+          <Card className="h-full">
             <CardHeader>
               <CardTitle className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
                 GitHub Source
               </CardTitle>
             </CardHeader>
-            <CardContent className="space-y-3">
+            <CardContent className="flex flex-1 flex-col gap-3">
               <p className="text-sm text-muted-foreground">
                 Create and install a GitHub App to enable repository discovery
                 and webhook events.
@@ -161,22 +161,23 @@ function IntegrationsPage() {
                 ]}
               />
               <Button
+                className="mt-auto self-start"
                 render={<Link to="/settings/integrations/github" />}
                 nativeButton={false}
               >
-                <HugeiconsIcon icon={LinkSquare02Icon} />
+                <HugeiconsIcon icon={Link04Icon} />
                 Connect GitHub
               </Button>
             </CardContent>
           </Card>
 
-          <Card>
+          <Card className="h-full">
             <CardHeader>
               <CardTitle className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
                 GitLab Source
               </CardTitle>
             </CardHeader>
-            <CardContent className="space-y-3">
+            <CardContent className="flex flex-1 flex-col gap-3">
               <p className="text-sm text-muted-foreground">
                 Connect GitLab.com or a self-managed GitLab host through a
                 personal access token or OAuth application.
@@ -195,10 +196,11 @@ function IntegrationsPage() {
                 ]}
               />
               <Button
+                className="mt-auto self-start"
                 render={<Link to="/settings/integrations/gitlab" />}
                 nativeButton={false}
               >
-                <HugeiconsIcon icon={LinkSquare02Icon} />
+                <HugeiconsIcon icon={Link04Icon} />
                 Connect GitLab
               </Button>
             </CardContent>
@@ -218,7 +220,7 @@ function IntegrationsPage() {
       ) : null}
 
       {isLoading ? (
-        <Card>
+        <Card size="sm">
           <CardContent className="space-y-3">
             <Skeleton className="h-10 w-full" />
             <Skeleton className="h-10 w-full" />
@@ -236,7 +238,7 @@ function IntegrationsPage() {
       ) : null}
 
       {!isLoading && !error && remoteEnabled ? (
-        <Card>
+        <Card size="sm">
           <CardHeader>
             <CardTitle className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
               Connected Sources
@@ -244,8 +246,8 @@ function IntegrationsPage() {
           </CardHeader>
           <CardContent>
             {integrations.length === 0 ? (
-              <p className="py-6 text-sm text-muted-foreground">
-                No sources connected yet.
+              <p className="text-sm text-muted-foreground">
+                No connected sources yet. Connect GitHub or GitLab above.
               </p>
             ) : (
               <div className="space-y-3">
@@ -255,7 +257,7 @@ function IntegrationsPage() {
                 {integrations.map((integration) => (
                   <div
                     key={integration.id}
-                    className="group flex items-start justify-between gap-3 border border-border/60 bg-card transition-colors hover:border-primary/30 hover:bg-primary/5"
+                    className="group flex flex-col border border-border/60 bg-card transition-colors hover:border-primary/30 hover:bg-primary/5 sm:flex-row sm:items-start sm:justify-between sm:gap-3"
                   >
                     <Link
                       to="/settings/integrations/$integrationId"
@@ -299,7 +301,7 @@ function IntegrationsPage() {
                       </div>
                     </Link>
 
-                    <div className="p-4 pl-0">
+                    <div className="p-4 pt-0 sm:pl-0 sm:pt-4">
                       <AlertDialog>
                         <AlertDialogTrigger
                           render={

--- a/apps/web/src/routes/settings/integrations/local-git.tsx
+++ b/apps/web/src/routes/settings/integrations/local-git.tsx
@@ -1,4 +1,6 @@
 import { Link, createFileRoute } from '@tanstack/react-router'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { Add01Icon } from '@hugeicons/core-free-icons'
 import {
   getActiveInstanceOrRedirect,
   requireAuthOrRedirect,
@@ -57,6 +59,7 @@ function LocalGitPage() {
             render={<Link to="/projects" search={{ openCreate: '1' }} />}
             nativeButton={false}
           >
+            <HugeiconsIcon icon={Add01Icon} />
             Create project
           </Button>
         </CardContent>

--- a/apps/web/src/routes/settings/notifications/$channelId.tsx
+++ b/apps/web/src/routes/settings/notifications/$channelId.tsx
@@ -284,7 +284,7 @@ function NotificationChannelDetailPage() {
             <AlertDialog>
               <AlertDialogTrigger
                 render={
-                  <Button variant="outline">
+                  <Button variant="destructive">
                     <HugeiconsIcon icon={Delete02Icon} />
                     Delete
                   </Button>
@@ -640,9 +640,7 @@ function NotificationChannelDetailPage() {
         </CardHeader>
         <CardContent>
           {deliveries.length === 0 ? (
-            <p className="py-6 text-sm text-muted-foreground">
-              No deliveries yet.
-            </p>
+            <p className="text-sm text-muted-foreground">No deliveries yet.</p>
           ) : (
             <div className="space-y-2">
               {deliveries.map((delivery) => (

--- a/apps/web/src/routes/settings/notifications/index.tsx
+++ b/apps/web/src/routes/settings/notifications/index.tsx
@@ -131,7 +131,7 @@ function NotificationsPage() {
           </CardHeader>
           <CardContent>
             {channels.length === 0 ? (
-              <p className="py-6 text-sm text-muted-foreground">
+              <p className="text-sm text-muted-foreground">
                 No notification channels configured yet.
               </p>
             ) : (
@@ -139,7 +139,7 @@ function NotificationsPage() {
                 {channels.map((channel) => (
                   <div
                     key={channel.id}
-                    className="group flex items-start justify-between gap-3 border border-border/60 bg-card transition-colors hover:border-primary/30 hover:bg-primary/5"
+                    className="group flex flex-col border border-border/60 bg-card transition-colors hover:border-primary/30 hover:bg-primary/5 sm:flex-row sm:items-start sm:justify-between sm:gap-3"
                   >
                     <Link
                       to="/settings/notifications/$channelId"
@@ -168,7 +168,7 @@ function NotificationsPage() {
                       </div>
                     </Link>
 
-                    <div className="flex items-center gap-1 p-4 pl-0">
+                    <div className="flex items-center gap-1 p-4 pt-0 sm:pl-0 sm:pt-4">
                       <Button
                         variant="ghost"
                         size="sm"

--- a/apps/web/src/routes/settings/preferences.tsx
+++ b/apps/web/src/routes/settings/preferences.tsx
@@ -11,6 +11,7 @@ import {
   ArrowDown01Icon,
   ArrowRight01Icon,
   CheckmarkCircle02Icon,
+  Download04Icon,
   Folder02Icon,
 } from '@hugeicons/core-free-icons'
 import type { RemoteAuthMode } from '@/lib/types'
@@ -25,6 +26,7 @@ import { useActiveInstance } from '@/stores/instance-store'
 import { resolveInstanceApiBaseUrl } from '@/lib/instance-url'
 import { PageMeta } from '@/lib/seo'
 import { useHasPermission } from '@/hooks/use-permissions'
+import { useRuntimeUpdates } from '@/hooks/use-runtime-updates'
 import {
   useArtifactStorageSettings,
   useConfigureExternalAccessOidc,
@@ -252,6 +254,10 @@ function healthVersionLabel(
   return health?.version?.trim() || 'Unknown'
 }
 
+function runtimeUpdateActive(phase?: string): boolean {
+  return phase === 'updating' || phase === 'restarting'
+}
+
 function parseAllowedOriginsInput(value: string): Array<string> {
   return value
     .split(/[\n,]/g)
@@ -315,6 +321,13 @@ function PreferencesPage() {
     retry: false,
     staleTime: 30_000,
   })
+  const runtimeUpdates = useRuntimeUpdates(backendHealthQuery.data ?? {})
+  const frontendUpdatePhase =
+    runtimeUpdates.startFrontendUpdate.data?.phase ??
+    runtimeUpdates.frontendRelease.data?.phase
+  const backendUpdatePhase =
+    runtimeUpdates.startBackendUpdate.data?.phase ??
+    runtimeUpdates.backendUpdate.data?.phase
   const preflightQuery = useExternalAccessPreflight()
   const networkSettingsQuery = useExternalAccessNetworkSettings()
   const oidcConfigQuery = useExternalAccessOidc()
@@ -1556,7 +1569,7 @@ function PreferencesPage() {
           </CardContent>
         </Card>
         <Card>
-          <CardContent>
+          <CardContent className="flex h-full flex-col">
             <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
               Frontend version
             </p>
@@ -1568,10 +1581,51 @@ function PreferencesPage() {
                 ? `${webHealthQuery.data.channel} channel`
                 : 'Loaded oore-web bundle'}
             </p>
+            {runtimeUpdates.frontendRelease.data?.update_available ? (
+              <>
+                <p className="mt-2 text-xs text-primary">
+                  {runtimeUpdates.frontendRelease.data.latest_version} is
+                  available
+                </p>
+                <Button
+                  size="sm"
+                  className="mt-3 self-start"
+                  disabled={
+                    !isOwner ||
+                    !runtimeUpdates.frontendRelease.data.managed_service ||
+                    runtimeUpdateActive(frontendUpdatePhase) ||
+                    runtimeUpdates.startFrontendUpdate.isPending
+                  }
+                  onClick={() =>
+                    runtimeUpdates.startFrontendUpdate.mutate(undefined, {
+                      onSuccess: () =>
+                        toast.success(
+                          'Frontend update started. The UI will reconnect after restart.',
+                        ),
+                      onError: (error) => toast.error(error.message),
+                    })
+                  }
+                >
+                  <HugeiconsIcon icon={Download04Icon} />
+                  {runtimeUpdates.startFrontendUpdate.isPending
+                    ? 'Starting...'
+                    : frontendUpdatePhase === 'restarting'
+                      ? 'Restarting...'
+                      : frontendUpdatePhase === 'updating'
+                        ? 'Updating...'
+                        : 'Update frontend'}
+                </Button>
+                {!runtimeUpdates.frontendRelease.data.managed_service ? (
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    Install oore-web as a managed service to update it here.
+                  </p>
+                ) : null}
+              </>
+            ) : null}
           </CardContent>
         </Card>
         <Card>
-          <CardContent>
+          <CardContent className="flex h-full flex-col">
             <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
               Backend version
             </p>
@@ -1583,6 +1637,49 @@ function PreferencesPage() {
                 ? `${backendHealthQuery.data.channel} channel`
                 : 'Loaded oored daemon'}
             </p>
+            {runtimeUpdates.backendRelease.data?.update_available ? (
+              <>
+                <p className="mt-2 text-xs text-primary">
+                  {runtimeUpdates.backendRelease.data.latest_version} is
+                  available
+                </p>
+                <Button
+                  size="sm"
+                  className="mt-3 self-start"
+                  disabled={
+                    !isOwner ||
+                    !runtimeUpdates.backendUpdate.data?.managed_service ||
+                    runtimeUpdateActive(backendUpdatePhase) ||
+                    runtimeUpdates.startBackendUpdate.isPending
+                  }
+                  onClick={() =>
+                    runtimeUpdates.startBackendUpdate.mutate(undefined, {
+                      onSuccess: () =>
+                        toast.success(
+                          'Backend update started. Readiness will recover after launchd restarts it.',
+                        ),
+                      onError: (error) => toast.error(error.message),
+                    })
+                  }
+                >
+                  <HugeiconsIcon icon={Download04Icon} />
+                  {runtimeUpdates.startBackendUpdate.isPending
+                    ? 'Starting...'
+                    : backendUpdatePhase === 'restarting'
+                      ? 'Restarting...'
+                      : backendUpdatePhase === 'updating'
+                        ? 'Updating...'
+                        : 'Update backend'}
+                </Button>
+                {runtimeUpdates.backendUpdate.data &&
+                !runtimeUpdates.backendUpdate.data.managed_service ? (
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    Install oored as the managed macOS service to update it
+                    here.
+                  </p>
+                ) : null}
+              </>
+            ) : null}
           </CardContent>
         </Card>
       </section>

--- a/apps/web/src/routes/settings/retention.tsx
+++ b/apps/web/src/routes/settings/retention.tsx
@@ -221,7 +221,7 @@ function RetentionPage() {
           {/* Enable/Disable */}
           <Card>
             <CardHeader>
-              <CardTitle className="flex items-center justify-between">
+              <CardTitle className="flex items-center justify-between text-sm font-medium uppercase tracking-wider text-muted-foreground">
                 <span>Global Retention Policy</span>
                 <Badge variant={enabled ? 'default' : 'outline'}>
                   {enabled ? 'Active' : 'Disabled'}
@@ -493,7 +493,9 @@ function RetentionPage() {
       {/* Last Cleanup Summary */}
       <Card>
         <CardHeader>
-          <CardTitle>Last Cleanup</CardTitle>
+          <CardTitle className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
+            Last Cleanup
+          </CardTitle>
         </CardHeader>
         <CardContent>
           {cleanupLoading ? (

--- a/apps/web/src/routes/settings/runners.tsx
+++ b/apps/web/src/routes/settings/runners.tsx
@@ -76,7 +76,9 @@ function formatRelativeTime(epochSeconds?: number): string {
   return `${days}d ago`
 }
 
-function getHeartbeatStaleness(epochSeconds?: number): 'fresh' | 'stale' | 'none' {
+function getHeartbeatStaleness(
+  epochSeconds?: number,
+): 'fresh' | 'stale' | 'none' {
   if (!epochSeconds) return 'none'
   const diffSecs = Math.floor(Date.now() / 1000) - epochSeconds
   if (diffSecs > 60) return 'stale'
@@ -93,7 +95,9 @@ function StatusDot({ status }: { status: string }) {
     )
   }
   if (status === 'offline') {
-    return <span className="bg-destructive mr-2 inline-flex size-2 rounded-full" />
+    return (
+      <span className="bg-destructive mr-2 inline-flex size-2 rounded-full" />
+    )
   }
   // draining
   return <span className="bg-warning mr-2 inline-flex size-2 rounded-full" />
@@ -139,7 +143,6 @@ function RenameRunnerDialog({
 
   const initialName = runner?.name ?? ''
   const isEmbedded = !runner?.registered_by
-
 
   function handleClose(nextOpen: boolean) {
     if (!nextOpen) {
@@ -340,7 +343,7 @@ function RunnersSettingsPage() {
           </CardHeader>
           <CardContent>
             {runners.length === 0 ? (
-              <p className="py-6 text-sm text-muted-foreground">
+              <p className="text-sm text-muted-foreground">
                 No runners registered yet.
               </p>
             ) : (
@@ -349,6 +352,7 @@ function RunnersSettingsPage() {
                   <TableRow>
                     <TableHead>Name</TableHead>
                     <TableHead>Status</TableHead>
+                    <TableHead>Version</TableHead>
                     <TableHead>Last heartbeat</TableHead>
                     <TableHead>Capabilities</TableHead>
                     <TableHead>Registered by</TableHead>
@@ -376,6 +380,11 @@ function RunnersSettingsPage() {
                               {runner.status}
                             </Badge>
                           </div>
+                        </TableCell>
+                        <TableCell className="font-mono text-xs text-muted-foreground">
+                          {typeof runner.capabilities.version === 'string'
+                            ? runner.capabilities.version
+                            : 'Unknown'}
                         </TableCell>
                         <TableCell
                           className={

--- a/apps/web/src/routes/settings/users.tsx
+++ b/apps/web/src/routes/settings/users.tsx
@@ -402,7 +402,7 @@ function UsersSettingsPage() {
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="flex gap-3">
+          <div className="flex flex-col gap-3 sm:flex-row">
             <div className="flex flex-1 flex-col gap-1">
               <Input
                 type="email"
@@ -430,7 +430,7 @@ function UsersSettingsPage() {
               onValueChange={(v) => setInviteRole(v as UserRole)}
               items={ROLE_OPTIONS}
             >
-              <SelectTrigger className="w-36">
+              <SelectTrigger className="w-full sm:w-36">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -442,6 +442,7 @@ function UsersSettingsPage() {
               </SelectContent>
             </Select>
             <Button
+              className="w-full sm:w-auto"
               onClick={handleInvite}
               disabled={
                 !inviteEmail || !!emailError || inviteMutation.isPending

--- a/apps/web/src/routes/setup.tsx
+++ b/apps/web/src/routes/setup.tsx
@@ -234,7 +234,7 @@ function SetupError({ error }: { error: Error }) {
             <AlertDescription>{error.message}</AlertDescription>
           </Alert>
           <Button onClick={() => void navigate({ to: '/setup' })}>
-            Retry Setup
+            Retry setup
           </Button>
         </div>
       </div>
@@ -290,13 +290,13 @@ function SetupError({ error }: { error: Error }) {
 
         <div className="flex gap-2">
           <Button onClick={() => void navigate({ to: '/setup' })}>
-            Retry Setup
+            Retry setup
           </Button>
           <Button
             variant="outline"
             onClick={() => window.open('https://docs.oore.build', '_blank')}
           >
-            Open Docs
+            Open docs
           </Button>
         </div>
       </div>

--- a/apps/web/src/stores/ui-store.ts
+++ b/apps/web/src/stores/ui-store.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand'
+
+interface UiStoreState {
+  commandPaletteOpen: boolean
+  setCommandPaletteOpen: (open: boolean) => void
+  toggleCommandPalette: () => void
+}
+
+export const useUiStore = create<UiStoreState>((set) => ({
+  commandPaletteOpen: false,
+  setCommandPaletteOpen: (commandPaletteOpen) => set({ commandPaletteOpen }),
+  toggleCommandPalette: () =>
+    set((state) => ({ commandPaletteOpen: !state.commandPaletteOpen })),
+}))

--- a/apps/web/tools/oore-web.js
+++ b/apps/web/tools/oore-web.js
@@ -253,7 +253,8 @@ function parseServeArgs(argv) {
 
     if (arg === '--trusted-proxy-secret-file') {
       const value = argv[i + 1]
-      if (!value) throw new Error('--trusted-proxy-secret-file requires a value')
+      if (!value)
+        throw new Error('--trusted-proxy-secret-file requires a value')
       config.trustedProxySecretFile = value
       i += 1
       continue
@@ -289,7 +290,9 @@ function parseServeArgs(argv) {
     if (arg === '--upstream-trusted-proxy-secret-header') {
       const value = argv[i + 1]
       if (!value)
-        throw new Error('--upstream-trusted-proxy-secret-header requires a value')
+        throw new Error(
+          '--upstream-trusted-proxy-secret-header requires a value',
+        )
       config.upstreamTrustedProxySecretHeader = value
       i += 1
       continue
@@ -492,7 +495,10 @@ function githubHeaders() {
 }
 
 async function fetchJson(url) {
-  const response = await fetch(url, { headers: githubHeaders() })
+  const response = await fetch(url, {
+    headers: githubHeaders(),
+    signal: AbortSignal.timeout(10_000),
+  })
   if (!response.ok) {
     throw new Error(`request failed (${response.status}) for ${url}`)
   }
@@ -500,7 +506,10 @@ async function fetchJson(url) {
 }
 
 async function fetchBytes(url) {
-  const response = await fetch(url, { headers: githubHeaders() })
+  const response = await fetch(url, {
+    headers: githubHeaders(),
+    signal: AbortSignal.timeout(120_000),
+  })
   if (!response.ok) {
     throw new Error(`download failed (${response.status}) for ${url}`)
   }
@@ -811,7 +820,7 @@ async function runUpdate(config) {
 
   if (compareVersions(current, latest) >= 0 && !config.force) {
     console.log('Already up to date.')
-    return
+    return { current: current.raw, latest: latest.raw, updated: false }
   }
 
   if (compareVersions(current, latest) < 0) {
@@ -883,6 +892,65 @@ async function runUpdate(config) {
   console.log(
     'If oore-web is running as a service, restart the service to use the updated launcher binary.',
   )
+  return { current: current.raw, latest: latest.raw, updated: true }
+}
+
+function hasManagedWebService() {
+  return (
+    fileExists(
+      path.join(os.homedir(), '.config', 'systemd', 'user', 'oore-web.service'),
+    ) ||
+    fileExists(
+      path.join(
+        os.homedir(),
+        'Library',
+        'LaunchAgents',
+        'build.oore.oore-web.plist',
+      ),
+    )
+  )
+}
+
+export async function authorizeOwner(
+  request,
+  backendUrl,
+  config,
+  signal = AbortSignal.timeout(5000),
+) {
+  const headers = new Headers(request.headers)
+  headers.delete('host')
+  headers.delete('content-length')
+  applyTrustedProxyHeaders(request, headers, config)
+  const response = await fetch(new URL('/v1/users/me', backendUrl), {
+    headers,
+    ...(signal ? { signal } : {}),
+  })
+  if (!response.ok) return false
+  const profile = await response.json()
+  return profile?.user?.role === 'owner'
+}
+
+async function getWebUpdateStatus(updateState, searchParams) {
+  const metadata = readInstalledMetadata()
+  const current = parseVersion(searchParams.get('current') || metadata.version)
+  const channel = parseChannel(
+    searchParams.get('channel') ||
+      metadata.channel ||
+      inferChannelFromVersion(current),
+  )
+  const repo = searchParams.get('repo') || metadata.github_repo
+  const release = await fetchLatestRelease(repo, channel)
+  const latest = parseVersion(release.tag_name)
+  return {
+    ...metadata,
+    version: current.raw,
+    channel,
+    github_repo: repo,
+    latest_version: latest.raw,
+    update_available: compareVersions(current, latest) < 0,
+    managed_service: hasManagedWebService(),
+    ...updateState,
+  }
 }
 
 export function isApiPath(pathname) {
@@ -1084,10 +1152,11 @@ async function main() {
     process.exit(2)
   }
 
+  const updateState = { phase: 'idle', error: null }
   const server = Bun.serve({
     hostname: listen.hostname,
     port: listen.port,
-    fetch: (request) => {
+    fetch: async (request) => {
       const url = new URL(request.url)
 
       if (url.pathname === '/__oore_web_healthz') {
@@ -1104,6 +1173,80 @@ async function main() {
             },
           },
         )
+      }
+
+      if (url.pathname === '/__oore_web_update') {
+        let owner = false
+        try {
+          owner = await authorizeOwner(request, backendUrl, config)
+        } catch {
+          return Response.json(
+            { error: 'Could not verify the current owner session' },
+            { status: 502 },
+          )
+        }
+        if (!owner) {
+          return Response.json(
+            { error: 'Only the instance owner can manage runtime updates' },
+            { status: 403 },
+          )
+        }
+
+        if (request.method === 'GET') {
+          try {
+            return Response.json(
+              await getWebUpdateStatus(updateState, url.searchParams),
+              {
+                headers: { 'Cache-Control': 'no-store' },
+              },
+            )
+          } catch (error) {
+            return Response.json(
+              {
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : 'Failed to check for frontend updates',
+              },
+              { status: 502 },
+            )
+          }
+        }
+
+        if (request.method !== 'POST') {
+          return new Response('Method not allowed', { status: 405 })
+        }
+        if (!hasManagedWebService()) {
+          return Response.json(
+            { error: 'Frontend updates require a managed service' },
+            { status: 409 },
+          )
+        }
+        if (updateState.phase === 'updating') {
+          return Response.json(
+            { error: 'A frontend update is already in progress' },
+            { status: 409 },
+          )
+        }
+
+        updateState.phase = 'updating'
+        updateState.error = null
+        void runUpdate({ check: false, force: false }).then(
+          (result) => {
+            if (!result.updated) {
+              updateState.phase = 'idle'
+              return
+            }
+            updateState.phase = 'restarting'
+            setTimeout(() => process.exit(75), 1000)
+          },
+          (error) => {
+            updateState.phase = 'failed'
+            updateState.error =
+              error instanceof Error ? error.message : 'Frontend update failed'
+          },
+        )
+        return Response.json(updateState, { status: 202 })
       }
 
       if (isApiPath(url.pathname)) {

--- a/apps/web/tools/oore-web.test.js
+++ b/apps/web/tools/oore-web.test.js
@@ -3,7 +3,11 @@ import path from 'node:path'
 import { spawn } from 'node:child_process'
 import { createServer } from 'node:http'
 
-import { applyTrustedProxyHeaders, isApiPath } from './oore-web.js'
+import {
+  applyTrustedProxyHeaders,
+  authorizeOwner,
+  isApiPath,
+} from './oore-web.js'
 
 const ooreWebPath = path.resolve(process.cwd(), 'tools/oore-web.js')
 
@@ -87,6 +91,30 @@ describe('oore-web trusted proxy contract', () => {
     expect(provedHeaders.get('x-oore-trusted-proxy-secret')).toBe(
       'backend-proof',
     )
+  })
+
+  it('allows runtime updates only for a backend-confirmed owner', async () => {
+    const { server, url } = await startServer((_request, response) => {
+      sendJson(response, { user: { role: 'owner' } })
+    })
+    try {
+      const allowed = await authorizeOwner(
+        new Request('https://ci.example.com/__oore_web_update', {
+          headers: { authorization: 'Bearer session' },
+        }),
+        new URL(url),
+        {
+          trustedProxySecret: '',
+          upstreamTrustedProxySecret: '',
+          trustedProxyUserEmailHeader: 'x-oore-user-email',
+          upstreamTrustedProxySecretHeader: 'x-oore-web-trusted-proxy-secret',
+        },
+        null,
+      )
+      expect(allowed).toBe(true)
+    } finally {
+      await stopServer(server)
+    }
   })
 })
 

--- a/crates/oore-contract/src/lib.rs
+++ b/crates/oore-contract/src/lib.rs
@@ -364,6 +364,23 @@ pub struct LogoutResponse {
     pub ok: bool,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeUpdatePhase {
+    Idle,
+    Updating,
+    Restarting,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct RuntimeUpdateStatus {
+    pub phase: RuntimeUpdatePhase,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    pub managed_service: bool,
+}
+
 // ── User management types ───────────────────────────────────────
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ToSchema)]

--- a/crates/oore-runner/src/lib.rs
+++ b/crates/oore-runner/src/lib.rs
@@ -75,12 +75,20 @@ pub async fn detect_capabilities() -> serde_json::Value {
         .unwrap_or_default();
 
     let arch = std::env::consts::ARCH.to_string();
+    let version = std::env::current_exe()
+        .ok()
+        .and_then(|path| path.parent()?.parent().map(|root| root.join("VERSION")))
+        .and_then(|path| fs::read_to_string(path).ok())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
 
     serde_json::json!({
         "os": "macos",
         "os_version": os_version,
         "arch": arch,
         "xcode_version": xcode_version,
+        "version": version,
     })
 }
 
@@ -3036,6 +3044,17 @@ mod tests {
         ));
         fs::create_dir_all(&dir).expect("create temp dir");
         dir
+    }
+
+    #[tokio::test]
+    async fn reported_capabilities_include_runner_version() {
+        let capabilities = detect_capabilities().await;
+        assert!(
+            capabilities
+                .get("version")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|version| !version.is_empty())
+        );
     }
 
     fn cleanup_workspace(path: &Path) {

--- a/crates/oore/src/main.rs
+++ b/crates/oore/src/main.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::io::Write;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::{Path, PathBuf};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::Context;
 use base64::Engine;
@@ -3767,23 +3767,64 @@ fn restart_launchd_service(label: &str) -> anyhow::Result<()> {
         (format!("gui/{uid}/{label}"), format!("gui/{uid}"))
     };
     let command = if system { "sudo" } else { "launchctl" };
-    let prefix: &[&str] = if system { &["launchctl"] } else { &[] };
-    let _ = std::process::Command::new(command)
+    let prefix: &[&str] = if system { &["-n", "launchctl"] } else { &[] };
+    let mut bootout = std::process::Command::new(command);
+    bootout.args(prefix).args(["bootout", &service]);
+    let _ = run_command_with_timeout(&mut bootout, "launchd bootout", Duration::from_secs(15))?;
+
+    let mut bootstrap = std::process::Command::new(command);
+    bootstrap
         .args(prefix)
-        .args(["bootout", &service])
-        .status();
-    let status = std::process::Command::new(command)
-        .args(prefix)
-        .args(["bootstrap", &domain, &plist.display().to_string()])
-        .status()
-        .context("failed to bootstrap launchd service")?;
+        .args(["bootstrap", &domain, &plist.display().to_string()]);
+    let status =
+        run_command_with_timeout(&mut bootstrap, "launchd bootstrap", Duration::from_secs(15))?;
     if !status.success() {
         anyhow::bail!("failed to bootstrap managed service {label}");
     }
-    let _ = std::process::Command::new(command)
-        .args(prefix)
-        .args(["kickstart", "-k", &service])
-        .status();
+    let mut kickstart = std::process::Command::new(command);
+    kickstart.args(prefix).args(["kickstart", "-k", &service]);
+    let _ = run_command_with_timeout(&mut kickstart, "launchd kickstart", Duration::from_secs(15))?;
+    Ok(())
+}
+
+fn run_command_with_timeout(
+    command: &mut std::process::Command,
+    description: &str,
+    timeout: Duration,
+) -> anyhow::Result<std::process::ExitStatus> {
+    let mut child = command
+        .spawn()
+        .with_context(|| format!("failed to start {description}"))?;
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(status) = child
+            .try_wait()
+            .with_context(|| format!("failed to wait for {description}"))?
+        {
+            return Ok(status);
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            anyhow::bail!(
+                "{description} timed out after {} seconds",
+                timeout.as_secs()
+            );
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn authorize_system_service_restart() -> anyhow::Result<()> {
+    println!("\nAdministrator access is required to restart Oore's macOS system service.");
+    println!("Your password is requested by sudo and is not stored by Oore.");
+    let status = std::process::Command::new("sudo")
+        .arg("-v")
+        .status()
+        .context("failed to request administrator access")?;
+    if !status.success() {
+        anyhow::bail!("administrator access was not granted; installed files were not changed");
+    }
     Ok(())
 }
 
@@ -3954,6 +3995,9 @@ where
 
 async fn handle_update(args: UpdateArgs) -> anyhow::Result<()> {
     let install_root = resolve_install_root()?;
+    // Web-triggered backend updates replace the release atomically, then let
+    // launchd KeepAlive restart this daemon after the API process exits.
+    let defer_daemon_restart = std::env::var_os("OORE_UPDATE_DEFER_DAEMON_RESTART").is_some();
 
     let current_str = read_trimmed_file(&install_root.join("VERSION"))
         .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
@@ -4140,6 +4184,14 @@ async fn handle_update(args: UpdateArgs) -> anyhow::Result<()> {
         None => false,
     };
 
+    let system_service_restart_required = (!defer_daemon_restart
+        && daemon_is_managed
+        && managed_service_plist(DAEMON_SERVICE_LABEL)?.1)
+        || (web_is_managed && managed_service_plist(WEB_SERVICE_LABEL)?.1);
+    if system_service_restart_required {
+        authorize_system_service_restart()?;
+    }
+
     if let Some(listen) = &unmanaged_daemon_listen {
         println!("oored daemon is running. Stopping before update...");
         stop_daemon(&install_root, listen)?;
@@ -4149,12 +4201,12 @@ async fn handle_update(args: UpdateArgs) -> anyhow::Result<()> {
     // readiness check succeeds. On any failure, restore the prior release.
     let update_result = async {
         install_staged_release(&staged_release, &install_root, channel, &repo)?;
-        if daemon_is_managed {
+        if daemon_is_managed && !defer_daemon_restart {
             restart_launchd_service(DAEMON_SERVICE_LABEL)?;
         } else if let Some(listen) = &unmanaged_daemon_listen {
             restart_daemon(&install_root, listen, &daemon_url, &client).await?;
         }
-        if daemon_should_be_running {
+        if daemon_should_be_running && !defer_daemon_restart {
             wait_for_endpoint(&client, &daemon_ready_url, "oored").await?;
         }
         if web_is_managed {
@@ -4172,12 +4224,12 @@ async fn handle_update(args: UpdateArgs) -> anyhow::Result<()> {
         eprintln!("Update failed; restoring the previous release...");
         let rollback = async {
             restore_release_snapshot(&install_root, &previous_release)?;
-            if daemon_is_managed {
+            if daemon_is_managed && !defer_daemon_restart {
                 restart_launchd_service(DAEMON_SERVICE_LABEL)?;
             } else if let Some(listen) = &unmanaged_daemon_listen {
                 restart_daemon(&install_root, listen, &daemon_url, &client).await?;
             }
-            if daemon_should_be_running {
+            if daemon_should_be_running && !defer_daemon_restart {
                 wait_for_endpoint(&client, &daemon_ready_url, "rollback oored").await?;
             }
             if web_is_managed {
@@ -4313,6 +4365,21 @@ fn main() -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn command_timeout_stops_stalled_service_commands() {
+        let mut command = std::process::Command::new("sh");
+        command.args(["-c", "sleep 1"]);
+
+        let error = run_command_with_timeout(
+            &mut command,
+            "test service command",
+            Duration::from_millis(20),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("timed out"));
+    }
 
     #[test]
     fn blocking_update_step_can_run_runtime_backed_backup_work() {

--- a/crates/oored/src/bin/openapi_export.rs
+++ b/crates/oored/src/bin/openapi_export.rs
@@ -47,6 +47,9 @@ use utoipa::OpenApi;
         paths::local_login,
         paths::trusted_proxy_login,
         paths::logout,
+        // ── Runtime updates ──
+        paths::get_runtime_update_status,
+        paths::start_runtime_update,
         // ── Users ──
         paths::get_me,
         paths::list_users,
@@ -198,6 +201,9 @@ use utoipa::OpenApi;
         oore_contract::LocalLoginResponse,
         oore_contract::AuthenticatedUser,
         oore_contract::LogoutResponse,
+        // Runtime updates
+        oore_contract::RuntimeUpdatePhase,
+        oore_contract::RuntimeUpdateStatus,
         // Users
         oore_contract::UserRole,
         oore_contract::UserStatus,
@@ -707,6 +713,37 @@ mod paths {
         )
     )]
     pub(super) async fn logout() {}
+
+    // ── Runtime updates ──
+
+    /// Get backend update state
+    ///
+    /// Reports whether the backend is managed by the supported macOS launchd
+    /// service and whether an update is currently running. Requires owner role.
+    #[utoipa::path(get, path = "/v1/system/update", tag = "System",
+        security(("bearer_auth" = [])),
+        responses(
+            (status = 200, description = "Backend update state", body = RuntimeUpdateStatus),
+            (status = 401, description = "Not authenticated", body = ApiError),
+            (status = 403, description = "Owner role required", body = ApiError),
+        )
+    )]
+    pub(super) async fn get_runtime_update_status() {}
+
+    /// Start a backend update
+    ///
+    /// Runs the installed updater and hands restart control to the managed
+    /// macOS launchd service. Requires owner role.
+    #[utoipa::path(post, path = "/v1/system/update", tag = "System",
+        security(("bearer_auth" = [])),
+        responses(
+            (status = 202, description = "Backend update started", body = RuntimeUpdateStatus),
+            (status = 401, description = "Not authenticated", body = ApiError),
+            (status = 403, description = "Owner role required", body = ApiError),
+            (status = 409, description = "Managed updater unavailable or already running", body = ApiError),
+        )
+    )]
+    pub(super) async fn start_runtime_update() {}
 
     // ── Users ──
 

--- a/crates/oored/src/lib.rs
+++ b/crates/oored/src/lib.rs
@@ -26,6 +26,7 @@ pub mod projects;
 pub mod rbac;
 pub mod retention;
 pub mod runners;
+pub mod runtime_updates;
 pub mod scheduler;
 pub mod session;
 pub mod storage;
@@ -102,6 +103,8 @@ pub struct AppState {
     pub allowed_origins: Arc<RwLock<Vec<String>>>,
     /// Effective public base URL for externally reachable callbacks/download links.
     pub public_url: Arc<RwLock<Option<String>>>,
+    /// Owner-triggered backend update state.
+    pub runtime_update: runtime_updates::RuntimeUpdateState,
 }
 
 // ── Constants ────────────────────────────────────────────────────
@@ -474,6 +477,7 @@ fn installed_runtime_metadata() -> serde_json::Value {
     json!({
         "version": read_trimmed("VERSION").unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string()),
         "channel": read_trimmed("CHANNEL"),
+        "github_repo": read_trimmed("GITHUB_REPO"),
         "package_version": env!("CARGO_PKG_VERSION"),
     })
 }
@@ -2061,6 +2065,7 @@ async fn build_router_inner(
         stream_tokens: logs::StreamTokenStore::new(),
         allowed_origins: allowed_origins_state.clone(),
         public_url: public_url_state,
+        runtime_update: runtime_updates::new_state(),
     });
 
     // Start background tasks (lease timeout, build timeout, heartbeat monitor)
@@ -2175,6 +2180,10 @@ async fn build_router_inner(
         .route("/v1/auth/logout", post(auth::logout))
         // User management endpoints
         .route("/v1/users/me", get(users::get_me))
+        .route(
+            "/v1/system/update",
+            get(runtime_updates::get_status).post(runtime_updates::start_update),
+        )
         .route("/v1/users", get(users::list_users))
         .route("/v1/users/invite", post(users::invite_user))
         .route(

--- a/crates/oored/src/runtime_updates.rs
+++ b/crates/oored/src/runtime_updates.rs
@@ -1,0 +1,127 @@
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use oore_contract::{ApiError, RuntimeUpdatePhase, RuntimeUpdateStatus};
+use tokio::sync::RwLock;
+
+use crate::AppState;
+use crate::extractors::AuthUser;
+use crate::store::write_audit_log;
+use crate::util::api_err;
+
+const SYSTEM_SERVICE_PLIST: &str = "/Library/LaunchDaemons/build.oore.oored.plist";
+
+pub type RuntimeUpdateState = Arc<RwLock<RuntimeUpdateStatus>>;
+
+pub fn new_state() -> RuntimeUpdateState {
+    Arc::new(RwLock::new(RuntimeUpdateStatus {
+        phase: RuntimeUpdatePhase::Idle,
+        error: None,
+        managed_service: PathBuf::from(SYSTEM_SERVICE_PLIST).is_file(),
+    }))
+}
+
+pub async fn get_status(
+    State(state): State<Arc<AppState>>,
+    auth: AuthUser,
+) -> Result<Json<RuntimeUpdateStatus>, (StatusCode, Json<ApiError>)> {
+    auth.require_owner()?;
+    Ok(Json(state.runtime_update.read().await.clone()))
+}
+
+pub async fn start_update(
+    State(state): State<Arc<AppState>>,
+    auth: AuthUser,
+) -> Result<(StatusCode, Json<RuntimeUpdateStatus>), (StatusCode, Json<ApiError>)> {
+    auth.require_owner()?;
+
+    let oore = std::env::current_exe()
+        .ok()
+        .and_then(|path| path.parent().map(|parent| parent.join("oore")))
+        .filter(|path| path.is_file())
+        .ok_or_else(|| {
+            api_err(
+                StatusCode::CONFLICT,
+                "runtime_update_unavailable",
+                "The installed oore updater was not found beside oored",
+            )
+        })?;
+
+    {
+        let mut status = state.runtime_update.write().await;
+        if !status.managed_service {
+            return Err(api_err(
+                StatusCode::CONFLICT,
+                "runtime_update_unmanaged",
+                "Backend updates from the web require the managed macOS launchd service",
+            ));
+        }
+        if matches!(
+            status.phase,
+            RuntimeUpdatePhase::Updating | RuntimeUpdatePhase::Restarting
+        ) {
+            return Err(api_err(
+                StatusCode::CONFLICT,
+                "runtime_update_in_progress",
+                "A backend update is already in progress",
+            ));
+        }
+        status.phase = RuntimeUpdatePhase::Updating;
+        status.error = None;
+    }
+
+    {
+        let store = state.store.lock().await;
+        let _ = write_audit_log(
+            store.pool(),
+            Some(&auth.0.user_id),
+            "runtime_update_started",
+            "system",
+            Some("backend"),
+            None,
+        )
+        .await;
+    }
+
+    let update_state = state.runtime_update.clone();
+    tokio::spawn(async move {
+        let result = tokio::task::spawn_blocking(move || {
+            Command::new(oore)
+                .arg("update")
+                .env("OORE_UPDATE_DEFER_DAEMON_RESTART", "1")
+                .output()
+        })
+        .await;
+
+        let output = match result {
+            Ok(Ok(output)) if output.status.success() => {
+                let mut status = update_state.write().await;
+                status.phase = RuntimeUpdatePhase::Restarting;
+                status.error = None;
+                drop(status);
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                std::process::exit(75);
+            }
+            Ok(Ok(output)) => String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            Ok(Err(error)) => error.to_string(),
+            Err(error) => error.to_string(),
+        };
+
+        let mut status = update_state.write().await;
+        status.phase = RuntimeUpdatePhase::Failed;
+        status.error = Some(if output.is_empty() {
+            "Backend update failed without diagnostic output".to_string()
+        } else {
+            output.chars().take(2_000).collect()
+        });
+    });
+
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(state.runtime_update.read().await.clone()),
+    ))
+}

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -14,8 +14,20 @@ Rules:
 
 ## 2026-07-13
 
+- **Runtime versions, owner-managed updates, and frontend state boundaries**:
+  - Preferences now reports frontend and backend versions independently, checks the installed release channel for updates, and lets the owner update managed `oore-web` and `oored` services through their existing systemd/launchd supervisors.
+  - Runner inventory now reports embedded and detached runner versions. Remote runner updates stay disabled until a runner-only package and managed service contract exist.
+  - Shared command-palette state now lives in Zustand, server update state remains in TanStack Query, build-log lifecycle state uses a reducer, and pipeline-form state no longer mirrors React Hook Form dirtiness through an effect.
+  - Linear feature docs: https://linear.app/oorebuild/document/feature-frontend-product-quality-and-build-experience-overhaul-c257decee5c5 and https://linear.app/oorebuild/document/feature-product-trust-hardening-release-592dfc525e77
+- **Updater system-service authorization fix**:
+  - `oore update` now obtains and explains macOS administrator authorization before replacing installed files, then restarts system launchd services non-interactively with bounded launchctl commands so a stalled password or service command cannot leave an apparently updated but unverified release.
+  - Linear feature doc: https://linear.app/oorebuild/document/feature-product-trust-hardening-release-592dfc525e77
 - **Frontend release smoke follow-up**:
   - Signed-in AWS smoke testing passed at desktop and 390 px widths for dashboard, projects, builds, sources, and GitLab setup; long setup URLs now wrap within narrow hint cards.
+  - Linear feature doc: https://linear.app/oorebuild/document/feature-frontend-product-quality-and-build-experience-overhaul-c257decee5c5
+- **Frontend layout and action consistency follow-up**:
+  - Source connection actions now align across providers, connected-source and other inventory empty states use compact spacing, and equivalent navigation/create/copy/destructive actions share icons, wording, and visual treatment.
+  - Shared page headers no longer double their section spacing; project cards align their actions; narrow settings layouts reflow instead of overflowing; and icon-only controls expose accessible names and selected state.
   - Linear feature doc: https://linear.app/oorebuild/document/feature-frontend-product-quality-and-build-experience-overhaul-c257decee5c5
 
 ## 2026-07-12


### PR DESCRIPTION
## What changed

- standardizes actions, responsive layouts, and source/settings UI consistency
- clarifies React state ownership with Zustand, TanStack Query, reducers, and React Hook Form
- reports frontend, backend, and runner versions separately
- adds owner-only managed frontend/backend update controls with service-manager restarts
- fixes system-service updater authorization and bounded launchd commands

## Why

The signed-in split deployment exposed inconsistent UI behavior and made runtime version management unnecessarily manual. This batch keeps local state local while making shared and server state explicit, and reuses the hardened updater rather than adding a second update mechanism.

## Validation

- `make validate`
- React Doctor changed-scope scan: no issues
- initial bundle: 225.17 KiB JavaScript gzip, within the 240 KiB budget
