### PR TITLE
fix(logs): show terminal loading state

### DIFF
--- a/apps/web/src/components/build-details/build-detail-page.tsx
+++ b/apps/web/src/components/build-details/build-detail-page.tsx
@@ -227,6 +227,7 @@ export function BuildDetailPage({ buildId }: { buildId: string }) {
           logs={mergedLogs}
           stepResults={build.step_results ?? []}
           isStreaming={isStreaming && !isTerminal}
+          isLoading={isTerminal && fullLogsQuery.isLoading}
           streamError={isTerminal ? undefined : (streamError ?? undefined)}
           logsUnavailable={fullLogsQuery.isError}
           isTerminal={isTerminal}

--- a/apps/web/src/components/terminal-log-viewer.test.tsx
+++ b/apps/web/src/components/terminal-log-viewer.test.tsx
@@ -74,4 +74,21 @@ describe('TerminalLogViewer', () => {
       screen.getByRole('button', { name: 'Download raw logs' }),
     ).toBeTruthy()
   })
+
+  it('does not claim terminal logs are absent while they are loading', () => {
+    render(
+      <TerminalLogViewer
+        logs={[]}
+        stepResults={[]}
+        isStreaming={false}
+        isLoading
+        isTerminal
+      />,
+    )
+
+    expect(screen.getByText('Loading build logs...')).toBeTruthy()
+    expect(
+      screen.queryByText('This build completed without recorded logs.'),
+    ).toBeNull()
+  })
 })

--- a/apps/web/src/components/terminal-log-viewer/log-output.tsx
+++ b/apps/web/src/components/terminal-log-viewer/log-output.tsx
@@ -13,6 +13,7 @@ interface LogOutputProps {
   selectedStep: string
   selectedStepMeta: SelectedStepMeta | null
   searchQuery: string
+  isLoading: boolean
   logsUnavailable: boolean
   isTerminal: boolean
   wrapLines: boolean
@@ -25,6 +26,7 @@ export function LogOutput({
   selectedStep,
   selectedStepMeta,
   searchQuery,
+  isLoading,
   logsUnavailable,
   isTerminal,
   wrapLines,
@@ -60,11 +62,13 @@ export function LogOutput({
           <span className="text-xs text-muted-foreground">
             {searchQuery
               ? 'No matching lines'
-              : logsUnavailable
-                ? 'Logs are unavailable for this build.'
-                : isTerminal
-                  ? 'This build completed without recorded logs.'
-                  : 'No logs yet'}
+              : isLoading
+                ? 'Loading build logs...'
+                : logsUnavailable
+                  ? 'Logs are unavailable for this build.'
+                  : isTerminal
+                    ? 'This build completed without recorded logs.'
+                    : 'No logs yet'}
           </span>
         </div>
       ) : (

--- a/apps/web/src/components/terminal-log-viewer/terminal-log-viewer.tsx
+++ b/apps/web/src/components/terminal-log-viewer/terminal-log-viewer.tsx
@@ -22,6 +22,7 @@ export default function TerminalLogViewer({
   stepResults,
   isStreaming,
   streamError,
+  isLoading = false,
   logsUnavailable = false,
   isTerminal = false,
 }: TerminalLogViewerProps) {
@@ -203,6 +204,7 @@ export default function TerminalLogViewer({
           selectedStep={selectedStep}
           selectedStepMeta={selectedStepMeta}
           searchQuery={searchQuery}
+          isLoading={isLoading}
           logsUnavailable={logsUnavailable}
           isTerminal={isTerminal}
           wrapLines={wrapLines}

--- a/apps/web/src/components/terminal-log-viewer/types.ts
+++ b/apps/web/src/components/terminal-log-viewer/types.ts
@@ -5,6 +5,7 @@ export interface TerminalLogViewerProps {
   stepResults: Array<StepResult>
   isStreaming: boolean
   streamError?: string
+  isLoading?: boolean
   logsUnavailable?: boolean
   isTerminal?: boolean
 }

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -20,6 +20,9 @@ Rules:
   - Pipeline forms preserve platform arguments, environment variables, and artifacts independently from custom command toggles. Built-in artifact patterns and the runner now share the same valid workspace-relative glob contract.
   - Terminal build logs no longer present stale or duplicate live state, and the no-op client-only Validate action was removed in favor of validation on save.
   - Linear feature doc: https://linear.app/oorebuild/document/feature-frontend-product-quality-and-build-experience-overhaul-c257decee5c5
+- **Terminal log loading truth**:
+  - A completed build now shows an explicit loading state while persisted logs are being fetched instead of briefly claiming the build recorded no logs.
+  - Linear feature doc: https://linear.app/oorebuild/document/feature-frontend-product-quality-and-build-experience-overhaul-c257decee5c5
 
 - **Reliable release tagging and Pages deployment**:
   - Release tags are again cut from pushes to protected release-channel branches, avoiding a `workflow_run` trigger that GitHub only evaluates from the default branch.


### PR DESCRIPTION
## Summary
- show an explicit loading state while terminal build logs are fetched
- avoid briefly claiming a successful build recorded no logs
- cover the terminal loading transition

## Live evidence
Kite build #2 succeeded with 253 persisted log lines and a 94.7 MB APK. Immediately after terminal transition, the UI briefly rendered the empty terminal message until the full-log query completed.

## Validation
- focused terminal-log tests (3 passed)
- TypeScript and ESLint
- docs gate
- React Doctor 100/100