### PR TITLE
fix(onboarding): streamline real project setup

### DIFF
--- a/FRONTEND_PRODUCT_PLAN.md
+++ b/FRONTEND_PRODUCT_PLAN.md
@@ -99,3 +99,30 @@ Remote-mode HttpOnly cookie sessions require frontend/backend architecture work 
 - [ ] Add detached-runner remote updates after runner-only packaging and a managed runner service/supervisor contract exist.
 
 **Gate:** shared, server, form, and lifecycle state each have one clear owner; runtime updates remain owner-only and unavailable for unmanaged processes; frontend/backend restart through their existing service managers.
+
+## Milestone 8 — Real Flutter project migration
+
+- [x] Make repository selection explicit; never create a project from an unshown fallback repository.
+- [x] Use the connected repository's name and default branch as visible project defaults while keeping them editable.
+- [x] Keep remote project creation focused on connected sources and local mode focused on local paths.
+- [x] Auto-connect a paired same-origin frontend when a browser has no saved instances, while preserving manual multi-instance setup.
+- [x] Keep UI-configured artifact paths consistent with the repository config and runner contracts.
+- [x] Validate a mature FVM Flutter project flow using Kite's existing build/release commands as a read-only benchmark.
+- [ ] Cover project creation, pipeline configuration, first build, logs, artifacts, and recovery UX with happy and failure paths.
+- [ ] Publish an alpha release, then verify owner-driven frontend and backend updates from the real AWS UI.
+
+**Gate:** a connected GitLab repository using `develop` can be turned into a truthful Android/iOS pipeline without editing or pushing to that repository; the first build either produces the configured artifacts or reports an actionable prerequisite failure; both managed Oore runtimes can be updated from the UI.
+
+## Milestone 9 — Guided setup and repository-owned workflows
+
+- [ ] Start project setup with an outcome-focused choice (for example, test an Android build or prepare a release) instead of presenting the full pipeline schema.
+- [ ] Derive project name, default branch, Flutter/FVM metadata, available platforms, flavors, and likely artifacts from the selected repository where the source provider permits read access.
+- [ ] Keep the common path short and progressively disclose triggers, command overrides, environment, artifacts, concurrency, and signing only when relevant.
+- [ ] Detect `.oore.yaml` and `.oore.yml` on the project's default branch before pipeline creation, including an explicitly configured path.
+- [ ] Preview every detected repository-owned workflow with its source path, resolved commands, triggers, platforms, artifacts, and validation state before it is imported or run.
+- [ ] Explain invalid config, unsupported keys, multiple-config conflicts, missing secrets, and runner/toolchain prerequisites with a concrete recovery action.
+- [ ] Keep repository config read-only unless a user explicitly asks Oore to prepare a change; never silently write or push workflow files.
+- [ ] Test auto-detection, explicit paths, multiple workflows, config changes between commits, malformed YAML, missing config, and UI-fallback behavior across GitHub, GitLab.com, and self-managed GitLab.
+- [ ] Use Kite read-only as the mature multi-workflow benchmark without copying its legacy pipeline defects or exposing repository secrets.
+
+**Gate:** after selecting a repository, a new user can understand the recommended next action without CI-specific knowledge; when repository-owned Oore config exists, the UI visibly discovers and validates it before the first run, and the runner executes the exact config from the checked-out commit.

--- a/apps/docs-site/docs/operations/split-roles.md
+++ b/apps/docs-site/docs/operations/split-roles.md
@@ -89,6 +89,8 @@ The installer checks the selected listen port before changing service state. If 
 
 `OORE_FRONTEND_PAIRING_CODE` exchanges the code with the backend over the private path, writes the returned backend proof into the frontend service's restrictive secret file, and generates a separate local proof for the authenticated reverse proxy -> `oore-web` hop. The pairing code is consumed once and is not saved. `oore-web` proxies `/v1/*`, `/healthz`, and `/readyz` to `OORE_WEB_BACKEND_URL`; browser-supplied identity and proof headers are stripped, and the identity header is forwarded only when the upstream proof matches.
 
+Browsers opening this paired frontend do not need to add the backend manually. When no Oore instance is saved in that browser, the UI recognizes the same-origin `oore-web` proxy and selects it automatically before authentication. Users who already manage multiple instances keep their existing registry unchanged.
+
 Manual `OORE_TRUSTED_PROXY_SHARED_SECRET_FILE` plus `OORE_WEB_UPSTREAM_TRUSTED_PROXY_SHARED_SECRET_FILE` configuration remains available for advanced Trusted Proxy secret-management workflows. Do not set a pairing code and manually reuse either proof value.
 
 During first-run setup, choose `Remote (Trusted Proxy)`, enter the initial owner email, and select a proxy preset. `Generic proxy` uses `x-oore-user-email`, `Warpgate` uses `x-warpgate-username`, and `Custom header` lets you enter the exact header your proxy forwards. The first owner claim must come from that same proxy-authenticated email, avoiding manual database edits.

--- a/apps/web/src/components/build-details/build-detail-page.tsx
+++ b/apps/web/src/components/build-details/build-detail-page.tsx
@@ -217,15 +217,16 @@ export function BuildDetailPage({ buildId }: { buildId: string }) {
               Build logs
             </h2>
             <p className="text-xs text-muted-foreground">
-              Live output, errors, and step-level context.
+              {isTerminal
+                ? 'Output, errors, and step-level context.'
+                : 'Live output, errors, and step-level context.'}
             </p>
           </div>
-          {isStreaming ? <Badge variant="info">Live</Badge> : null}
         </div>
         <TerminalLogViewer
           logs={mergedLogs}
           stepResults={build.step_results ?? []}
-          isStreaming={isStreaming}
+          isStreaming={isStreaming && !isTerminal}
           streamError={isTerminal ? undefined : (streamError ?? undefined)}
           logsUnavailable={fullLogsQuery.isError}
           isTerminal={isTerminal}

--- a/apps/web/src/components/pipeline-form.tsx
+++ b/apps/web/src/components/pipeline-form.tsx
@@ -332,35 +332,6 @@ export default function PipelineForm({
     )
   }
 
-  async function handleValidate() {
-    const valid = await form.trigger()
-    if (!valid) {
-      const errors = form.formState.errors
-      dispatchSections({
-        type: 'reveal',
-        sections: {
-          config: !!(
-            errors.name ||
-            errors.config_mode ||
-            errors.config_path ||
-            errors.flutter_version
-          ),
-          triggers: !!(errors.max_concurrent || errors.branches),
-          commands: !!(
-            errors.pre_build_commands ||
-            errors.build_commands ||
-            errors.post_build_commands
-          ),
-          iosSigning: !!(
-            errors.ios_signing_enabled ||
-            errors.ios_signing_team_id ||
-            errors.ios_signing_bundle_ids
-          ),
-        },
-      })
-    }
-  }
-
   const values = form.watch()
   const configMode = values.config_mode
   const previewDefaults = previewPlatformCommands(values)
@@ -1663,9 +1634,6 @@ export default function PipelineForm({
           <div className="flex items-center justify-end gap-3 px-6 py-3">
             <Button type="button" variant="outline" onClick={onCancel}>
               Cancel
-            </Button>
-            <Button type="button" variant="outline" onClick={handleValidate}>
-              Validate
             </Button>
             <Button
               type="button"

--- a/apps/web/src/hooks/use-log-stream.ts
+++ b/apps/web/src/hooks/use-log-stream.ts
@@ -116,7 +116,10 @@ export function useLogStream(
 
   useEffect(() => {
     cleanup()
-    if (!enabled || !baseUrl || !token) return cleanup
+    if (!enabled || !baseUrl || !token) {
+      updateStream({ isStreaming: false })
+      return cleanup
+    }
 
     updateStream('reset')
     logsBySequenceRef.current = new Map()

--- a/apps/web/src/lib/managed-frontend.test.ts
+++ b/apps/web/src/lib/managed-frontend.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { isManagedFrontend } from './managed-frontend'
+
+describe('isManagedFrontend', () => {
+  it('recognizes the same-origin oore-web proxy', async () => {
+    const fetcher = vi.fn(() =>
+      Promise.resolve(
+        new Response('{}', {
+          status: 200,
+          headers: { 'x-oore-web-proxy': '1' },
+        }),
+      ),
+    )
+    await expect(isManagedFrontend(fetcher)).resolves.toBe(true)
+  })
+
+  it('does not claim a generic or unavailable frontend', async () => {
+    await expect(
+      isManagedFrontend(vi.fn(() => Promise.resolve(new Response('{}')))),
+    ).resolves.toBe(false)
+    await expect(
+      isManagedFrontend(vi.fn(() => Promise.reject(new Error('down')))),
+    ).resolves.toBe(false)
+  })
+})

--- a/apps/web/src/lib/managed-frontend.ts
+++ b/apps/web/src/lib/managed-frontend.ts
@@ -1,0 +1,13 @@
+export async function isManagedFrontend(
+  fetcher: typeof fetch = fetch,
+): Promise<boolean> {
+  try {
+    const response = await fetcher('/healthz', {
+      method: 'GET',
+      cache: 'no-store',
+    })
+    return response.ok && response.headers.get('x-oore-web-proxy') === '1'
+  } catch {
+    return false
+  }
+}

--- a/apps/web/src/lib/pipeline-form-utils.test.ts
+++ b/apps/web/src/lib/pipeline-form-utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { PipelineFormValues } from '@/lib/pipeline-schema'
 import {
   defaultArtifactPatterns,
+  executionConfigFromForm,
   previewPlatformCommands,
 } from '@/lib/pipeline-form-utils'
 
@@ -57,6 +58,26 @@ describe('pipeline form defaults', () => {
   it('keeps the Quick Debug APK command in the pipeline payload preview', () => {
     expect(previewPlatformCommands(defaults)).toEqual([
       'flutter build apk --debug',
+    ])
+  })
+
+  it('keeps independent args, env, and artifacts when custom commands are off', () => {
+    const config = executionConfigFromForm({
+      ...defaults,
+      enable_customization: false,
+      build_commands: 'echo ignored',
+      android_build_args: '--target=lib/main_adhoc.dart',
+      env_vars: 'APP_FLAVOR=adhoc',
+      artifact_patterns: 'build/app/outputs/bundle/release/*.aab',
+    })
+
+    expect(config.commands.build).toEqual([])
+    expect(config.platform_build_args?.android).toEqual([
+      '--target=lib/main_adhoc.dart',
+    ])
+    expect(config.env).toEqual([{ key: 'APP_FLAVOR', value: 'adhoc' }])
+    expect(config.artifact_patterns).toEqual([
+      'build/app/outputs/bundle/release/*.aab',
     ])
   })
 })

--- a/apps/web/src/lib/pipeline-form-utils.ts
+++ b/apps/web/src/lib/pipeline-form-utils.ts
@@ -1,4 +1,8 @@
-import type { BuildPlatform, Pipeline } from '@/lib/types'
+import type {
+  BuildPlatform,
+  Pipeline,
+  PipelineExecutionConfig,
+} from '@/lib/types'
 import type { PipelineFormValues } from '@/lib/pipeline-schema'
 
 export function parseMultiline(raw?: string): Array<string> {
@@ -100,6 +104,40 @@ export function defaultArtifactPatterns(
     patterns.add('build/macos/Build/Products/Release/*.app')
   if (patterns.size === 0) patterns.add('build/app/outputs/flutter-apk/*.apk')
   return [...patterns]
+}
+
+export function executionConfigFromForm(
+  data: PipelineFormValues,
+): PipelineExecutionConfig {
+  const platforms = selectedPlatforms(data)
+  const artifactPatterns = parseMultiline(data.artifact_patterns)
+
+  return {
+    platforms,
+    flutter_version: trimToUndefined(data.flutter_version),
+    commands: data.enable_customization
+      ? {
+          pre_build: parseMultiline(data.pre_build_commands),
+          build: parseMultiline(data.build_commands),
+          post_build: parseMultiline(data.post_build_commands),
+        }
+      : { pre_build: [], build: [], post_build: [] },
+    platform_build_args: {
+      android: parseMultiline(data.android_build_args),
+      ios: parseMultiline(data.ios_build_args),
+      macos: parseMultiline(data.macos_build_args),
+    },
+    platform_commands: {
+      android: trimToUndefined(data.android_command_override),
+      ios: trimToUndefined(data.ios_command_override),
+      macos: trimToUndefined(data.macos_command_override),
+    },
+    env: parseEnvVars(data.env_vars),
+    artifact_patterns:
+      artifactPatterns.length > 0
+        ? artifactPatterns
+        : defaultArtifactPatterns(platforms),
+  }
 }
 
 export function trimToUndefined(value?: string): string | undefined {

--- a/apps/web/src/lib/project-form-utils.test.ts
+++ b/apps/web/src/lib/project-form-utils.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { repositoryProjectDefaults } from './project-form-utils'
+
+describe('repositoryProjectDefaults', () => {
+  it('uses the repository name and its configured default branch', () => {
+    expect(
+      repositoryProjectDefaults({
+        id: 'repo-1',
+        installation_id: 'installation-1',
+        external_id: 'mobile/kite',
+        full_name: 'mobile-apps/kite',
+        default_branch: 'develop',
+        is_private: true,
+        created_at: 1,
+        updated_at: 1,
+        integration_id: 'integration-1',
+        provider: 'gitlab',
+        host_url: 'https://gitlab.example.com',
+      }),
+    ).toEqual({ name: 'kite', defaultBranch: 'develop' })
+  })
+})

--- a/apps/web/src/lib/project-form-utils.ts
+++ b/apps/web/src/lib/project-form-utils.ts
@@ -1,0 +1,8 @@
+import type { SourceRepository } from '@/hooks/use-source-repositories'
+
+export function repositoryProjectDefaults(repository: SourceRepository) {
+  return {
+    name: repository.full_name.split('/').filter(Boolean).at(-1) ?? '',
+    defaultBranch: repository.default_branch ?? '',
+  }
+}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -42,6 +42,7 @@ import { getSetupStatus } from '@/lib/api'
 import { getStatusVariant } from '@/lib/status-variants'
 import { relativeTime } from '@/lib/format-utils'
 import { PageMeta } from '@/lib/seo'
+import { isManagedFrontend } from '@/lib/managed-frontend'
 import { useAuthStore } from '@/stores/auth-store'
 import { useActiveInstance, useInstanceStore } from '@/stores/instance-store'
 
@@ -102,15 +103,25 @@ function IndexPage() {
 
   useMountEffect(() => {
     if (instance || autoDetectAttemptedRef.current) return
-    if (!isLoopbackHostname(window.location.hostname)) return
 
     autoDetectAttemptedRef.current = true
     setIsDetectingLocalInstance(true)
 
-    void detectReachableLocalDaemonUrl()
-      .then((detectedUrl) => {
-        if (!detectedUrl) return
+    void Promise.all([
+      isManagedFrontend(),
+      isLoopbackHostname(window.location.hostname)
+        ? detectReachableLocalDaemonUrl()
+        : Promise.resolve(null),
+    ])
+      .then(([managedFrontend, detectedUrl]) => {
         const store = useInstanceStore.getState()
+        if (Object.keys(store.instances).length > 0) return
+        if (managedFrontend) {
+          const instanceId = store.addInstance(window.location.hostname, '')
+          store.setActiveInstance(instanceId)
+          return
+        }
+        if (!detectedUrl) return
         const existingInstance = Object.values(store.instances).find(
           (candidate) =>
             normalizeUrl(candidate.url) === normalizeUrl(detectedUrl),

--- a/apps/web/src/routes/projects/$projectId/pipelines/$pipelineId_.edit.tsx
+++ b/apps/web/src/routes/projects/$projectId/pipelines/$pipelineId_.edit.tsx
@@ -28,14 +28,12 @@ import {
 import { useRepositoryProvider } from '@/hooks/use-integrations'
 import { useProject } from '@/hooks/use-projects'
 import {
-  defaultArtifactPatterns,
+  executionConfigFromForm,
   fileToBase64,
   fileToUtf8,
   hasCustomFallback,
   parseBundleIdsInput,
   parseCsv,
-  parseEnvVars,
-  parseMultiline,
   selectedPlatforms,
   toMultiline,
   trimToUndefined,
@@ -230,18 +228,6 @@ function EditPipelinePage() {
         : undefined,
     }
 
-    const commands = values.enable_customization
-      ? {
-          pre_build: parseMultiline(values.pre_build_commands),
-          build: parseMultiline(values.build_commands),
-          post_build: parseMultiline(values.post_build_commands),
-        }
-      : { pre_build: [], build: [], post_build: [] }
-
-    const customPatterns = values.enable_customization
-      ? parseMultiline(values.artifact_patterns)
-      : []
-
     const payload: UpdatePipelineRequest = {
       name: values.name.trim(),
       config_path:
@@ -249,30 +235,7 @@ function EditPipelinePage() {
           ? values.config_path?.trim()
           : '.oore.yaml',
       config_path_explicit: values.config_mode === 'explicit',
-      execution_config: {
-        platforms,
-        flutter_version: values.flutter_version?.trim() || undefined,
-        commands,
-        platform_build_args: values.enable_customization
-          ? {
-              android: parseMultiline(values.android_build_args),
-              ios: parseMultiline(values.ios_build_args),
-              macos: parseMultiline(values.macos_build_args),
-            }
-          : { android: [], ios: [], macos: [] },
-        platform_commands: values.enable_customization
-          ? {
-              android: values.android_command_override?.trim() || undefined,
-              ios: values.ios_command_override?.trim() || undefined,
-              macos: values.macos_command_override?.trim() || undefined,
-            }
-          : {},
-        env: values.enable_customization ? parseEnvVars(values.env_vars) : [],
-        artifact_patterns:
-          customPatterns.length > 0
-            ? customPatterns
-            : defaultArtifactPatterns(platforms),
-      },
+      execution_config: executionConfigFromForm(values),
       trigger_config,
       concurrency,
     }

--- a/apps/web/src/routes/projects/$projectId/pipelines/new.tsx
+++ b/apps/web/src/routes/projects/$projectId/pipelines/new.tsx
@@ -23,13 +23,11 @@ import {
 import { useRepositoryProvider } from '@/hooks/use-integrations'
 import { useProject } from '@/hooks/use-projects'
 import {
-  defaultArtifactPatterns,
+  executionConfigFromForm,
   fileToBase64,
   fileToUtf8,
   parseBundleIdsInput,
   parseCsv,
-  parseEnvVars,
-  parseMultiline,
   selectedPlatforms,
   trimToUndefined,
 } from '@/lib/pipeline-form-utils'
@@ -101,7 +99,7 @@ const PIPELINE_TEMPLATES = [
       platform_macos: false,
       enable_customization: true,
       android_command_override: 'flutter build apk --debug',
-      artifact_patterns: 'build/app/outputs/flutter-apk/app-debug.apk',
+      artifact_patterns: 'build/app/outputs/flutter-apk/*.apk',
     } satisfies PipelineFormValues,
     events: ['push'],
   },
@@ -212,18 +210,6 @@ function NewPipelinePage() {
         : undefined,
     }
 
-    const commands = data.enable_customization
-      ? {
-          pre_build: parseMultiline(data.pre_build_commands),
-          build: parseMultiline(data.build_commands),
-          post_build: parseMultiline(data.post_build_commands),
-        }
-      : { pre_build: [], build: [], post_build: [] }
-
-    const customPatterns = data.enable_customization
-      ? parseMultiline(data.artifact_patterns)
-      : []
-
     const payload: CreatePipelineRequest = {
       name: data.name.trim(),
       config_path:
@@ -231,30 +217,7 @@ function NewPipelinePage() {
           ? data.config_path?.trim()
           : '.oore.yaml',
       config_path_explicit: data.config_mode === 'explicit',
-      execution_config: {
-        platforms,
-        flutter_version: data.flutter_version?.trim() || undefined,
-        commands,
-        platform_build_args: data.enable_customization
-          ? {
-              android: parseMultiline(data.android_build_args),
-              ios: parseMultiline(data.ios_build_args),
-              macos: parseMultiline(data.macos_build_args),
-            }
-          : { android: [], ios: [], macos: [] },
-        platform_commands: data.enable_customization
-          ? {
-              android: data.android_command_override?.trim() || undefined,
-              ios: data.ios_command_override?.trim() || undefined,
-              macos: data.macos_command_override?.trim() || undefined,
-            }
-          : {},
-        env: data.enable_customization ? parseEnvVars(data.env_vars) : [],
-        artifact_patterns:
-          customPatterns.length > 0
-            ? customPatterns
-            : defaultArtifactPatterns(platforms),
-      },
+      execution_config: executionConfigFromForm(data),
       trigger_config,
       concurrency,
     }

--- a/apps/web/src/routes/projects/-create-project-dialog.tsx
+++ b/apps/web/src/routes/projects/-create-project-dialog.tsx
@@ -36,18 +36,19 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Spinner } from '@/components/ui/spinner'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useCreateProject } from '@/hooks/use-projects'
 import { useSetupStatus } from '@/hooks/use-setup'
 import { useSourceRepositories } from '@/hooks/use-source-repositories'
 import { useActiveInstance } from '@/stores/instance-store'
 import { resolveInstanceApiBaseUrl } from '@/lib/instance-url'
+import { repositoryProjectDefaults } from '@/lib/project-form-utils'
 
 const createProjectSchema = z.object({
   name: z.string().min(1, 'Name is required'),
   description: z.string().optional(),
   default_branch: z.string().optional(),
   local_repository_path: z.string().optional(),
+  repository_id: z.string().optional(),
 })
 
 type CreateProjectForm = z.infer<typeof createProjectSchema>
@@ -100,11 +101,9 @@ export default function CreateProjectDialog({
   )
   const canBrowseLocalFs = uiIsLoopback && backendIsLoopback
 
-  const [sourceKind, setSourceKind] = useState<'local' | 'repo'>('local')
   const { data: repos, isLoading: reposLoading } = useSourceRepositories(
-    open && isRemoteMode && sourceKind === 'repo',
+    open && isRemoteMode,
   )
-  const [selectedRepoId, setSelectedRepoId] = useState<string>('')
   const [pickerOpen, setPickerOpen] = useState(false)
 
   const repoItems = useMemo(
@@ -126,12 +125,10 @@ export default function CreateProjectDialog({
       description: '',
       default_branch: '',
       local_repository_path: '',
+      repository_id: '',
     },
     mode: 'onBlur',
   })
-
-  const effectiveSourceKind = sourceKind
-  const effectiveSelectedRepoId = selectedRepoId || repos?.[0]?.id || ''
 
   function applyLocalPath(path: string, closePicker = false) {
     form.setValue('local_repository_path', path, {
@@ -159,7 +156,7 @@ export default function CreateProjectDialog({
       return
     }
 
-    if (effectiveSourceKind === 'local') {
+    if (!isRemoteMode) {
       const localRepositoryPath = data.local_repository_path?.trim()
       if (!localRepositoryPath) {
         toast.error('Path is required.')
@@ -191,7 +188,8 @@ export default function CreateProjectDialog({
       return
     }
 
-    if (!effectiveSelectedRepoId) {
+    const repositoryId = data.repository_id?.trim()
+    if (!repositoryId) {
       toast.error('Select a source repository before creating a project.')
       return
     }
@@ -200,14 +198,13 @@ export default function CreateProjectDialog({
       {
         name,
         description: data.description?.trim() || undefined,
-        repository_id: effectiveSelectedRepoId,
+        repository_id: repositoryId,
         default_branch: data.default_branch?.trim() || undefined,
       },
       {
         onSuccess: (res) => {
           toast.success('Project created')
           form.reset()
-          setSelectedRepoId('')
           onOpenChange(false)
           void navigate({
             to: '/projects/$projectId',
@@ -222,13 +219,8 @@ export default function CreateProjectDialog({
   }
 
   function handleOpenChange(nextOpen: boolean) {
-    if (nextOpen) {
-      setSourceKind(isRemoteMode ? 'repo' : 'local')
-      setSelectedRepoId('')
-    } else {
+    if (!nextOpen) {
       form.reset()
-      setSelectedRepoId('')
-      setSourceKind('local')
       setPickerOpen(false)
     }
     onOpenChange(nextOpen)
@@ -241,14 +233,87 @@ export default function CreateProjectDialog({
           <DialogHeader>
             <DialogTitle>Create Project</DialogTitle>
             <DialogDescription>
-              {effectiveSourceKind === 'local'
-                ? 'Create a project from a local repository path.'
-                : 'Create a project linked to a connected source repository.'}
+              {isRemoteMode
+                ? 'Choose a repository from a connected source. Project defaults are filled in for you.'
+                : 'Create a project from a repository on this Mac.'}
             </DialogDescription>
           </DialogHeader>
 
           <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              {isRemoteMode ? (
+                <FormField
+                  control={form.control}
+                  name="repository_id"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Repository</FormLabel>
+                      {reposLoading ? (
+                        <div className="flex items-center gap-2 py-2">
+                          <Spinner className="size-4" />
+                          <span className="text-sm text-muted-foreground">
+                            Loading repositories...
+                          </span>
+                        </div>
+                      ) : hasRepos ? (
+                        <Select
+                          value={field.value}
+                          onValueChange={(value) => {
+                            field.onChange(value ?? '')
+                            const repository = repos?.find(
+                              (repo) => repo.id === value,
+                            )
+                            if (!repository) return
+                            const defaults =
+                              repositoryProjectDefaults(repository)
+                            if (!form.getFieldState('name').isDirty) {
+                              form.setValue('name', defaults.name)
+                            }
+                            if (!form.getFieldState('default_branch').isDirty) {
+                              form.setValue(
+                                'default_branch',
+                                defaults.defaultBranch,
+                              )
+                            }
+                          }}
+                          items={repoItems}
+                        >
+                          <FormControl>
+                            <SelectTrigger autoFocus>
+                              <SelectValue placeholder="Select a repository..." />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {(repos ?? []).map((repo) => (
+                              <SelectItem key={repo.id} value={repo.id}>
+                                {repo.full_name}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      ) : (
+                        <div className="space-y-3">
+                          <FormDescription>
+                            No repositories are available. Connect a source and
+                            sync its repositories first.
+                          </FormDescription>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            render={<Link to="/settings/integrations" />}
+                            nativeButton={false}
+                          >
+                            <HugeiconsIcon icon={Link04Icon} />
+                            Connect source
+                          </Button>
+                        </div>
+                      )}
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              ) : null}
+
               <FormField
                 control={form.control}
                 name="name"
@@ -256,7 +321,11 @@ export default function CreateProjectDialog({
                   <FormItem>
                     <FormLabel>Name</FormLabel>
                     <FormControl>
-                      <Input placeholder="My App" autoFocus {...field} />
+                      <Input
+                        placeholder="My App"
+                        autoFocus={!isRemoteMode}
+                        {...field}
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -285,111 +354,51 @@ export default function CreateProjectDialog({
                 )}
               />
 
-              <Tabs
-                value={effectiveSourceKind}
-                onValueChange={(v) => {
-                  setSourceKind(v as 'local' | 'repo')
-                }}
-              >
-                <TabsList className="w-full">
-                  <TabsTrigger value="local">Local path</TabsTrigger>
-                  <TabsTrigger value="repo" disabled={!isRemoteMode}>
-                    Connected repo
-                  </TabsTrigger>
-                </TabsList>
-
-                <TabsContent value="local" className="space-y-4">
-                  <FormField
-                    control={form.control}
-                    name="local_repository_path"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Path</FormLabel>
-                        <div className="flex flex-col gap-2 md:flex-row">
-                          <FormControl>
-                            <Input
-                              {...field}
-                              placeholder="/absolute/path/to/repository"
-                              className="font-mono text-xs"
-                            />
-                          </FormControl>
-                          {canBrowseLocalFs ? (
-                            <div className="flex gap-2">
-                              <Button
-                                type="button"
-                                variant="outline"
-                                size="icon"
-                                aria-label="Browse"
-                                title="Browse"
-                                onClick={handleOpenPicker}
-                              >
-                                <HugeiconsIcon icon={Folder02Icon} />
-                              </Button>
-                            </div>
-                          ) : null}
-                        </div>
-                        <FormDescription>
-                          Absolute path to the Git repository.
-                          {!canBrowseLocalFs ? (
-                            <>
-                              {' '}
-                              For security, folder browsing is only available
-                              from localhost.
-                            </>
-                          ) : null}
-                        </FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </TabsContent>
-
-                <TabsContent value="repo" className="space-y-2">
-                  <FormLabel>Source repository</FormLabel>
-                  {reposLoading ? (
-                    <div className="flex items-center gap-2 py-2">
-                      <Spinner className="size-4" />
-                      <span className="text-sm text-muted-foreground">
-                        Loading source repositories...
-                      </span>
-                    </div>
-                  ) : hasRepos ? (
-                    <Select
-                      value={selectedRepoId}
-                      onValueChange={(v) => setSelectedRepoId(v ?? '')}
-                      items={repoItems}
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select a repository..." />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {(repos ?? []).map((repo) => (
-                          <SelectItem key={repo.id} value={repo.id}>
-                            {repo.full_name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  ) : (
-                    <div className="space-y-3">
-                      <p className="text-sm text-muted-foreground">
-                        No source repositories are available yet. Connect a
-                        source, then sync its repositories before creating a
-                        project.
-                      </p>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        render={<Link to="/settings/integrations" />}
-                        nativeButton={false}
-                      >
-                        <HugeiconsIcon icon={Link04Icon} />
-                        Connect source
-                      </Button>
-                    </div>
+              {!isRemoteMode ? (
+                <FormField
+                  control={form.control}
+                  name="local_repository_path"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Path</FormLabel>
+                      <div className="flex flex-col gap-2 md:flex-row">
+                        <FormControl>
+                          <Input
+                            {...field}
+                            placeholder="/absolute/path/to/repository"
+                            className="font-mono text-xs"
+                          />
+                        </FormControl>
+                        {canBrowseLocalFs ? (
+                          <div className="flex gap-2">
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="icon"
+                              aria-label="Browse"
+                              title="Browse"
+                              onClick={handleOpenPicker}
+                            >
+                              <HugeiconsIcon icon={Folder02Icon} />
+                            </Button>
+                          </div>
+                        ) : null}
+                      </div>
+                      <FormDescription>
+                        Absolute path to the Git repository.
+                        {!canBrowseLocalFs ? (
+                          <>
+                            {' '}
+                            For security, folder browsing is only available from
+                            localhost.
+                          </>
+                        ) : null}
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
                   )}
-                </TabsContent>
-              </Tabs>
+                />
+              ) : null}
 
               <FormField
                 control={form.control}
@@ -397,7 +406,7 @@ export default function CreateProjectDialog({
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>
-                      Default Branch{' '}
+                      Default branch{' '}
                       <span className="text-muted-foreground font-normal">
                         (optional)
                       </span>
@@ -422,8 +431,7 @@ export default function CreateProjectDialog({
                   type="submit"
                   disabled={
                     createMutation.isPending ||
-                    (effectiveSourceKind === 'repo' &&
-                      (reposLoading || !hasRepos))
+                    (isRemoteMode && (reposLoading || !hasRepos))
                   }
                 >
                   {createMutation.isPending ? (
@@ -432,7 +440,7 @@ export default function CreateProjectDialog({
                       Creating...
                     </>
                   ) : (
-                    'Create'
+                    'Create project'
                   )}
                 </Button>
               </DialogFooter>
@@ -444,7 +452,7 @@ export default function CreateProjectDialog({
       <LocalFolderPickerDialog
         open={pickerOpen}
         onOpenChange={setPickerOpen}
-        enabled={open && effectiveSourceKind === 'local' && canBrowseLocalFs}
+        enabled={open && !isRemoteMode && canBrowseLocalFs}
         initialPath={form.getValues('local_repository_path')}
         title="Browse Local Folders"
         description="Select a Git repository folder and use it for this project."

--- a/apps/web/src/routes/settings/preferences.tsx
+++ b/apps/web/src/routes/settings/preferences.tsx
@@ -232,7 +232,6 @@ interface RuntimeHealth {
   version?: string
   channel?: string | null
   github_repo?: string | null
-  backend_url?: string
   package_version?: string
 }
 

--- a/apps/web/tools/oore-web.js
+++ b/apps/web/tools/oore-web.js
@@ -1164,8 +1164,6 @@ async function main() {
           {
             ok: true,
             ...readInstalledMetadata(),
-            backend_url: backendUrl.toString(),
-            dist_dir: distDir,
           },
           {
             headers: {

--- a/crates/oore-runner/src/lib.rs
+++ b/crates/oore-runner/src/lib.rs
@@ -11,7 +11,7 @@ use oore_contract::{
     PipelineCommandStages, PipelineEnvVar, PipelineExecutionConfig, PlatformBuildArgs,
     PlatformBuildCommands, RUNNER_PROTOCOL_VERSION, RunnerAndroidSigningProfile,
     RunnerAndroidSigningResponse, RunnerIosSigningBundle, RunnerIosSigningResponse, StepResult,
-    artifact_pattern_matches, parse_repository_pipeline_yaml,
+    artifact_pattern_matches, parse_repository_pipeline_yaml, validate_artifact_pattern,
 };
 use rand::RngCore;
 use sha2::{Digest, Sha256};
@@ -1321,9 +1321,8 @@ fn validate_artifact_patterns(patterns: &[String]) -> anyhow::Result<Vec<String>
         if trimmed.is_empty() {
             anyhow::bail!("artifacts.patterns[{idx}] must not be empty");
         }
-        if !trimmed.starts_with("*.") || trimmed.chars().any(char::is_whitespace) {
-            anyhow::bail!("artifacts.patterns[{idx}] must be extension globs like '*.apk'");
-        }
+        validate_artifact_pattern(trimmed)
+            .map_err(|error| anyhow::anyhow!("artifacts.patterns[{idx}] {error}"))?;
         cleaned.push(trimmed.to_string());
     }
     Ok(cleaned)
@@ -3692,6 +3691,33 @@ mod tests {
 
         let error = resolve_execution_plan(&workspace, &snapshot).expect_err("should fail");
         assert!(error.to_string().contains(".fvmrc"));
+
+        cleanup_workspace(&workspace);
+    }
+
+    #[test]
+    fn ui_fallback_accepts_workspace_relative_artifact_patterns() {
+        let workspace = temp_workspace();
+        let snapshot = serde_json::json!({
+            "config_path_explicit": false,
+            "ui_execution_config": {
+                "platforms": ["android", "ios"],
+                "commands": { "pre_build": [], "build": [], "post_build": [] },
+                "artifact_patterns": [
+                    "build/app/outputs/bundle/release/*.aab",
+                    "build/ios/ipa/*.ipa"
+                ]
+            }
+        });
+
+        let plan = resolve_execution_plan(&workspace, &snapshot).expect("resolve UI fallback");
+        assert_eq!(
+            plan.artifact_patterns,
+            vec![
+                "build/app/outputs/bundle/release/*.aab".to_string(),
+                "build/ios/ipa/*.ipa".to_string(),
+            ]
+        );
 
         cleanup_workspace(&workspace);
     }

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -14,6 +14,13 @@ Rules:
 
 ## 2026-07-13
 
+- **Managed frontend onboarding and real Flutter migration fixes**:
+  - A paired same-origin `oore-web` frontend now becomes the browser's instance automatically when no instance has been saved, so invited users can proceed directly to authentication; manual instance management remains available for generic and multi-instance clients.
+  - Remote project creation now requires an explicitly selected connected repository and fills its editable name and default branch, while local project paths stay confined to Local Only mode.
+  - Pipeline forms preserve platform arguments, environment variables, and artifacts independently from custom command toggles. Built-in artifact patterns and the runner now share the same valid workspace-relative glob contract.
+  - Terminal build logs no longer present stale or duplicate live state, and the no-op client-only Validate action was removed in favor of validation on save.
+  - Linear feature doc: https://linear.app/oorebuild/document/feature-frontend-product-quality-and-build-experience-overhaul-c257decee5c5
+
 - **Reliable release tagging and Pages deployment**:
   - Release tags are again cut from pushes to protected release-channel branches, avoiding a `workflow_run` trigger that GitHub only evaluates from the default branch.
   - Pages projects now deploy serially and retry only transient Cloudflare 5xx API failures with bounded backoff; authentication and configuration errors still fail immediately.


### PR DESCRIPTION
## Summary
- auto-connect paired same-origin frontends for first-time browsers
- make remote project creation repository-first with visible repo-derived defaults
- align UI and runner artifact contracts and preserve independent pipeline settings
- make terminal build logs truthful and remove the no-op Validate action
- record guided repository-workflow discovery as the next product milestone

## Real-flow evidence
- created the Kite GitLab project with default branch `develop` without modifying or pushing Kite
- created and ran an Android ad-hoc pipeline
- reproduced the runner artifact-pattern failure after successful checkout
- added a regression covering workspace-relative artifact globs

## Validation
- `make validate`
- `bunx react-doctor@latest --verbose --diff` (no issues in changed React code)
- focused managed-frontend, project-default, pipeline-form, and runner regression tests