### PR TITLE
fix(release): retry transient Pages deploys

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -1,9 +1,7 @@
 name: Autotag
 
 on:
-  workflow_run:
-    workflows: [Validate]
-    types: [completed]
+  push:
     branches: [stable, alpha, beta]
 
 concurrency:
@@ -13,10 +11,6 @@ concurrency:
 jobs:
   autotag:
     name: Cut release tag
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      contains(fromJSON('["stable","alpha","beta"]'), github.event.workflow_run.head_branch)
     runs-on: ${{ vars.RUNNER_MACOS || 'macos-latest' }}
     # Only run after validate completes — but since validate is a separate workflow,
     # we rely on branch protection rules to enforce this ordering.
@@ -25,12 +19,10 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PAT }}
-          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Autotag
         env:
-          AUTOTAG_CHANNEL: ${{ github.event.workflow_run.head_branch }}
-          AUTOTAG_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          AUTOTAG_SHA: ${{ github.event.workflow_run.head_sha }}
+          AUTOTAG_CHANNEL: ${{ github.ref_name }}
+          AUTOTAG_BRANCH: ${{ github.ref_name }}
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: bash tools/autotag.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,17 +50,40 @@ jobs:
 
           make build-web build-site build-docs
 
-          status=0
-          make deploy-site-only & pid_site=$!
-          make deploy-docs-only & pid_docs=$!
-          make deploy-web-only & pid_web=$!
-          wait "$pid_site" || status=$?
-          wait "$pid_docs" || status=$?
-          wait "$pid_web" || status=$?
-          [ "$status" -eq 0 ] || exit "$status"
+          deploy_pages() {
+            local target="$1"
+            local attempt log_file delay
+            log_file="$(mktemp)"
+            trap 'rm -f "$log_file"' RETURN
+
+            for attempt in 1 2 3 4; do
+              if make "$target" 2>&1 | tee "$log_file"; then
+                return 0
+              fi
+
+              if ! grep -Eq '(HTTP status|status code:)[[:space:]]*5[0-9]{2}' "$log_file"; then
+                echo "${target} failed with a non-transient error; not retrying."
+                return 1
+              fi
+
+              if [ "$attempt" -eq 4 ]; then
+                echo "${target} still failed after ${attempt} attempts."
+                return 1
+              fi
+
+              delay=$((attempt * 15))
+              echo "${target} hit a transient Cloudflare API error; retrying in ${delay}s (${attempt}/4)."
+              sleep "$delay"
+            done
+          }
+
+          # Deploy serially so one release does not burst Cloudflare's Pages API.
+          deploy_pages deploy-site-only
+          deploy_pages deploy-docs-only
+          deploy_pages deploy-web-only
 
           make build-demo
-          make deploy-demo-only
+          deploy_pages deploy-demo-only
 
   rust:
     name: Build Rust (${{ matrix.arch }})

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -14,6 +14,10 @@ Rules:
 
 ## 2026-07-13
 
+- **Reliable release tagging and Pages deployment**:
+  - Release tags are again cut from pushes to protected release-channel branches, avoiding a `workflow_run` trigger that GitHub only evaluates from the default branch.
+  - Pages projects now deploy serially and retry only transient Cloudflare 5xx API failures with bounded backoff; authentication and configuration errors still fail immediately.
+  - Linear release channels doc: https://linear.app/oorebuild/document/release-channels-alpha-beta-stable-via-woodpecker-github-releases-993db297927a
 - **Runtime versions, owner-managed updates, and frontend state boundaries**:
   - Preferences now reports frontend and backend versions independently, checks the installed release channel for updates, and lets the owner update managed `oore-web` and `oored` services through their existing systemd/launchd supervisors.
   - Runner inventory now reports embedded and detached runner versions. Remote runner updates stay disabled until a runner-only package and managed service contract exist.

--- a/tools/release-smoke.sh
+++ b/tools/release-smoke.sh
@@ -6,6 +6,17 @@ cd "$ROOT_DIR"
 
 echo "[release-smoke] Running local-first regression smoke checks..."
 
+# Release automation must remain taggable and resilient to transient Pages outages.
+grep -q '^  push:' .github/workflows/autotag.yml
+grep -q 'deploy_pages deploy-site-only' .github/workflows/release.yml
+grep -q 'deploy_pages deploy-docs-only' .github/workflows/release.yml
+grep -q 'deploy_pages deploy-web-only' .github/workflows/release.yml
+grep -q 'deploy_pages deploy-demo-only' .github/workflows/release.yml
+if grep -Eq 'make deploy-(site|docs|web)-only &' .github/workflows/release.yml; then
+  echo "[release-smoke] Pages deploys must not run concurrently." >&2
+  exit 1
+fi
+
 # Release installer local-first defaults and browser-open policy.
 bash scripts/install-acceptance.sh
 


### PR DESCRIPTION
## Summary
- deploy Cloudflare Pages projects serially instead of bursting the API
- retry only transient 5xx responses with bounded backoff
- restore push-driven autotagging for protected release branches
- add release smoke assertions for both behaviors

## Validation
- actionlint .github/workflows/release.yml .github/workflows/autotag.yml
- shellcheck tools/release-smoke.sh
- bun run docs:check
- make release-smoke
- make validate