### PR TITLE
feat(pipelines): guide repository workflow setup

### DIFF
--- a/FRONTEND_PRODUCT_PLAN.md
+++ b/FRONTEND_PRODUCT_PLAN.md
@@ -118,10 +118,10 @@ Remote-mode HttpOnly cookie sessions require frontend/backend architecture work 
 - [ ] Start project setup with an outcome-focused choice (for example, test an Android build or prepare a release) instead of presenting the full pipeline schema.
 - [ ] Derive project name, default branch, Flutter/FVM metadata, available platforms, flavors, and likely artifacts from the selected repository where the source provider permits read access.
 - [ ] Keep the common path short and progressively disclose triggers, command overrides, environment, artifacts, concurrency, and signing only when relevant.
-- [ ] Detect `.oore.yaml` and `.oore.yml` on the project's default branch before pipeline creation, including an explicitly configured path.
-- [ ] Preview every detected repository-owned workflow with its source path, resolved commands, triggers, platforms, artifacts, and validation state before it is imported or run.
+- [x] Detect `.oore.yaml` and `.oore.yml` on the project's default branch before pipeline creation, including an explicitly configured path.
+- [x] Preview every detected repository-owned workflow with its source path, resolved commands, platforms, artifacts, environment key names, and validation state before it is imported or run. Repository-owned triggers remain a later schema decision.
 - [ ] Explain invalid config, unsupported keys, multiple-config conflicts, missing secrets, and runner/toolchain prerequisites with a concrete recovery action.
-- [ ] Keep repository config read-only unless a user explicitly asks Oore to prepare a change; never silently write or push workflow files.
+- [x] Keep repository config read-only unless a user explicitly asks Oore to prepare a change; never silently write or push workflow files.
 - [ ] Test auto-detection, explicit paths, multiple workflows, config changes between commits, malformed YAML, missing config, and UI-fallback behavior across GitHub, GitLab.com, and self-managed GitLab.
 - [ ] Use Kite read-only as the mature multi-workflow benchmark without copying its legacy pipeline defects or exposing repository secrets.
 

--- a/apps/docs-site/docs/guides/projects/trigger-builds.md
+++ b/apps/docs-site/docs/guides/projects/trigger-builds.md
@@ -20,7 +20,7 @@ Oore CI supports three ways to trigger builds: manual triggers from the UI, webh
 3. Select the pipeline, branch, and optionally a specific commit
 4. Click **Start Build**
 
-The build enters `queued` state and is picked up by the next available runner.
+Oore resolves the selected branch to its current commit before the build enters `queued` state. The runner checks out that exact commit, and a rerun keeps the same commit even if the branch has moved.
 
 ## Webhook trigger
 
@@ -64,13 +64,13 @@ curl -X POST http://127.0.0.1:8787/v1/projects/{project_id}/builds \
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `pipeline_id` | `string` | Yes | ID of the pipeline to build |
-| `branch` | `string` | No | Branch to build (defaults to repository default) |
+| `branch` | `string` | No | Branch to resolve and build (defaults to repository default) |
 | `commit_sha` | `string` | No | Specific commit to build |
 | `trigger_ref` | `string` | No | Reference string (e.g., PR number) |
 
 ### Response `200 OK`
 
-Returns the created build object with its ID and initial `queued` status.
+Returns the created build object with its ID, resolved `commit_sha`, and initial `queued` status.
 
 ## Monitoring builds
 

--- a/apps/docs-site/docs/public/openapi.json
+++ b/apps/docs-site/docs/public/openapi.json
@@ -3124,6 +3124,102 @@
         ]
       }
     },
+    "/v1/projects/{project_id}/repository-workflows": {
+      "get": {
+        "tags": [
+          "Pipelines"
+        ],
+        "summary": "Discover repository-owned workflows",
+        "description": "Reads supported Oore workflow files from the linked repository without\nmodifying it. The response contains validated behavior but never raw YAML,\nenvironment values, or source credentials.",
+        "operationId": "discover_repository_workflows",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "description": "Project ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ref",
+            "in": "query",
+            "description": "Branch, tag, or commit; defaults to the project branch",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "description": "Additional explicit repository-relative config path",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Secret-free repository workflow previews",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiscoverRepositoryWorkflowsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ref or config path",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Manage Pipelines permission required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Project source not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Source provider request failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/v1/projects/{project_id}/retention": {
       "get": {
         "tags": [
@@ -7570,6 +7666,38 @@
           }
         }
       },
+      "DiscoverRepositoryWorkflowsResponse": {
+        "type": "object",
+        "required": [
+          "project_id",
+          "provider",
+          "reference",
+          "workflows",
+          "truncated"
+        ],
+        "properties": {
+          "project_id": {
+            "type": "string"
+          },
+          "provider": {
+            "$ref": "#/components/schemas/ScmProvider"
+          },
+          "reference": {
+            "type": "string",
+            "description": "Branch, tag, or commit requested for discovery."
+          },
+          "truncated": {
+            "type": "boolean",
+            "description": "True when more matching files existed than the bounded response could inspect."
+          },
+          "workflows": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RepositoryWorkflowPreview"
+            }
+          }
+        }
+      },
       "EffectiveProjectRetentionResponse": {
         "type": "object",
         "required": [
@@ -9475,6 +9603,86 @@
           "oidc",
           "trusted_proxy"
         ]
+      },
+      "RepositoryWorkflowExecutionPreview": {
+        "type": "object",
+        "description": "Pipeline behavior safe to show before import. Environment values are never returned.",
+        "required": [
+          "platforms",
+          "commands",
+          "platform_build_args",
+          "platform_commands",
+          "env_keys",
+          "artifact_patterns"
+        ],
+        "properties": {
+          "artifact_patterns": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "commands": {
+            "$ref": "#/components/schemas/PipelineCommandStages"
+          },
+          "env_keys": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "flutter_version": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "platform_build_args": {
+            "$ref": "#/components/schemas/PlatformBuildArgs"
+          },
+          "platform_commands": {
+            "$ref": "#/components/schemas/PlatformBuildCommands"
+          },
+          "platforms": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildPlatform"
+            }
+          }
+        }
+      },
+      "RepositoryWorkflowPreview": {
+        "type": "object",
+        "description": "Secret-free representation of a repository-owned pipeline config.",
+        "required": [
+          "path",
+          "valid",
+          "errors"
+        ],
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "execution": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RepositoryWorkflowExecutionPreview"
+              }
+            ]
+          },
+          "path": {
+            "type": "string"
+          },
+          "valid": {
+            "type": "boolean"
+          }
+        }
       },
       "RerunBuildResponse": {
         "type": "object",

--- a/apps/docs-site/docs/reference/api/builds.md
+++ b/apps/docs-site/docs/reference/api/builds.md
@@ -31,11 +31,13 @@ POST /v1/projects/{project_id}/builds
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `pipeline_id` | `string` | Yes | ID of the pipeline to build |
-| `branch` | `string` | No | Branch to build |
+| `branch` | `string` | No | Branch to resolve before queueing; defaults to the project's default branch |
 | `commit_sha` | `string` | No | Specific commit to build |
 | `trigger_ref` | `string` | No | Reference string (e.g., PR number) |
 
 ### Response `200 OK`
+
+When `commit_sha` is omitted, Oore resolves `branch` to its current commit before queueing and returns that SHA. Reruns retain the original SHA.
 
 ```json
 {

--- a/apps/web/src/components/pipeline-form.tsx
+++ b/apps/web/src/components/pipeline-form.tsx
@@ -74,6 +74,8 @@ interface PipelineFormProps {
   submitLabel: string
   isPending: boolean
   validationErrors?: Array<string>
+  /** Read-only repository workflow summary. When present, repository config owns execution fields. */
+  repositoryWorkflow?: React.ReactNode
   /** Content rendered after all form sections but before the sticky action bar */
   children?: React.ReactNode
   /** Local-mode repositories only support manual/API build triggers for now. */
@@ -266,6 +268,7 @@ export default function PipelineForm({
   submitLabel,
   isPending,
   validationErrors = [],
+  repositoryWorkflow,
   children,
   manualOnlyTriggers = false,
   readOnly = false,
@@ -387,13 +390,28 @@ export default function PipelineForm({
               <CardHeader>
                 <SectionHeader
                   title="Configuration"
-                  summary={`${platforms.length} platform${platforms.length !== 1 ? 's' : ''}, ${configMode === 'explicit' ? 'explicit config' : 'auto-detect'}`}
+                  summary={
+                    repositoryWorkflow
+                      ? 'Owned by repository'
+                      : `${platforms.length} platform${platforms.length !== 1 ? 's' : ''}, ${configMode === 'explicit' ? 'explicit config' : 'auto-detect'}`
+                  }
                   open={sections.config}
                 />
               </CardHeader>
             </CollapsibleTrigger>
             <CollapsibleContent>
-              <CardContent className="space-y-4">
+              <CardContent
+                className={
+                  repositoryWorkflow
+                    ? 'space-y-4 [&>:not(.repository-workflow-summary)]:hidden'
+                    : 'space-y-4'
+                }
+              >
+                {repositoryWorkflow ? (
+                  <div className="repository-workflow-summary">
+                    {repositoryWorkflow}
+                  </div>
+                ) : null}
                 <FormField
                   control={form.control}
                   name="config_mode"
@@ -644,6 +662,7 @@ export default function PipelineForm({
 
         {/* Build Commands section */}
         <Collapsible
+          className={repositoryWorkflow ? 'hidden' : undefined}
           open={sections.commands}
           onOpenChange={setSectionOpen('commands')}
         >
@@ -759,6 +778,7 @@ export default function PipelineForm({
 
         {/* Platform Build Args section */}
         <Collapsible
+          className={repositoryWorkflow ? 'hidden' : undefined}
           open={sections.platformArgs}
           onOpenChange={setSectionOpen('platformArgs')}
         >
@@ -905,7 +925,11 @@ export default function PipelineForm({
         </Collapsible>
 
         {/* Environment Variables section */}
-        <Collapsible open={sections.env} onOpenChange={setSectionOpen('env')}>
+        <Collapsible
+          className={repositoryWorkflow ? 'hidden' : undefined}
+          open={sections.env}
+          onOpenChange={setSectionOpen('env')}
+        >
           <Card>
             <CollapsibleTrigger className="w-full cursor-pointer">
               <CardHeader>
@@ -965,6 +989,7 @@ export default function PipelineForm({
 
         {/* Artifacts section */}
         <Collapsible
+          className={repositoryWorkflow ? 'hidden' : undefined}
           open={sections.artifacts}
           onOpenChange={setSectionOpen('artifacts')}
         >
@@ -1604,8 +1629,8 @@ export default function PipelineForm({
               <HugeiconsIcon icon={AlertCircleIcon} size={16} />
               <AlertDescription>
                 <ul className="list-disc space-y-1 pl-4">
-                  {validationErrors.map((err, index) => (
-                    <li key={index}>{err}</li>
+                  {validationErrors.map((err) => (
+                    <li key={err}>{err}</li>
                   ))}
                 </ul>
               </AlertDescription>

--- a/apps/web/src/hooks/use-pipelines.ts
+++ b/apps/web/src/hooks/use-pipelines.ts
@@ -10,6 +10,7 @@ import type {
 import {
   createPipeline,
   deletePipeline,
+  discoverRepositoryWorkflows,
   getPipeline,
   getPipelineAndroidSigning,
   getPipelineIosSigning,
@@ -58,6 +59,30 @@ export function usePipelines(
     ],
     queryFn: () => listPipelines(baseUrl!, token!, projectId, params),
     enabled: enabled && !!baseUrl && !!token && !!projectId,
+  })
+}
+
+export function useRepositoryWorkflows(
+  projectId: string,
+  params?: { reference?: string; path?: string },
+  options?: { enabled?: boolean },
+) {
+  const baseUrl = useBaseUrl()
+  const token = useAuthToken()
+  const instance = useActiveInstance()
+  const enabled = options?.enabled ?? true
+
+  return useQuery({
+    queryKey: [
+      instance?.id ?? '__none__',
+      'repository-workflows',
+      projectId,
+      params ?? {},
+    ],
+    queryFn: () =>
+      discoverRepositoryWorkflows(baseUrl!, token!, projectId, params),
+    enabled: enabled && !!baseUrl && !!token && !!projectId,
+    staleTime: 30_000,
   })
 }
 

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -5,6 +5,7 @@ import {
   configureExternalAccessOidc,
   configureOidc,
   createPipeline,
+  discoverRepositoryWorkflows,
   getApiErrorMessage,
   getArtifactStorageSettings,
   getExternalAccessOidc,
@@ -576,6 +577,34 @@ describe('external access oidc api', () => {
 })
 
 describe('pipeline api', () => {
+  it('discovers repository workflows at an encoded ref and path', async () => {
+    mockFetch.mockReturnValue(
+      mockJsonResponse(200, {
+        project_id: 'proj-1',
+        provider: 'gitlab',
+        reference: 'feature/mobile',
+        workflows: [],
+        truncated: false,
+      }),
+    )
+
+    await discoverRepositoryWorkflows(
+      'https://ci.example.com',
+      'session-token',
+      'proj-1',
+      { reference: 'feature/mobile', path: '.oore/android release.yaml' },
+    )
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://ci.example.com/v1/projects/proj-1/repository-workflows?ref=feature%2Fmobile&path=.oore%2Fandroid+release.yaml',
+      {
+        headers: {
+          Authorization: 'Bearer session-token',
+        },
+      },
+    )
+  })
+
   it('calls POST /v1/projects/{project_id}/pipelines with execution config fields', async () => {
     const payload = {
       pipeline: {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -23,6 +23,7 @@ import type {
   CreateScopedDownloadTokenRequest,
   CreateScopedDownloadTokenResponse,
   DeleteNotificationChannelResponse,
+  DiscoverRepositoryWorkflowsResponse,
   EffectiveProjectRetentionResponse,
   ExternalAccessNetworkSettingsResponse,
   ExternalAccessPreflightResponse,
@@ -1145,6 +1146,23 @@ export function listPipelines(
   return request<ListPipelinesResponse>(
     baseUrl,
     `/v1/projects/${projectId}/pipelines${qs ? `?${qs}` : ''}`,
+    { headers: authHeaders(token) },
+  )
+}
+
+export function discoverRepositoryWorkflows(
+  baseUrl: string,
+  token: string,
+  projectId: string,
+  params?: { reference?: string; path?: string },
+): Promise<DiscoverRepositoryWorkflowsResponse> {
+  const query = new URLSearchParams()
+  if (params?.reference) query.set('ref', params.reference)
+  if (params?.path) query.set('path', params.path)
+  const suffix = query.size > 0 ? `?${query.toString()}` : ''
+  return request<DiscoverRepositoryWorkflowsResponse>(
+    baseUrl,
+    `/v1/projects/${projectId}/repository-workflows${suffix}`,
     { headers: authHeaders(token) },
   )
 }

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -783,6 +783,31 @@ export interface PipelineExecutionConfig {
   artifact_patterns: Array<string>
 }
 
+export interface RepositoryWorkflowExecutionPreview {
+  platforms: Array<BuildPlatform>
+  flutter_version?: string
+  commands: PipelineCommandStages
+  platform_build_args: PlatformBuildArgs
+  platform_commands: PlatformBuildCommands
+  env_keys: Array<string>
+  artifact_patterns: Array<string>
+}
+
+export interface RepositoryWorkflowPreview {
+  path: string
+  valid: boolean
+  errors: Array<string>
+  execution?: RepositoryWorkflowExecutionPreview
+}
+
+export interface DiscoverRepositoryWorkflowsResponse {
+  project_id: string
+  provider: 'github' | 'gitlab' | 'local_git'
+  reference: string
+  workflows: Array<RepositoryWorkflowPreview>
+  truncated: boolean
+}
+
 export interface Pipeline {
   id: string
   project_id: string

--- a/apps/web/src/routes/projects/$projectId/index.tsx
+++ b/apps/web/src/routes/projects/$projectId/index.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/lib/instance-context'
 import { useBuilds } from '@/hooks/use-builds'
 import { useHasPermission } from '@/hooks/use-permissions'
-import { usePipelines } from '@/hooks/use-pipelines'
+import { usePipelines, useRepositoryWorkflows } from '@/hooks/use-pipelines'
 import {
   useDeleteProject,
   useProject,
@@ -232,6 +232,15 @@ function ProjectDetailPage() {
   const canDeleteProjects = useHasPermission('projects', 'delete')
   const canWritePipelines = useHasPermission('pipelines', 'write')
   const canTriggerBuild = useHasPermission('builds', 'write')
+  const shouldDiscoverWorkflows =
+    canWritePipelines &&
+    !!data?.project.repository_id &&
+    (pipelinesData?.pipelines.length ?? 0) === 0
+  const repositoryWorkflowsQuery = useRepositoryWorkflows(
+    projectId,
+    undefined,
+    { enabled: shouldDiscoverWorkflows },
+  )
 
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [dangerOpen, setDangerOpen] = useState(false)
@@ -400,7 +409,7 @@ function ProjectDetailPage() {
         {/* ---- Pipelines tab ---- */}
         <TabsContent value="pipelines">
           <div className="space-y-4 pt-2">
-            {canWritePipelines ? (
+            {canWritePipelines && pipelines.length > 0 ? (
               <div className="flex justify-end">
                 <Button
                   size="sm"
@@ -418,11 +427,58 @@ function ProjectDetailPage() {
             ) : null}
 
             {pipelines.length === 0 ? (
-              <p className="py-6 text-center text-sm text-muted-foreground">
-                {canWritePipelines
-                  ? 'No pipelines yet. Add one to start building.'
-                  : 'No pipelines yet. Ask a developer or admin to add one.'}
-              </p>
+              <Empty className="border p-8">
+                <EmptyHeader>
+                  <EmptyMedia variant="icon">
+                    {repositoryWorkflowsQuery.isLoading ? (
+                      <Spinner className="size-5" />
+                    ) : (
+                      <HugeiconsIcon icon={Add01Icon} />
+                    )}
+                  </EmptyMedia>
+                  <EmptyTitle>
+                    {repositoryWorkflowsQuery.isLoading
+                      ? 'Checking your repository'
+                      : repositoryWorkflowsQuery.data?.workflows.some(
+                            (workflow) => workflow.valid,
+                          )
+                        ? 'Your repository is ready'
+                        : 'Set up your first build'}
+                  </EmptyTitle>
+                  <EmptyDescription>
+                    {!canWritePipelines
+                      ? 'Ask a developer or admin to set up the first build.'
+                      : repositoryWorkflowsQuery.isLoading
+                        ? `Looking for Oore workflows on ${project.default_branch ?? 'the default branch'}...`
+                        : repositoryWorkflowsQuery.error
+                          ? 'Oore could not inspect the repository. Open setup to retry or continue manually.'
+                          : repositoryWorkflowsQuery.data?.workflows.some(
+                                (workflow) => workflow.valid,
+                              )
+                            ? 'Oore found a checked-in workflow. Review it, name the pipeline, and run your first build.'
+                            : 'Choose a clear starter for your app. Advanced build details stay out of the way until you need them.'}
+                  </EmptyDescription>
+                </EmptyHeader>
+                {canWritePipelines ? (
+                  <EmptyContent>
+                    <Button
+                      render={
+                        <Link
+                          to="/projects/$projectId/pipelines/new"
+                          params={{ projectId }}
+                        />
+                      }
+                    >
+                      <HugeiconsIcon icon={Add01Icon} />
+                      {repositoryWorkflowsQuery.data?.workflows.some(
+                        (workflow) => workflow.valid,
+                      )
+                        ? 'Use repository workflow'
+                        : 'Set up a build'}
+                    </Button>
+                  </EmptyContent>
+                ) : null}
+              </Empty>
             ) : (
               pipelines.map((pipeline) => {
                 const lb = lastBuildByPipeline.get(pipeline.id)

--- a/apps/web/src/routes/projects/$projectId/pipelines/new.tsx
+++ b/apps/web/src/routes/projects/$projectId/pipelines/new.tsx
@@ -1,10 +1,18 @@
 import { useRef, useState } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { HugeiconsIcon } from '@hugeicons/react'
+import {
+  AlertCircleIcon,
+  CheckmarkCircle02Icon,
+  File02Icon,
+  RefreshIcon,
+} from '@hugeicons/core-free-icons'
 import { toast } from 'sonner'
 
 import type {
   ConcurrencyPolicy,
   CreatePipelineRequest,
+  RepositoryWorkflowPreview,
   TriggerConfig,
   UpdatePipelineAndroidSigningRequest,
   UpdatePipelineIosSigningRequest,
@@ -16,6 +24,7 @@ import {
 } from '@/lib/instance-context'
 import {
   useCreatePipeline,
+  useRepositoryWorkflows,
   useUpdatePipelineAndroidSigning,
   useUpdatePipelineIosSigning,
   useValidatePipeline,
@@ -37,6 +46,11 @@ import PipelineForm from '@/components/pipeline-form'
 import { PageMeta } from '@/lib/seo'
 import { cn } from '@/lib/utils'
 import { READ_ONLY_REASON, isDemoMode } from '@/lib/demo-mode'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Spinner } from '@/components/ui/spinner'
 
 export const Route = createFileRoute('/projects/$projectId/pipelines/new')({
   staticData: { breadcrumbLabel: 'New Pipeline' },
@@ -158,10 +172,109 @@ const PIPELINE_TEMPLATES = [
   },
 ] as const
 
+function workflowDefaults(
+  workflow: RepositoryWorkflowPreview,
+): PipelineFormValues {
+  const execution = workflow.execution
+  const workflowName =
+    workflow.path
+      .split('/')
+      .at(-1)
+      ?.replace(/^\.oore\.?/, '')
+      .replace(/\.ya?ml$/, '')
+      .replaceAll('-', ' ')
+      .trim() || 'Repository workflow'
+
+  return {
+    ...emptyDefaults,
+    name:
+      workflow.path === '.oore.yaml' || workflow.path === '.oore.yml'
+        ? 'Repository workflow'
+        : workflowName.replace(/\b\w/g, (letter) => letter.toUpperCase()),
+    config_mode: 'explicit',
+    config_path: workflow.path,
+    platform_android: execution?.platforms.includes('android') ?? false,
+    platform_ios: execution?.platforms.includes('ios') ?? false,
+    platform_macos: execution?.platforms.includes('macos') ?? false,
+    flutter_version: execution?.flutter_version ?? '',
+    enable_customization: true,
+    pre_build_commands: execution?.commands.pre_build.join('\n') ?? '',
+    build_commands: execution?.commands.build.join('\n') ?? '',
+    post_build_commands: execution?.commands.post_build.join('\n') ?? '',
+    android_build_args: execution?.platform_build_args.android.join('\n') ?? '',
+    ios_build_args: execution?.platform_build_args.ios.join('\n') ?? '',
+    macos_build_args: execution?.platform_build_args.macos.join('\n') ?? '',
+    android_command_override: execution?.platform_commands.android ?? '',
+    ios_command_override: execution?.platform_commands.ios ?? '',
+    macos_command_override: execution?.platform_commands.macos ?? '',
+    artifact_patterns: execution?.artifact_patterns.join('\n') ?? '',
+  }
+}
+
+function RepositoryWorkflowSummary({
+  workflow,
+  reference,
+}: {
+  workflow: RepositoryWorkflowPreview
+  reference: string
+}) {
+  const execution = workflow.execution
+  if (!execution) return null
+  const commandCount =
+    execution.commands.pre_build.length +
+    execution.commands.build.length +
+    execution.commands.post_build.length +
+    Object.values(execution.platform_commands).filter(Boolean).length
+
+  return (
+    <div className="space-y-4">
+      <Alert>
+        <HugeiconsIcon icon={CheckmarkCircle02Icon} size={16} />
+        <AlertDescription>
+          Oore will read <code>{workflow.path}</code> from the exact commit
+          being built. This preview is from <code>{reference}</code>.
+        </AlertDescription>
+      </Alert>
+      <div className="grid gap-3 text-sm sm:grid-cols-2">
+        <div>
+          <p className="text-xs text-muted-foreground">Platforms</p>
+          <p>{execution.platforms.join(', ')}</p>
+        </div>
+        <div>
+          <p className="text-xs text-muted-foreground">Flutter</p>
+          <p>{execution.flutter_version ?? 'Detected from .fvmrc or runner'}</p>
+        </div>
+        <div>
+          <p className="text-xs text-muted-foreground">Commands</p>
+          <p>
+            {commandCount > 0
+              ? `${commandCount} configured`
+              : 'Platform defaults'}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs text-muted-foreground">Artifacts</p>
+          <p className="font-mono text-xs">
+            {execution.artifact_patterns.join(', ') || 'Platform defaults'}
+          </p>
+        </div>
+      </div>
+      {execution.env_keys.length > 0 ? (
+        <p className="text-xs text-muted-foreground">
+          Environment keys: {execution.env_keys.join(', ')}. Values stay hidden.
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
 function NewPipelinePage() {
   const { projectId } = Route.useParams()
   const navigate = useNavigate()
   const { data: projectData } = useProject(projectId)
+  const workflowsQuery = useRepositoryWorkflows(projectId, undefined, {
+    enabled: !!projectData?.project.repository_id,
+  })
   const repoProviderQuery = useRepositoryProvider(
     projectData?.project.repository_id,
   )
@@ -173,9 +286,38 @@ function NewPipelinePage() {
   const [validationErrors, setValidationErrors] = useState<Array<string>>([])
   const createdPipelineId = useRef<string | null>(null)
   const [selectedTemplate, setSelectedTemplate] = useState<string>('custom')
+  const [selectedWorkflowPath, setSelectedWorkflowPath] = useState<
+    string | null
+  >(null)
+  const [manualSetup, setManualSetup] = useState(false)
+  const { validWorkflows, invalidWorkflows } = (
+    workflowsQuery.data?.workflows ?? []
+  ).reduce<{
+    validWorkflows: Array<RepositoryWorkflowPreview>
+    invalidWorkflows: Array<RepositoryWorkflowPreview>
+  }>(
+    (groups, workflow) => {
+      groups[workflow.valid ? 'validWorkflows' : 'invalidWorkflows'].push(
+        workflow,
+      )
+      return groups
+    },
+    { validWorkflows: [], invalidWorkflows: [] },
+  )
+  const selectedWorkflow: RepositoryWorkflowPreview | undefined =
+    validWorkflows.find((workflow) => workflow.path === selectedWorkflowPath) ??
+    validWorkflows.at(0)
   const activeTemplate =
-    PIPELINE_TEMPLATES.find((t) => t.key === selectedTemplate) ??
-    PIPELINE_TEMPLATES[PIPELINE_TEMPLATES.length - 1]
+    !manualSetup && selectedWorkflow !== undefined
+      ? {
+          key: `repository:${selectedWorkflow.path}`,
+          label: selectedWorkflow.path,
+          description: 'Repository-owned workflow',
+          values: workflowDefaults(selectedWorkflow),
+          events: ['push'],
+        }
+      : (PIPELINE_TEMPLATES.find((t) => t.key === selectedTemplate) ??
+        PIPELINE_TEMPLATES[PIPELINE_TEMPLATES.length - 1])
 
   async function handleSubmit(
     data: PipelineFormValues,
@@ -234,15 +376,10 @@ function NewPipelinePage() {
 
     setValidationErrors([])
 
-    const signingPayload = await buildAndroidSigningPayload(
-      data,
-      releaseKeystoreFile,
-      debugKeystoreFile,
-    )
-    const iosSigningPayload = await buildIosSigningPayload(
-      data,
-      iosSigningFiles,
-    )
+    const [signingPayload, iosSigningPayload] = await Promise.all([
+      buildAndroidSigningPayload(data, releaseKeystoreFile, debugKeystoreFile),
+      buildIosSigningPayload(data, iosSigningFiles),
+    ])
     if (
       (data.android_signing_release_enabled ||
         data.android_signing_debug_enabled) &&
@@ -471,24 +608,25 @@ function NewPipelinePage() {
       return null
     }
 
-    const provisioningProfiles: Array<{
-      bundle_id: string
-      profile_filename?: string
-      profile_base64?: string
-    }> = []
-    for (const bundleId of bundleIds) {
-      const profileFile = iosSigningFiles.profileFiles[bundleId]
-      if (!profileFile) continue
-      provisioningProfiles.push({
-        bundle_id: bundleId,
-        profile_filename: profileFile.name,
-        profile_base64: await fileToBase64(profileFile),
-      })
-    }
-
-    const apiPrivateKey = iosSigningFiles.apiKeyFile
-      ? await fileToUtf8(iosSigningFiles.apiKeyFile)
-      : undefined
+    const [provisioningProfiles, apiPrivateKey] = await Promise.all([
+      Promise.all(
+        bundleIds.flatMap((bundleId) => {
+          const profileFile = iosSigningFiles.profileFiles[bundleId]
+          return profileFile
+            ? [
+                fileToBase64(profileFile).then((profile_base64) => ({
+                  bundle_id: bundleId,
+                  profile_filename: profileFile.name,
+                  profile_base64,
+                })),
+              ]
+            : []
+        }),
+      ),
+      iosSigningFiles.apiKeyFile
+        ? fileToUtf8(iosSigningFiles.apiKeyFile)
+        : Promise.resolve(undefined),
+    ])
 
     return {
       enabled: data.ios_signing_enabled,
@@ -523,56 +661,196 @@ function NewPipelinePage() {
     <PageLayout width="wide">
       <PageMeta title="New Pipeline" />
       <PageHeader
-        title="New Pipeline"
+        title="Set up a build"
         back={{ to: `/projects/${projectId}`, label: 'Project' }}
-        description="Configure a new build pipeline for this project."
+        description="Use the workflow already in your repository, or start with a guided template."
       />
       <div className="mx-auto mb-6 max-w-4xl">
-        <div className="space-y-2">
-          <p className="text-sm font-medium">Start from a template</p>
-          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
-            {PIPELINE_TEMPLATES.map((tmpl) => (
-              <button
-                key={tmpl.key}
+        {workflowsQuery.isLoading ? (
+          <Card>
+            <CardContent className="flex items-center gap-3 py-6 text-sm text-muted-foreground">
+              <Spinner className="size-4" />
+              Looking for Oore workflows on{' '}
+              {projectData?.project.default_branch ?? 'the default branch'}...
+            </CardContent>
+          </Card>
+        ) : workflowsQuery.error ? (
+          <Alert variant="destructive">
+            <HugeiconsIcon icon={AlertCircleIcon} size={16} />
+            <AlertDescription className="flex flex-wrap items-center justify-between gap-3">
+              <span>
+                Oore could not inspect this repository. Nothing has been
+                changed. {workflowsQuery.error.message}
+              </span>
+              <Button
                 type="button"
-                aria-pressed={selectedTemplate === tmpl.key}
-                onClick={() => setSelectedTemplate(tmpl.key)}
-                className={cn(
-                  'flex flex-col items-start gap-1 border p-3 text-left text-sm transition-colors hover:bg-accent',
-                  selectedTemplate === tmpl.key && 'border-primary bg-accent',
-                )}
+                size="sm"
+                variant="outline"
+                onClick={() => void workflowsQuery.refetch()}
               >
-                <span className="font-medium">{tmpl.label}</span>
-                <span className="text-xs text-muted-foreground">
-                  {tmpl.description}
-                </span>
-              </button>
-            ))}
+                <HugeiconsIcon icon={RefreshIcon} />
+                Retry
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={() => setManualSetup(true)}
+              >
+                Continue manually
+              </Button>
+            </AlertDescription>
+          </Alert>
+        ) : validWorkflows.length > 0 && !manualSetup ? (
+          <Card>
+            <CardHeader className="gap-2">
+              <div className="flex items-center justify-between gap-3">
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <HugeiconsIcon icon={File02Icon} size={18} />
+                  Repository workflow found
+                </CardTitle>
+                <Badge variant="secondary">
+                  {workflowsQuery.data?.reference}
+                </Badge>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                This is the reproducible setup checked into your repository, so
+                Oore recommends using it.
+              </p>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {validWorkflows.length > 1 ? (
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {validWorkflows.map((workflow) => (
+                    <Button
+                      key={workflow.path}
+                      type="button"
+                      variant={
+                        (selectedWorkflowPath ?? validWorkflows.at(0)?.path) ===
+                        workflow.path
+                          ? 'secondary'
+                          : 'outline'
+                      }
+                      className="justify-start font-mono"
+                      onClick={() => setSelectedWorkflowPath(workflow.path)}
+                    >
+                      <HugeiconsIcon icon={File02Icon} />
+                      {workflow.path}
+                    </Button>
+                  ))}
+                </div>
+              ) : null}
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => setManualSetup(true)}
+              >
+                Set up manually instead
+              </Button>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-3">
+            {invalidWorkflows.length > 0 ? (
+              <Alert variant="destructive">
+                <HugeiconsIcon icon={AlertCircleIcon} size={16} />
+                <AlertDescription>
+                  Oore found repository workflow files, but they need attention:
+                  <ul className="mt-2 list-disc pl-5">
+                    {invalidWorkflows.map((workflow) => (
+                      <li key={workflow.path}>
+                        <code>{workflow.path}</code>:{' '}
+                        {workflow.errors.join('; ')}
+                      </li>
+                    ))}
+                  </ul>
+                </AlertDescription>
+              </Alert>
+            ) : !manualSetup ? (
+              <Alert>
+                <HugeiconsIcon icon={File02Icon} size={16} />
+                <AlertDescription>
+                  No Oore workflow was found on{' '}
+                  <code>{workflowsQuery.data?.reference}</code>. Choose a
+                  starter below; you can move the configuration into{' '}
+                  <code>.oore.yaml</code> later.
+                </AlertDescription>
+              </Alert>
+            ) : null}
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-sm font-medium">Choose a starting point</p>
+              {manualSetup && validWorkflows.length > 0 ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setManualSetup(false)}
+                >
+                  Use repository workflow
+                </Button>
+              ) : null}
+            </div>
+            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+              {PIPELINE_TEMPLATES.map((tmpl) => (
+                <button
+                  key={tmpl.key}
+                  type="button"
+                  aria-pressed={selectedTemplate === tmpl.key}
+                  onClick={() => setSelectedTemplate(tmpl.key)}
+                  className={cn(
+                    'flex flex-col items-start gap-1 border p-3 text-left text-sm transition-colors hover:bg-accent',
+                    selectedTemplate === tmpl.key && 'border-primary bg-accent',
+                  )}
+                >
+                  <span className="font-medium">{tmpl.label}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {tmpl.description}
+                  </span>
+                </button>
+              ))}
+            </div>
           </div>
+        )}
+      </div>
+      {(!workflowsQuery.isLoading || manualSetup) &&
+      (!workflowsQuery.error || manualSetup) ? (
+        <div className="mx-auto max-w-4xl">
+          <PipelineForm
+            key={activeTemplate.key}
+            initialValues={activeTemplate.values}
+            initialEvents={manualOnlyTriggers ? [] : [...activeTemplate.events]}
+            initialCancelPrevious={true}
+            manualOnlyTriggers={manualOnlyTriggers}
+            onSubmit={handleSubmit}
+            onCancel={() =>
+              void navigate({
+                to: '/projects/$projectId',
+                params: { projectId },
+              })
+            }
+            submitLabel="Create"
+            isPending={
+              createMutation.isPending ||
+              updateSigningMutation.isPending ||
+              updateIosSigningMutation.isPending
+            }
+            validationErrors={validationErrors}
+            repositoryWorkflow={
+              !manualSetup &&
+              selectedWorkflow !== undefined &&
+              workflowsQuery.data !== undefined ? (
+                <RepositoryWorkflowSummary
+                  workflow={selectedWorkflow}
+                  reference={workflowsQuery.data.reference}
+                />
+              ) : undefined
+            }
+            readOnly={isDemoMode}
+            readOnlyReason={READ_ONLY_REASON}
+          />
         </div>
-      </div>
-      <div className="mx-auto max-w-4xl">
-        <PipelineForm
-          key={selectedTemplate}
-          initialValues={activeTemplate.values}
-          initialEvents={manualOnlyTriggers ? [] : [...activeTemplate.events]}
-          initialCancelPrevious={true}
-          manualOnlyTriggers={manualOnlyTriggers}
-          onSubmit={handleSubmit}
-          onCancel={() =>
-            void navigate({ to: '/projects/$projectId', params: { projectId } })
-          }
-          submitLabel="Create"
-          isPending={
-            createMutation.isPending ||
-            updateSigningMutation.isPending ||
-            updateIosSigningMutation.isPending
-          }
-          validationErrors={validationErrors}
-          readOnly={isDemoMode}
-          readOnlyReason={READ_ONLY_REASON}
-        />
-      </div>
+      ) : null}
     </PageLayout>
   )
 }

--- a/crates/oore-contract/src/lib.rs
+++ b/crates/oore-contract/src/lib.rs
@@ -1839,6 +1839,40 @@ pub struct PipelineExecutionConfig {
     pub artifact_patterns: Vec<String>,
 }
 
+/// Secret-free representation of a repository-owned pipeline config.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct RepositoryWorkflowPreview {
+    pub path: String,
+    pub valid: bool,
+    pub errors: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution: Option<RepositoryWorkflowExecutionPreview>,
+}
+
+/// Pipeline behavior safe to show before import. Environment values are never returned.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct RepositoryWorkflowExecutionPreview {
+    pub platforms: Vec<BuildPlatform>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flutter_version: Option<String>,
+    pub commands: PipelineCommandStages,
+    pub platform_build_args: PlatformBuildArgs,
+    pub platform_commands: PlatformBuildCommands,
+    pub env_keys: Vec<String>,
+    pub artifact_patterns: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct DiscoverRepositoryWorkflowsResponse {
+    pub project_id: String,
+    pub provider: ScmProvider,
+    /// Branch, tag, or commit requested for discovery.
+    pub reference: String,
+    pub workflows: Vec<RepositoryWorkflowPreview>,
+    /// True when more matching files existed than the bounded response could inspect.
+    pub truncated: bool,
+}
+
 fn default_platforms() -> Vec<BuildPlatform> {
     vec![BuildPlatform::Android]
 }
@@ -1936,6 +1970,29 @@ pub fn validate_artifact_pattern(pattern: &str) -> Result<(), String> {
         return Err("must be a workspace-relative path using '/' separators".to_string());
     }
     if pattern
+        .split('/')
+        .any(|part| part.is_empty() || part == "." || part == "..")
+    {
+        return Err("must not contain empty, '.' or '..' path segments".to_string());
+    }
+    Ok(())
+}
+
+pub fn validate_repository_config_path(path: &str) -> Result<(), String> {
+    let path = path.trim();
+    if path.is_empty() {
+        return Err("must not be empty".to_string());
+    }
+    if path.len() > 512 {
+        return Err("is too long (max 512 chars)".to_string());
+    }
+    if path.starts_with('/') {
+        return Err("must be a repository-relative path".to_string());
+    }
+    if path.contains('\\') {
+        return Err("must use '/' separators".to_string());
+    }
+    if path
         .split('/')
         .any(|part| part.is_empty() || part == "." || part == "..")
     {
@@ -2770,6 +2827,25 @@ artifacts:
         )
         .expect_err("parent traversal must fail");
         assert!(traversal.contains("'..'"));
+    }
+
+    #[test]
+    fn repository_config_paths_must_stay_within_the_checkout() {
+        for path in [".oore.yaml", ".oore/mobile.yaml", "ci/release.yml"] {
+            assert!(validate_repository_config_path(path).is_ok(), "{path}");
+        }
+
+        for path in [
+            "",
+            "/etc/oore.yaml",
+            "../.oore.yaml",
+            "./.oore.yaml",
+            ".oore//mobile.yaml",
+            ".oore\\mobile.yaml",
+            &"a".repeat(513),
+        ] {
+            assert!(validate_repository_config_path(path).is_err(), "{path}");
+        }
     }
 
     #[test]

--- a/crates/oore-runner/src/lib.rs
+++ b/crates/oore-runner/src/lib.rs
@@ -12,6 +12,7 @@ use oore_contract::{
     PlatformBuildCommands, RUNNER_PROTOCOL_VERSION, RunnerAndroidSigningProfile,
     RunnerAndroidSigningResponse, RunnerIosSigningBundle, RunnerIosSigningResponse, StepResult,
     artifact_pattern_matches, parse_repository_pipeline_yaml, validate_artifact_pattern,
+    validate_repository_config_path,
 };
 use rand::RngCore;
 use sha2::{Digest, Sha256};
@@ -1531,17 +1532,35 @@ fn resolve_execution_plan(
         .to_string();
 
     let candidate_paths: Vec<String> = if config_path_explicit {
+        validate_repository_config_path(&snapshot_config_path)
+            .map_err(|error| anyhow::anyhow!("Invalid explicit repository config path: {error}"))?;
         vec![snapshot_config_path]
     } else {
         AUTO_CONFIG_PATHS.iter().map(|p| p.to_string()).collect()
     };
 
     let fvmrc_version = read_fvmrc_version(workspace)?;
+    let canonical_workspace = workspace
+        .canonicalize()
+        .map_err(|error| anyhow::anyhow!("Failed to resolve build workspace: {error}"))?;
 
     for rel_path in &candidate_paths {
         let full_path = workspace.join(rel_path);
         if !full_path.exists() {
             continue;
+        }
+
+        let canonical_path = full_path.canonicalize().map_err(|error| {
+            anyhow::anyhow!(
+                "Failed to resolve repository config file {}: {error}",
+                full_path.display()
+            )
+        })?;
+        if !canonical_path.starts_with(&canonical_workspace) {
+            anyhow::bail!(
+                "Repository config path resolves outside the build workspace: {}",
+                full_path.display()
+            );
         }
 
         let content = fs::read_to_string(&full_path).map_err(|e| {
@@ -3298,6 +3317,12 @@ mod tests {
     fn checkout_sha_materializes_nested_submodules() {
         let fixture_root = temp_workspace();
         let fixture = create_nested_submodule_fixture(&fixture_root);
+        add_commit(
+            &fixture.root_repo,
+            "AFTER_PIN.md",
+            "created after the build was queued\n",
+            "advance branch after pin",
+        );
         let workspace = fixture_root.join("checkout-sha");
         fs::create_dir_all(&workspace).expect("create checkout workspace");
 
@@ -3315,6 +3340,7 @@ mod tests {
         );
 
         assert!(workspace.join("deps/child/README.md").exists());
+        assert!(!workspace.join("AFTER_PIN.md").exists());
         assert!(
             workspace
                 .join("deps/child/deps/grandchild/README.md")
@@ -3517,6 +3543,50 @@ mod tests {
         assert_eq!(plan.artifact_patterns, vec!["*.zip".to_string()]);
 
         cleanup_workspace(&workspace);
+    }
+
+    #[test]
+    fn explicit_config_path_must_stay_within_workspace() {
+        let workspace = temp_workspace();
+        let snapshot = serde_json::json!({
+            "config_path_explicit": true,
+            "config_path": "../outside.oore.yaml",
+        });
+
+        let error = resolve_execution_plan(&workspace, &snapshot).expect_err("path must fail");
+        assert!(
+            error
+                .to_string()
+                .contains("Invalid explicit repository config path")
+        );
+
+        cleanup_workspace(&workspace);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn repository_config_symlink_must_stay_within_workspace() {
+        let workspace = temp_workspace();
+        let outside = temp_workspace();
+        let outside_config = outside.join(".oore.yaml");
+        fs::write(
+            &outside_config,
+            "version: 1\nplatforms: [android]\nartifacts:\n  patterns: [\"*.apk\"]\n",
+        )
+        .expect("write outside config");
+        std::os::unix::fs::symlink(&outside_config, workspace.join(".oore.yaml"))
+            .expect("link outside config");
+
+        let error = resolve_execution_plan(&workspace, &serde_json::json!({}))
+            .expect_err("symlink escape must fail");
+        assert!(
+            error
+                .to_string()
+                .contains("resolves outside the build workspace")
+        );
+
+        cleanup_workspace(&workspace);
+        cleanup_workspace(&outside);
     }
 
     #[test]

--- a/crates/oored/src/bin/openapi_export.rs
+++ b/crates/oored/src/bin/openapi_export.rs
@@ -98,6 +98,7 @@ use utoipa::OpenApi;
         paths::get_project,
         paths::update_project,
         paths::delete_project,
+        paths::discover_repository_workflows,
         // ── Project Members ──
         paths::list_project_members,
         paths::add_project_member,
@@ -248,6 +249,9 @@ use utoipa::OpenApi;
         oore_contract::UpdateProjectRequest,
         oore_contract::ProjectDetailResponse,
         oore_contract::ListProjectsResponse,
+        oore_contract::RepositoryWorkflowExecutionPreview,
+        oore_contract::RepositoryWorkflowPreview,
+        oore_contract::DiscoverRepositoryWorkflowsResponse,
         // Project Members
         oore_contract::ProjectRole,
         oore_contract::ProjectMember,
@@ -1335,6 +1339,28 @@ mod paths {
         )
     )]
     pub(super) async fn remove_project_member() {}
+
+    /// Discover repository-owned workflows
+    ///
+    /// Reads supported Oore workflow files from the linked repository without
+    /// modifying it. The response contains validated behavior but never raw YAML,
+    /// environment values, or source credentials.
+    #[utoipa::path(get, path = "/v1/projects/{project_id}/repository-workflows", tag = "Pipelines",
+        params(
+            ("project_id" = String, Path, description = "Project ID"),
+            ("ref" = Option<String>, Query, description = "Branch, tag, or commit; defaults to the project branch"),
+            ("path" = Option<String>, Query, description = "Additional explicit repository-relative config path"),
+        ),
+        security(("bearer_auth" = [])),
+        responses(
+            (status = 200, description = "Secret-free repository workflow previews", body = DiscoverRepositoryWorkflowsResponse),
+            (status = 400, description = "Invalid ref or config path", body = ApiError),
+            (status = 403, description = "Manage Pipelines permission required", body = ApiError),
+            (status = 404, description = "Project source not found", body = ApiError),
+            (status = 502, description = "Source provider request failed", body = ApiError),
+        )
+    )]
+    pub(super) async fn discover_repository_workflows() {}
 
     // ── Pipelines ──
 

--- a/crates/oored/src/builds.rs
+++ b/crates/oored/src/builds.rs
@@ -456,11 +456,13 @@ pub async fn create_build(
     Path(project_id): Path<String>,
     Json(req): Json<CreateBuildRequest>,
 ) -> ApiResult<CreateBuildResponse> {
-    let store = state.store.lock().await;
-    let pool = store.pool();
+    let pool = {
+        let store = state.store.lock().await;
+        store.pool().clone()
+    };
 
     let effective = resolve_effective_project_role(
-        pool,
+        &pool,
         &auth.0.user_id,
         &auth.0.role,
         &project_id,
@@ -470,14 +472,14 @@ pub async fn create_build(
     require_project_permission(&effective, ProjectPermission::TriggerBuild)?;
 
     let requested_branch = normalize_optional(req.branch);
-    let commit_sha = normalize_optional(req.commit_sha);
+    let mut commit_sha = normalize_optional(req.commit_sha);
     let trigger_ref = normalize_optional(req.trigger_ref);
 
     // Verify project exists and has source linkage.
     let project_row =
         sqlx::query("SELECT repository_id, default_branch FROM projects WHERE id = ?1")
             .bind(&project_id)
-            .fetch_optional(pool)
+            .fetch_optional(&pool)
             .await
             .map_err(|e| {
                 error!(error = %e, "failed to fetch project");
@@ -521,7 +523,7 @@ pub async fn create_build(
     )
     .bind(&req.pipeline_id)
     .bind(&project_id)
-    .fetch_optional(pool)
+    .fetch_optional(&pool)
     .await
     .map_err(|e| {
         error!(error = %e, "failed to fetch pipeline");
@@ -539,10 +541,24 @@ pub async fn create_build(
     let concurrency: ConcurrencyPolicy =
         serde_json::from_str(&concurrency_json).unwrap_or_default();
 
+    if commit_sha.is_none() {
+        commit_sha = Some(
+            crate::integrations::resolve_branch_commit(
+                &pool,
+                &state.encryption_key,
+                repository_id
+                    .as_deref()
+                    .expect("repository linkage checked"),
+                branch.as_deref().expect("branch presence checked"),
+            )
+            .await?,
+        );
+    }
+
     // Apply cancel_previous policy
     if concurrency.cancel_previous {
         let canceled = apply_cancel_previous(
-            pool,
+            &pool,
             &req.pipeline_id,
             branch.as_deref(),
             Some(&auth.0.email),
@@ -572,7 +588,7 @@ pub async fn create_build(
          WHERE p.id = ?1",
     )
     .bind(&project_id)
-    .fetch_optional(pool)
+    .fetch_optional(&pool)
     .await
     .map_err(|e| {
         error!(error = %e, project_id = %project_id, "failed to resolve project repository URL");
@@ -610,7 +626,7 @@ pub async fn create_build(
 
     let snapshot_str = config_snapshot.to_string();
     insert_build_with_retry(
-        pool,
+        &pool,
         &BuildInsertBinds {
             build_id: &build_id,
             project_id: &project_id,
@@ -629,7 +645,7 @@ pub async fn create_build(
     )
     .await?;
 
-    let build_number = fetch_build_number(pool, &build_id).await?;
+    let build_number = fetch_build_number(&pool, &build_id).await?;
 
     // Insert initial build event
     sqlx::query(
@@ -640,7 +656,7 @@ pub async fn create_build(
     .bind(&build_id)
     .bind(&auth.0.email)
     .bind(now)
-    .execute(pool)
+    .execute(&pool)
     .await
     .map_err(|e| {
         error!(error = %e, "failed to insert initial build event");
@@ -656,7 +672,7 @@ pub async fn create_build(
     })
     .to_string();
     let _ = write_audit_log(
-        pool,
+        &pool,
         Some(&auth.0.user_id),
         "build_created",
         "build",

--- a/crates/oored/src/integrations/github.rs
+++ b/crates/oored/src/integrations/github.rs
@@ -940,6 +940,190 @@ fn generate_github_jwt(
     })
 }
 
+async fn installation_access_token(
+    client: &reqwest::Client,
+    app_id: &str,
+    private_key: &str,
+    installation_id: &str,
+) -> Result<String, (StatusCode, Json<ApiError>)> {
+    let jwt = generate_github_jwt(app_id, private_key)?;
+    let response = client
+        .post(format!(
+            "https://api.github.com/app/installations/{installation_id}/access_tokens"
+        ))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .header("Accept", "application/vnd.github+json")
+        .header("User-Agent", "oore-ci")
+        .send()
+        .await
+        .map_err(|e| {
+            error!(error = %e, "failed to get GitHub installation access token");
+            api_err(
+                StatusCode::BAD_GATEWAY,
+                "github_api_error",
+                "Failed to authenticate with GitHub",
+            )
+        })?;
+    if !response.status().is_success() {
+        return Err(api_err(
+            StatusCode::BAD_GATEWAY,
+            "github_api_error",
+            format!("GitHub returned {} for access token", response.status()),
+        ));
+    }
+
+    #[derive(Deserialize)]
+    struct TokenResponse {
+        token: String,
+    }
+
+    response
+        .json::<TokenResponse>()
+        .await
+        .map(|response| response.token)
+        .map_err(|e| {
+            error!(error = %e, "failed to parse GitHub access token response");
+            api_err(
+                StatusCode::BAD_GATEWAY,
+                "github_parse_error",
+                "Failed to parse GitHub response",
+            )
+        })
+}
+
+pub(crate) async fn load_installation_access_token(
+    client: &reqwest::Client,
+    pool: &sqlx::SqlitePool,
+    encryption_key: &[u8],
+    integration_id: &str,
+    installation_id: &str,
+) -> Result<String, (StatusCode, Json<ApiError>)> {
+    let row = sqlx::query(
+        "SELECT i.app_id, c.encrypted_value FROM integrations i \
+         JOIN integration_credentials c ON c.integration_id = i.id \
+         WHERE i.id = ?1 AND c.credential_type = 'app_private_key'",
+    )
+    .bind(integration_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| {
+        error!(error = %e, "failed to load GitHub credentials");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to load source credentials",
+        )
+    })?
+    .ok_or_else(|| {
+        api_err(
+            StatusCode::CONFLICT,
+            "missing_credentials",
+            "GitHub credentials are missing; reconnect the source",
+        )
+    })?;
+    let app_id: Option<String> = row.get("app_id");
+    let encrypted_key: String = row.get("encrypted_value");
+    let private_key = crypto::decrypt(&encrypted_key, encryption_key).map_err(|e| {
+        error!(error = %e, "failed to decrypt GitHub credentials");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "encryption_error",
+            "Failed to decrypt source credentials",
+        )
+    })?;
+    installation_access_token(
+        client,
+        app_id.as_deref().ok_or_else(|| {
+            api_err(
+                StatusCode::CONFLICT,
+                "missing_credentials",
+                "GitHub App ID is missing; reconnect the source",
+            )
+        })?,
+        &private_key,
+        installation_id,
+    )
+    .await
+}
+
+pub(crate) async fn resolve_branch_commit(
+    pool: &sqlx::SqlitePool,
+    encryption_key: &[u8],
+    integration_id: &str,
+    installation_id: &str,
+    full_name: &str,
+    branch: &str,
+) -> Result<String, (StatusCode, Json<ApiError>)> {
+    let client = build_http_client().map_err(|e| {
+        error!(error = %e, "failed to build GitHub client");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "http_client_error",
+            "Failed to create GitHub client",
+        )
+    })?;
+    let token = load_installation_access_token(
+        &client,
+        pool,
+        encryption_key,
+        integration_id,
+        installation_id,
+    )
+    .await?;
+    let response = client
+        .get(format!(
+            "https://api.github.com/repos/{full_name}/commits/{}",
+            urlencoding::encode(branch)
+        ))
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Accept", "application/vnd.github+json")
+        .header("User-Agent", "oore-ci")
+        .send()
+        .await
+        .map_err(|e| {
+            error!(error = %e, "failed to resolve GitHub branch");
+            api_err(
+                StatusCode::BAD_GATEWAY,
+                "github_api_error",
+                "Failed to resolve the GitHub branch",
+            )
+        })?;
+    if response.status() == StatusCode::NOT_FOUND {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "invalid_ref",
+            format!("Branch '{branch}' was not found in the linked repository"),
+        ));
+    }
+    if !response.status().is_success() {
+        return Err(api_err(
+            StatusCode::BAD_GATEWAY,
+            "github_api_error",
+            format!(
+                "GitHub returned {} while resolving the branch",
+                response.status()
+            ),
+        ));
+    }
+
+    #[derive(Deserialize)]
+    struct CommitResponse {
+        sha: String,
+    }
+    response
+        .json::<CommitResponse>()
+        .await
+        .map(|response| response.sha)
+        .map_err(|e| {
+            error!(error = %e, "failed to parse GitHub commit response");
+            api_err(
+                StatusCode::BAD_GATEWAY,
+                "github_parse_error",
+                "Failed to parse GitHub commit response",
+            )
+        })
+}
+
 /// Core sync logic — fetches installations and repos from GitHub, upserts them,
 /// and removes stale records that are no longer present on GitHub.
 ///
@@ -1146,52 +1330,17 @@ async fn sync_installation_repos(
     installation_id_internal: &str,
     now: i64,
 ) -> Result<(), (StatusCode, Json<ApiError>)> {
-    let jwt = generate_github_jwt(app_id, private_key)?;
-
-    let token_resp = client
-        .post(format!(
-            "https://api.github.com/app/installations/{installation_id_external}/access_tokens"
-        ))
-        .header("Authorization", format!("Bearer {jwt}"))
-        .header("Accept", "application/vnd.github+json")
-        .header("User-Agent", "oore-ci")
-        .send()
-        .await
-        .map_err(|e| {
-            error!(error = %e, "failed to get installation access token");
-            api_err(
-                StatusCode::BAD_GATEWAY,
-                "github_api_error",
-                "Failed to get access token",
-            )
-        })?;
-
-    if !token_resp.status().is_success() {
-        let status = token_resp.status();
-        return Err(api_err(
-            StatusCode::BAD_GATEWAY,
-            "github_api_error",
-            format!("GitHub returned {status} for access token"),
-        ));
-    }
-
-    #[derive(Deserialize)]
-    struct TokenResponse {
-        token: String,
-    }
-
-    let token: TokenResponse = token_resp.json().await.map_err(|e| {
-        error!(error = %e, "failed to parse access token response");
-        api_err(
-            StatusCode::BAD_GATEWAY,
-            "github_parse_error",
-            "Failed to parse token response",
-        )
-    })?;
+    let token = installation_access_token(
+        client,
+        app_id,
+        private_key,
+        &installation_id_external.to_string(),
+    )
+    .await?;
 
     let repos_resp = client
         .get("https://api.github.com/installation/repositories?per_page=100")
-        .header("Authorization", format!("token {}", token.token))
+        .header("Authorization", format!("token {token}"))
         .header("Accept", "application/vnd.github+json")
         .header("User-Agent", "oore-ci")
         .send()

--- a/crates/oored/src/integrations/gitlab.rs
+++ b/crates/oored/src/integrations/gitlab.rs
@@ -37,6 +37,118 @@ fn build_http_client() -> Result<reqwest::Client, reqwest::Error> {
         .build()
 }
 
+async fn access_token(
+    pool: &sqlx::SqlitePool,
+    encryption_key: &[u8],
+    integration_id: &str,
+) -> Result<String, (StatusCode, Json<ApiError>)> {
+    let encrypted: Option<String> = sqlx::query_scalar(
+        "SELECT encrypted_value FROM integration_credentials \
+         WHERE integration_id = ?1 AND credential_type = 'access_token'",
+    )
+    .bind(integration_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| {
+        error!(error = %e, "failed to fetch GitLab access token");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to fetch source credentials",
+        )
+    })?;
+    let encrypted = encrypted.ok_or_else(|| {
+        api_err(
+            StatusCode::CONFLICT,
+            "missing_credentials",
+            "GitLab access token is missing; reconnect or re-authorize the source",
+        )
+    })?;
+    crypto::decrypt(&encrypted, encryption_key).map_err(|e| {
+        error!(error = %e, "failed to decrypt GitLab access token");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "encryption_error",
+            "Failed to decrypt source credentials",
+        )
+    })
+}
+
+pub(crate) async fn resolve_branch_commit(
+    pool: &sqlx::SqlitePool,
+    encryption_key: &[u8],
+    integration_id: &str,
+    host_url: &str,
+    auth_mode: &str,
+    repository_external_id: &str,
+    branch: &str,
+) -> Result<String, (StatusCode, Json<ApiError>)> {
+    let token = access_token(pool, encryption_key, integration_id).await?;
+    let client = build_http_client().map_err(|e| {
+        error!(error = %e, "failed to build GitLab client");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "http_client_error",
+            "Failed to create GitLab client",
+        )
+    })?;
+    let mut request = client
+        .get(format!(
+            "{}/api/v4/projects/{}/repository/commits/{}",
+            host_url.trim_end_matches('/'),
+            urlencoding::encode(repository_external_id),
+            urlencoding::encode(branch)
+        ))
+        .header("User-Agent", "oore-ci");
+    request = if auth_mode == "oauth_app" {
+        request.header("Authorization", format!("Bearer {token}"))
+    } else {
+        request.header("PRIVATE-TOKEN", token)
+    };
+    let response = request.send().await.map_err(|e| {
+        error!(error = %e, "failed to resolve GitLab branch");
+        api_err(
+            StatusCode::BAD_GATEWAY,
+            "gitlab_api_error",
+            "Failed to resolve the GitLab branch",
+        )
+    })?;
+    if response.status() == StatusCode::NOT_FOUND {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "invalid_ref",
+            format!("Branch '{branch}' was not found in the linked repository"),
+        ));
+    }
+    if !response.status().is_success() {
+        return Err(api_err(
+            StatusCode::BAD_GATEWAY,
+            "gitlab_api_error",
+            format!(
+                "GitLab returned {} while resolving the branch",
+                response.status()
+            ),
+        ));
+    }
+
+    #[derive(Deserialize)]
+    struct CommitResponse {
+        id: String,
+    }
+    response
+        .json::<CommitResponse>()
+        .await
+        .map(|response| response.id)
+        .map_err(|e| {
+            error!(error = %e, "failed to parse GitLab commit response");
+            api_err(
+                StatusCode::BAD_GATEWAY,
+                "gitlab_parse_error",
+                "Failed to parse GitLab commit response",
+            )
+        })
+}
+
 fn normalize_gitlab_host_url(raw: &str) -> Result<String, (StatusCode, Json<ApiError>)> {
     let parsed = url::Url::parse(raw.trim()).map_err(|_| {
         api_err(
@@ -143,38 +255,7 @@ pub(crate) async fn perform_sync_installations(
     let auth_mode: String = row.get("auth_mode");
     let use_bearer_auth = auth_mode == "oauth_app";
 
-    let encrypted_access_token: Option<String> = sqlx::query_scalar(
-        "SELECT encrypted_value FROM integration_credentials \
-         WHERE integration_id = ?1 AND credential_type = 'access_token'",
-    )
-    .bind(integration_id)
-    .fetch_optional(pool)
-    .await
-    .map_err(|e| {
-        error!(error = %e, "failed to fetch GitLab access token");
-        api_err(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "store_error",
-            "Failed to fetch credentials",
-        )
-    })?;
-
-    let encrypted_access_token = encrypted_access_token.ok_or_else(|| {
-        api_err(
-            StatusCode::CONFLICT,
-            "missing_credentials",
-            "GitLab access token is missing; re-connect or re-authorize the integration",
-        )
-    })?;
-
-    let token = crypto::decrypt(&encrypted_access_token, encryption_key).map_err(|e| {
-        error!(error = %e, "failed to decrypt GitLab access token");
-        api_err(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "encryption_error",
-            "Failed to decrypt credentials",
-        )
-    })?;
+    let token = access_token(pool, encryption_key, integration_id).await?;
 
     let installation_rows = sqlx::query(
         "SELECT * FROM integration_installations WHERE integration_id = ?1 ORDER BY created_at DESC",

--- a/crates/oored/src/integrations/local_git.rs
+++ b/crates/oored/src/integrations/local_git.rs
@@ -102,6 +102,60 @@ fn resolve_default_branch(path: &std::path::Path) -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
+pub(crate) async fn resolve_branch_commit(
+    repo_path: &str,
+    branch: &str,
+) -> Result<String, (StatusCode, Json<ApiError>)> {
+    let repo_path = repo_path.to_string();
+    let branch = branch.to_string();
+    tokio::task::spawn_blocking(move || {
+        let output = Command::new("git")
+            .args([
+                "-C",
+                repo_path.as_str(),
+                "rev-parse",
+                "--verify",
+                &format!("refs/heads/{branch}^{{commit}}"),
+            ])
+            .output()
+            .map_err(|e| {
+                error!(error = %e, "failed to resolve local git branch");
+                api_err(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "git_error",
+                    "Failed to inspect the local repository",
+                )
+            })?;
+        if !output.status.success() {
+            return Err(api_err(
+                StatusCode::BAD_REQUEST,
+                "invalid_ref",
+                format!("Branch '{branch}' was not found in the linked repository"),
+            ));
+        }
+        String::from_utf8(output.stdout)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                api_err(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "git_error",
+                    "Git returned an invalid commit identifier",
+                )
+            })
+    })
+    .await
+    .map_err(|e| {
+        error!(error = %e, "local git branch resolution task failed");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "git_error",
+            "Failed to inspect the local repository",
+        )
+    })?
+}
+
 struct LocalGitRepoInspection {
     canonical_str: String,
     default_branch: Option<String>,

--- a/crates/oored/src/integrations/mod.rs
+++ b/crates/oored/src/integrations/mod.rs
@@ -103,6 +103,93 @@ pub(crate) async fn require_remote_mode(
     Ok(())
 }
 
+pub(crate) async fn resolve_branch_commit(
+    pool: &sqlx::SqlitePool,
+    encryption_key: &[u8],
+    repository_id: &str,
+    branch: &str,
+) -> Result<String, (StatusCode, Json<ApiError>)> {
+    let row = sqlx::query(
+        "SELECT i.id AS integration_id, i.provider, i.host_url, i.auth_mode, \
+                inst.external_id AS installation_external_id, r.external_id AS repository_external_id, \
+                r.full_name, r.html_url \
+         FROM integration_repositories r \
+         JOIN integration_installations inst ON inst.id = r.installation_id \
+         JOIN integrations i ON i.id = inst.integration_id \
+         WHERE r.id = ?1 AND i.status = 'active'",
+    )
+    .bind(repository_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| {
+        error!(error = %e, repository_id = %repository_id, "failed to load source revision target");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to load the linked repository",
+        )
+    })?
+    .ok_or_else(|| {
+        api_err(
+            StatusCode::CONFLICT,
+            "source_unresolvable",
+            "The linked source is unavailable; reconnect it before triggering a build",
+        )
+    })?;
+
+    let provider: String = row.get("provider");
+    let integration_id: String = row.get("integration_id");
+    match provider.as_str() {
+        "local_git" => {
+            let path: Option<String> = row.get("html_url");
+            local_git::resolve_branch_commit(
+                path.as_deref().ok_or_else(|| {
+                    api_err(
+                        StatusCode::CONFLICT,
+                        "source_unresolvable",
+                        "The linked local repository path is missing",
+                    )
+                })?,
+                branch,
+            )
+            .await
+        }
+        "github" => {
+            let installation_id: String = row.get("installation_external_id");
+            let full_name: String = row.get("full_name");
+            github::resolve_branch_commit(
+                pool,
+                encryption_key,
+                &integration_id,
+                &installation_id,
+                &full_name,
+                branch,
+            )
+            .await
+        }
+        "gitlab" => {
+            let host_url: String = row.get("host_url");
+            let auth_mode: String = row.get("auth_mode");
+            let repository_external_id: String = row.get("repository_external_id");
+            gitlab::resolve_branch_commit(
+                pool,
+                encryption_key,
+                &integration_id,
+                &host_url,
+                &auth_mode,
+                &repository_external_id,
+                branch,
+            )
+            .await
+        }
+        _ => Err(api_err(
+            StatusCode::CONFLICT,
+            "unsupported_provider",
+            "The linked source provider cannot resolve branch revisions",
+        )),
+    }
+}
+
 // ── Row conversion helpers ──────────────────────────────────────
 
 pub fn row_to_integration(row: &sqlx::sqlite::SqliteRow) -> Integration {

--- a/crates/oored/src/lib.rs
+++ b/crates/oored/src/lib.rs
@@ -24,6 +24,7 @@ pub mod project_members;
 pub mod project_rbac;
 pub mod projects;
 pub mod rbac;
+pub mod repository_workflows;
 pub mod retention;
 pub mod runners;
 pub mod runtime_updates;
@@ -2303,6 +2304,10 @@ async fn build_router_inner(
             get(projects::get_project)
                 .patch(projects::update_project)
                 .delete(projects::delete_project),
+        )
+        .route(
+            "/v1/projects/{project_id}/repository-workflows",
+            get(repository_workflows::discover_repository_workflows),
         )
         // Project member endpoints
         .route(

--- a/crates/oored/src/pipelines.rs
+++ b/crates/oored/src/pipelines.rs
@@ -8,7 +8,7 @@ use oore_contract::{
     ApiError, BuildPlatform, ConcurrencyPolicy, CreatePipelineRequest, CreatePipelineResponse,
     ListPipelinesResponse, Pipeline, PipelineDetailResponse, PipelineExecutionConfig,
     TriggerConfig, UpdatePipelineRequest, ValidatePipelineRequest, ValidatePipelineResponse,
-    parse_repository_pipeline_yaml, validate_artifact_pattern,
+    parse_repository_pipeline_yaml, validate_artifact_pattern, validate_repository_config_path,
 };
 use serde::Deserialize;
 use sqlx::Row;
@@ -235,6 +235,8 @@ fn validate_config_path(path: &str, explicit: bool) -> Vec<String> {
         } else {
             errors.push("config_path must not be empty".to_string());
         }
+    } else if let Err(error) = validate_repository_config_path(path) {
+        errors.push(format!("config_path {error}"));
     }
     errors
 }

--- a/crates/oored/src/repository_workflows.rs
+++ b/crates/oored/src/repository_workflows.rs
@@ -1,0 +1,889 @@
+use std::collections::HashSet;
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use oore_contract::{
+    ApiError, DiscoverRepositoryWorkflowsResponse, RepositoryWorkflowExecutionPreview,
+    RepositoryWorkflowPreview, ScmProvider, parse_repository_pipeline_yaml,
+    validate_repository_config_path,
+};
+use serde::Deserialize;
+use sqlx::Row;
+use tracing::error;
+
+use crate::AppState;
+use crate::crypto;
+use crate::extractors::AuthUser;
+use crate::project_rbac::{
+    ProjectPermission, require_project_permission, resolve_effective_project_role,
+};
+use crate::util::api_err;
+
+type ApiResult<T> = Result<Json<T>, (StatusCode, Json<ApiError>)>;
+
+const MAX_WORKFLOW_FILES: usize = 16;
+const MAX_WORKFLOW_BYTES: usize = 128 * 1024;
+const MAX_DIRECTORY_RESPONSE_BYTES: usize = 512 * 1024;
+
+#[derive(Debug, Deserialize)]
+pub struct DiscoverRepositoryWorkflowsQuery {
+    #[serde(rename = "ref")]
+    reference: Option<String>,
+    path: Option<String>,
+}
+
+struct ProjectSource {
+    provider: ScmProvider,
+    integration_id: String,
+    installation_external_id: String,
+    repository_external_id: String,
+    full_name: String,
+    host_url: String,
+    auth_mode: String,
+    local_path: Option<String>,
+    default_reference: String,
+}
+
+fn validate_reference(reference: &str) -> Result<String, (StatusCode, Json<ApiError>)> {
+    let reference = reference.trim();
+    if reference.is_empty()
+        || reference.len() > 255
+        || reference.starts_with('-')
+        || reference.chars().any(char::is_control)
+    {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "invalid_ref",
+            "ref must be a non-empty branch, tag, or commit name up to 255 characters",
+        ));
+    }
+    Ok(reference.to_string())
+}
+
+fn workflow_candidates(
+    explicit_path: Option<&str>,
+    directory_paths: impl IntoIterator<Item = String>,
+) -> Result<(Vec<String>, bool), (StatusCode, Json<ApiError>)> {
+    let mut paths = Vec::new();
+    let mut seen = HashSet::new();
+    for path in explicit_path
+        .into_iter()
+        .map(str::to_string)
+        .chain([".oore.yaml".to_string(), ".oore.yml".to_string()])
+        .chain(directory_paths)
+    {
+        if validate_repository_config_path(&path).is_err() || !seen.insert(path.clone()) {
+            continue;
+        }
+        if paths.len() == MAX_WORKFLOW_FILES {
+            return Ok((paths, true));
+        }
+        paths.push(path);
+    }
+    Ok((paths, false))
+}
+
+fn preview(path: String, raw: &str) -> RepositoryWorkflowPreview {
+    match parse_repository_pipeline_yaml(raw) {
+        Ok(config) => RepositoryWorkflowPreview {
+            path,
+            valid: true,
+            errors: Vec::new(),
+            execution: Some(RepositoryWorkflowExecutionPreview {
+                platforms: config.platforms,
+                flutter_version: config.flutter_version,
+                commands: config.commands,
+                platform_build_args: config.platform_build_args,
+                platform_commands: config.platform_commands,
+                env_keys: config.env.into_iter().map(|entry| entry.key).collect(),
+                artifact_patterns: config.artifact_patterns,
+            }),
+        },
+        Err(error) => RepositoryWorkflowPreview {
+            path,
+            valid: false,
+            errors: if error.starts_with("YAML parse error:") {
+                let location = error
+                    .rfind(" at line ")
+                    .map(|index| &error[index..])
+                    .unwrap_or_default();
+                vec![format!(
+                    "YAML is invalid{location}; check its syntax and value types"
+                )]
+            } else {
+                error.lines().map(str::to_string).collect()
+            },
+            execution: None,
+        },
+    }
+}
+
+async fn response_bytes(
+    mut response: reqwest::Response,
+    max_bytes: usize,
+) -> Result<Vec<u8>, (StatusCode, Json<ApiError>)> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > max_bytes as u64)
+    {
+        return Err(api_err(
+            StatusCode::BAD_GATEWAY,
+            "source_response_too_large",
+            "The source provider returned more data than workflow discovery allows",
+        ));
+    }
+    let mut bytes = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(|e| {
+        error!(error = %e, "failed to read source provider response");
+        api_err(
+            StatusCode::BAD_GATEWAY,
+            "source_api_error",
+            "Failed to read the source provider response",
+        )
+    })? {
+        if bytes.len() + chunk.len() > max_bytes {
+            return Err(api_err(
+                StatusCode::BAD_GATEWAY,
+                "source_response_too_large",
+                "The source provider returned more data than workflow discovery allows",
+            ));
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(bytes)
+}
+
+fn provider_error(provider: &str, status: reqwest::StatusCode) -> (StatusCode, Json<ApiError>) {
+    api_err(
+        StatusCode::BAD_GATEWAY,
+        "source_api_error",
+        format!("{provider} returned {status} while discovering repository workflows"),
+    )
+}
+
+fn gitlab_api_url(
+    host_url: &str,
+    suffix: &[&str],
+) -> Result<url::Url, (StatusCode, Json<ApiError>)> {
+    let mut url = url::Url::parse(host_url).map_err(|_| {
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "invalid_source_host",
+            "The linked GitLab host is invalid",
+        )
+    })?;
+    if !matches!(url.scheme(), "http" | "https")
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+    {
+        return Err(api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "invalid_source_host",
+            "The linked GitLab host is invalid",
+        ));
+    }
+    url.set_query(None);
+    url.set_fragment(None);
+    url.path_segments_mut()
+        .map_err(|_| {
+            api_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "invalid_source_host",
+                "The linked GitLab host is invalid",
+            )
+        })?
+        .clear()
+        .extend(["api", "v4"])
+        .extend(suffix.iter().copied());
+    Ok(url)
+}
+
+fn source_client() -> Result<reqwest::Client, (StatusCode, Json<ApiError>)> {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(15))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|e| {
+            error!(error = %e, "failed to build workflow discovery client");
+            api_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "http_client_error",
+                "Failed to create the source provider client",
+            )
+        })
+}
+
+async fn gitlab_request(
+    client: &reqwest::Client,
+    source: &ProjectSource,
+    token: &str,
+    url: url::Url,
+) -> Result<reqwest::Response, (StatusCode, Json<ApiError>)> {
+    let request = client.get(url).header("User-Agent", "oore-ci");
+    let request = if source.auth_mode == "oauth_app" {
+        request.header("Authorization", format!("Bearer {token}"))
+    } else {
+        request.header("PRIVATE-TOKEN", token)
+    };
+    request.send().await.map_err(|e| {
+        error!(error = %e, "GitLab workflow discovery request failed");
+        api_err(
+            StatusCode::BAD_GATEWAY,
+            "source_api_error",
+            "Failed to communicate with GitLab",
+        )
+    })
+}
+
+async fn discover_gitlab(
+    pool: &sqlx::SqlitePool,
+    encryption_key: &[u8],
+    source: &ProjectSource,
+    reference: &str,
+    explicit_path: Option<&str>,
+) -> Result<(Vec<RepositoryWorkflowPreview>, bool), (StatusCode, Json<ApiError>)> {
+    let encrypted_token: Option<String> = sqlx::query_scalar(
+        "SELECT encrypted_value FROM integration_credentials \
+         WHERE integration_id = ?1 AND credential_type = 'access_token'",
+    )
+    .bind(&source.integration_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| {
+        error!(error = %e, "failed to load GitLab workflow discovery credentials");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to load source credentials",
+        )
+    })?;
+    let token = crypto::decrypt(
+        encrypted_token.as_deref().ok_or_else(|| {
+            api_err(
+                StatusCode::CONFLICT,
+                "missing_credentials",
+                "GitLab credentials are missing; reconnect the source",
+            )
+        })?,
+        encryption_key,
+    )
+    .map_err(|e| {
+        error!(error = %e, "failed to decrypt GitLab workflow discovery credentials");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "encryption_error",
+            "Failed to decrypt source credentials",
+        )
+    })?;
+
+    let client = source_client()?;
+    let mut tree_url = gitlab_api_url(
+        &source.host_url,
+        &[
+            "projects",
+            &source.repository_external_id,
+            "repository",
+            "tree",
+        ],
+    )?;
+    tree_url
+        .query_pairs_mut()
+        .append_pair("path", ".oore")
+        .append_pair("ref", reference)
+        .append_pair("per_page", "100");
+    let tree_response = gitlab_request(&client, source, &token, tree_url).await?;
+    let tree_truncated = tree_response
+        .headers()
+        .get("x-next-page")
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| !value.is_empty());
+    let directory_paths = if tree_response.status() == StatusCode::NOT_FOUND {
+        Vec::new()
+    } else if tree_response.status().is_success() {
+        #[derive(Deserialize)]
+        struct TreeEntry {
+            name: String,
+            #[serde(rename = "type")]
+            kind: String,
+        }
+        let body = response_bytes(tree_response, MAX_DIRECTORY_RESPONSE_BYTES).await?;
+        serde_json::from_slice::<Vec<TreeEntry>>(&body)
+            .map_err(|e| {
+                error!(error = %e, "failed to parse GitLab repository tree");
+                api_err(
+                    StatusCode::BAD_GATEWAY,
+                    "source_parse_error",
+                    "Failed to parse the GitLab repository tree",
+                )
+            })?
+            .into_iter()
+            .filter(|entry| {
+                entry.kind == "blob"
+                    && (entry.name.ends_with(".yaml") || entry.name.ends_with(".yml"))
+            })
+            .map(|entry| format!(".oore/{}", entry.name))
+            .collect()
+    } else {
+        return Err(provider_error("GitLab", tree_response.status()));
+    };
+
+    let (paths, truncated) = workflow_candidates(explicit_path, directory_paths)?;
+    let mut workflows = Vec::new();
+    for path in paths {
+        let mut file_url = gitlab_api_url(
+            &source.host_url,
+            &[
+                "projects",
+                &source.repository_external_id,
+                "repository",
+                "files",
+                &path,
+                "raw",
+            ],
+        )?;
+        file_url.query_pairs_mut().append_pair("ref", reference);
+        let response = gitlab_request(&client, source, &token, file_url).await?;
+        if response.status() == StatusCode::NOT_FOUND {
+            continue;
+        }
+        if !response.status().is_success() {
+            return Err(provider_error("GitLab", response.status()));
+        }
+        let body = response_bytes(response, MAX_WORKFLOW_BYTES).await?;
+        let raw = std::str::from_utf8(&body).map_err(|_| {
+            api_err(
+                StatusCode::BAD_GATEWAY,
+                "invalid_workflow_encoding",
+                format!("{path} must be UTF-8 text"),
+            )
+        })?;
+        workflows.push(preview(path, raw));
+    }
+    Ok((workflows, truncated || tree_truncated))
+}
+
+async fn github_get(
+    client: &reqwest::Client,
+    source: &ProjectSource,
+    token: &str,
+    path: &str,
+    reference: &str,
+    raw: bool,
+) -> Result<reqwest::Response, (StatusCode, Json<ApiError>)> {
+    let url = github_contents_url(&source.full_name, path, reference);
+    client
+        .get(url)
+        .header("Authorization", format!("Bearer {token}"))
+        .header(
+            "Accept",
+            if raw {
+                "application/vnd.github.raw+json"
+            } else {
+                "application/vnd.github+json"
+            },
+        )
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "oore-ci")
+        .send()
+        .await
+        .map_err(|e| {
+            error!(error = %e, "GitHub workflow discovery request failed");
+            api_err(
+                StatusCode::BAD_GATEWAY,
+                "source_api_error",
+                "Failed to communicate with GitHub",
+            )
+        })
+}
+
+fn github_contents_url(full_name: &str, path: &str, reference: &str) -> url::Url {
+    let mut url = url::Url::parse("https://api.github.com").expect("static GitHub API URL");
+    url.path_segments_mut()
+        .expect("GitHub API URL supports path segments")
+        .extend(["repos"])
+        .extend(full_name.split('/'))
+        .extend(["contents"])
+        .extend(path.split('/'));
+    url.query_pairs_mut().append_pair("ref", reference);
+    url
+}
+
+async fn discover_github(
+    pool: &sqlx::SqlitePool,
+    encryption_key: &[u8],
+    source: &ProjectSource,
+    reference: &str,
+    explicit_path: Option<&str>,
+) -> Result<(Vec<RepositoryWorkflowPreview>, bool), (StatusCode, Json<ApiError>)> {
+    let client = source_client()?;
+    let token = crate::integrations::github::load_installation_access_token(
+        &client,
+        pool,
+        encryption_key,
+        &source.integration_id,
+        &source.installation_external_id,
+    )
+    .await?;
+    let tree_response = github_get(&client, source, &token, ".oore", reference, false).await?;
+    let directory_paths = if tree_response.status() == StatusCode::NOT_FOUND {
+        Vec::new()
+    } else if tree_response.status().is_success() {
+        #[derive(Deserialize)]
+        struct ContentEntry {
+            name: String,
+            #[serde(rename = "type")]
+            kind: String,
+        }
+        let body = response_bytes(tree_response, MAX_DIRECTORY_RESPONSE_BYTES).await?;
+        serde_json::from_slice::<Vec<ContentEntry>>(&body)
+            .map_err(|e| {
+                error!(error = %e, "failed to parse GitHub repository contents");
+                api_err(
+                    StatusCode::BAD_GATEWAY,
+                    "source_parse_error",
+                    "Failed to parse the GitHub repository contents",
+                )
+            })?
+            .into_iter()
+            .filter(|entry| {
+                entry.kind == "file"
+                    && (entry.name.ends_with(".yaml") || entry.name.ends_with(".yml"))
+            })
+            .map(|entry| format!(".oore/{}", entry.name))
+            .collect()
+    } else {
+        return Err(provider_error("GitHub", tree_response.status()));
+    };
+
+    let (paths, truncated) = workflow_candidates(explicit_path, directory_paths)?;
+    let mut workflows = Vec::new();
+    for path in paths {
+        let response = github_get(&client, source, &token, &path, reference, true).await?;
+        if response.status() == StatusCode::NOT_FOUND {
+            continue;
+        }
+        if !response.status().is_success() {
+            return Err(provider_error("GitHub", response.status()));
+        }
+        let body = response_bytes(response, MAX_WORKFLOW_BYTES).await?;
+        let raw = std::str::from_utf8(&body).map_err(|_| {
+            api_err(
+                StatusCode::BAD_GATEWAY,
+                "invalid_workflow_encoding",
+                format!("{path} must be UTF-8 text"),
+            )
+        })?;
+        workflows.push(preview(path, raw));
+    }
+    Ok((workflows, truncated))
+}
+
+fn read_limited_stdout(
+    mut command: Command,
+    max_bytes: usize,
+) -> Result<Option<Vec<u8>>, std::io::Error> {
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()?;
+    let mut output = Vec::new();
+    child
+        .stdout
+        .take()
+        .expect("piped stdout")
+        .take((max_bytes + 1) as u64)
+        .read_to_end(&mut output)?;
+    let status = child.wait()?;
+    if !status.success() {
+        return Ok(None);
+    }
+    if output.len() > max_bytes {
+        return Err(std::io::Error::other("git output exceeded discovery limit"));
+    }
+    Ok(Some(output))
+}
+
+async fn discover_local(
+    repo_path: &str,
+    reference: &str,
+    explicit_path: Option<&str>,
+) -> Result<(Vec<RepositoryWorkflowPreview>, bool), (StatusCode, Json<ApiError>)> {
+    let repo_path = repo_path.to_string();
+    let reference = reference.to_string();
+    let explicit_path = explicit_path.map(str::to_string);
+    tokio::task::spawn_blocking(move || {
+        let commit_output = Command::new("git")
+            .args([
+                "-C",
+                repo_path.as_str(),
+                "rev-parse",
+                "--verify",
+                "--end-of-options",
+                &format!("{reference}^{{commit}}"),
+            ])
+            .output()
+            .map_err(|e| {
+                error!(error = %e, "failed to resolve local workflow discovery ref");
+                api_err(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "git_error",
+                    "Failed to inspect the local repository",
+                )
+            })?;
+        if !commit_output.status.success() {
+            return Err(api_err(
+                StatusCode::BAD_REQUEST,
+                "invalid_ref",
+                format!("ref '{reference}' was not found in the linked repository"),
+            ));
+        }
+        let commit = String::from_utf8(commit_output.stdout)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                api_err(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "git_error",
+                    "Git returned an invalid commit identifier",
+                )
+            })?;
+
+        let mut tree = Command::new("git");
+        tree.args([
+            "-C",
+            repo_path.as_str(),
+            "ls-tree",
+            "--name-only",
+            &format!("{commit}:.oore"),
+        ]);
+        let directory_paths = match read_limited_stdout(tree, MAX_DIRECTORY_RESPONSE_BYTES) {
+            Ok(Some(bytes)) => String::from_utf8_lossy(&bytes)
+                .lines()
+                .filter(|name| name.ends_with(".yaml") || name.ends_with(".yml"))
+                .map(|name| format!(".oore/{name}"))
+                .collect(),
+            Ok(None) => Vec::new(),
+            Err(_) => {
+                return Err(api_err(
+                    StatusCode::PAYLOAD_TOO_LARGE,
+                    "repository_tree_too_large",
+                    "The repository contains too many workflow files to discover safely",
+                ));
+            }
+        };
+        let (paths, truncated) = workflow_candidates(explicit_path.as_deref(), directory_paths)?;
+        let mut workflows = Vec::new();
+        for path in paths {
+            let object = format!("{commit}:{path}");
+            let size = Command::new("git")
+                .args(["-C", repo_path.as_str(), "cat-file", "-s", &object])
+                .output()
+                .map_err(|e| {
+                    error!(error = %e, "failed to inspect local workflow file");
+                    api_err(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "git_error",
+                        "Failed to inspect the local repository",
+                    )
+                })?;
+            if !size.status.success() {
+                continue;
+            }
+            let size = String::from_utf8_lossy(&size.stdout)
+                .trim()
+                .parse::<usize>()
+                .unwrap_or(usize::MAX);
+            if size > MAX_WORKFLOW_BYTES {
+                return Err(api_err(
+                    StatusCode::PAYLOAD_TOO_LARGE,
+                    "workflow_too_large",
+                    format!("{path} exceeds the {MAX_WORKFLOW_BYTES} byte discovery limit"),
+                ));
+            }
+            let mut cat = Command::new("git");
+            cat.args(["-C", repo_path.as_str(), "cat-file", "blob", &object]);
+            let body = read_limited_stdout(cat, MAX_WORKFLOW_BYTES)
+                .map_err(|_| {
+                    api_err(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "git_error",
+                        "Failed to read the local repository workflow",
+                    )
+                })?
+                .ok_or_else(|| {
+                    api_err(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "git_error",
+                        "Failed to read the local repository workflow",
+                    )
+                })?;
+            let raw = std::str::from_utf8(&body).map_err(|_| {
+                api_err(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_workflow_encoding",
+                    format!("{path} must be UTF-8 text"),
+                )
+            })?;
+            workflows.push(preview(path, raw));
+        }
+        Ok((workflows, truncated))
+    })
+    .await
+    .map_err(|e| {
+        error!(error = %e, "local workflow discovery task failed");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "git_error",
+            "Failed to inspect the local repository",
+        )
+    })?
+}
+
+async fn load_project_source(
+    pool: &sqlx::SqlitePool,
+    project_id: &str,
+) -> Result<ProjectSource, (StatusCode, Json<ApiError>)> {
+    let row = sqlx::query(
+        "SELECT i.id AS integration_id, i.provider, i.host_url, i.auth_mode, \
+                inst.external_id AS installation_external_id, r.external_id AS repository_external_id, \
+                r.full_name, r.default_branch AS repository_default_branch, \
+                p.default_branch AS project_default_branch \
+         FROM projects p \
+         JOIN integration_repositories r ON r.id = p.repository_id \
+         JOIN integration_installations inst ON inst.id = r.installation_id \
+         JOIN integrations i ON i.id = inst.integration_id \
+         WHERE p.id = ?1 AND i.status = 'active'",
+    )
+    .bind(project_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| {
+        error!(error = %e, project_id, "failed to load project source");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to load the project source",
+        )
+    })?
+    .ok_or_else(|| {
+        api_err(
+            StatusCode::NOT_FOUND,
+            "source_not_found",
+            "The project does not have an active linked repository",
+        )
+    })?;
+    let provider_raw: String = row.get("provider");
+    let provider = provider_raw.parse::<ScmProvider>().map_err(|_| {
+        api_err(
+            StatusCode::BAD_REQUEST,
+            "unsupported_provider",
+            "The linked repository provider does not support workflow discovery",
+        )
+    })?;
+    let repository_external_id: String = row.get("repository_external_id");
+    let project_default: Option<String> = row.get("project_default_branch");
+    let repository_default: Option<String> = row.get("repository_default_branch");
+    let default_reference = project_default
+        .or(repository_default)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            api_err(
+                StatusCode::CONFLICT,
+                "missing_default_branch",
+                "Set a project default branch before discovering repository workflows",
+            )
+        })?;
+    Ok(ProjectSource {
+        provider,
+        integration_id: row.get("integration_id"),
+        installation_external_id: row.get("installation_external_id"),
+        repository_external_id: repository_external_id.clone(),
+        full_name: row.get("full_name"),
+        host_url: row.get("host_url"),
+        auth_mode: row.get("auth_mode"),
+        local_path: (provider == ScmProvider::LocalGit).then_some(repository_external_id),
+        default_reference,
+    })
+}
+
+/// `GET /v1/projects/{project_id}/repository-workflows` — discover repository-owned configs.
+pub async fn discover_repository_workflows(
+    State(state): State<Arc<AppState>>,
+    auth: AuthUser,
+    Path(project_id): Path<String>,
+    Query(query): Query<DiscoverRepositoryWorkflowsQuery>,
+) -> ApiResult<DiscoverRepositoryWorkflowsResponse> {
+    let pool = {
+        let store = state.store.lock().await;
+        store.pool().clone()
+    };
+    let effective = resolve_effective_project_role(
+        &pool,
+        &auth.0.user_id,
+        &auth.0.role,
+        &project_id,
+        &auth.0.auth_source,
+    )
+    .await?;
+    require_project_permission(&effective, ProjectPermission::ManagePipelines)?;
+
+    let source = load_project_source(&pool, &project_id).await?;
+    let reference = validate_reference(
+        query
+            .reference
+            .as_deref()
+            .unwrap_or(&source.default_reference),
+    )?;
+    let explicit_path = query.path.as_deref().map(str::trim);
+    if let Some(path) = explicit_path
+        && let Err(error) = validate_repository_config_path(path)
+    {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "invalid_config_path",
+            format!("path {error}"),
+        ));
+    }
+
+    let (workflows, truncated) = match source.provider {
+        ScmProvider::Github => {
+            discover_github(
+                &pool,
+                &state.encryption_key,
+                &source,
+                &reference,
+                explicit_path,
+            )
+            .await?
+        }
+        ScmProvider::Gitlab => {
+            discover_gitlab(
+                &pool,
+                &state.encryption_key,
+                &source,
+                &reference,
+                explicit_path,
+            )
+            .await?
+        }
+        ScmProvider::LocalGit => {
+            discover_local(
+                source.local_path.as_deref().expect("local path loaded"),
+                &reference,
+                explicit_path,
+            )
+            .await?
+        }
+    };
+
+    // A missing ref and a valid repository with no workflow files both produce
+    // provider 404s. Resolve only the empty result so the latter stays a normal
+    // empty discovery response while invalid refs get an actionable error.
+    if workflows.is_empty() {
+        match source.provider {
+            ScmProvider::Github => {
+                crate::integrations::github::resolve_branch_commit(
+                    &pool,
+                    &state.encryption_key,
+                    &source.integration_id,
+                    &source.installation_external_id,
+                    &source.full_name,
+                    &reference,
+                )
+                .await?;
+            }
+            ScmProvider::Gitlab => {
+                crate::integrations::gitlab::resolve_branch_commit(
+                    &pool,
+                    &state.encryption_key,
+                    &source.integration_id,
+                    &source.host_url,
+                    &source.auth_mode,
+                    &source.repository_external_id,
+                    &reference,
+                )
+                .await?;
+            }
+            ScmProvider::LocalGit => {}
+        }
+    }
+
+    Ok(Json(DiscoverRepositoryWorkflowsResponse {
+        project_id,
+        provider: source.provider,
+        reference,
+        workflows,
+        truncated,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preview_omits_environment_values() {
+        let preview = preview(
+            ".oore.yaml".to_string(),
+            "version: 1\nplatforms: [android]\nenv:\n  - key: API_TOKEN\n    value: super-secret\n",
+        );
+        let json = serde_json::to_string(&preview).expect("serialize preview");
+        assert!(preview.valid);
+        assert!(json.contains("API_TOKEN"));
+        assert!(!json.contains("super-secret"));
+    }
+
+    #[test]
+    fn candidates_are_deduplicated_and_bounded() {
+        let discovered = (0..32).map(|index| format!(".oore/{index}.yaml"));
+        let (paths, truncated) =
+            workflow_candidates(Some(".oore/custom.yaml"), discovered).expect("candidates");
+        assert_eq!(paths.len(), MAX_WORKFLOW_FILES);
+        assert_eq!(paths[0], ".oore/custom.yaml");
+        assert!(truncated);
+    }
+
+    #[test]
+    fn malformed_yaml_errors_do_not_echo_values() {
+        let preview = preview(
+            ".oore.yaml".to_string(),
+            "version: 1\nplatforms: [android]\nenv: do-not-return-this\n",
+        );
+        let json = serde_json::to_string(&preview).expect("serialize preview");
+        assert!(!preview.valid);
+        assert!(!json.contains("do-not-return-this"));
+        assert!(json.contains("YAML is invalid"));
+    }
+
+    #[test]
+    fn provider_urls_encode_repository_and_workflow_paths() {
+        let github = github_contents_url("org/mobile app", ".oore/release.yml", "feature/x");
+        assert_eq!(
+            github.as_str(),
+            "https://api.github.com/repos/org/mobile%20app/contents/.oore/release.yml?ref=feature%2Fx"
+        );
+
+        for host in ["https://gitlab.com", "https://gitlab.internal.example"] {
+            let gitlab = gitlab_api_url(
+                host,
+                &[
+                    "projects",
+                    "group/mobile-app",
+                    "repository",
+                    "files",
+                    ".oore/release.yml",
+                    "raw",
+                ],
+            )
+            .expect("GitLab URL");
+            assert!(gitlab.as_str().contains("group%2Fmobile-app"));
+            assert!(gitlab.as_str().contains(".oore%2Frelease.yml"));
+        }
+    }
+}

--- a/crates/oored/tests/build_reproducibility_integration.rs
+++ b/crates/oored/tests/build_reproducibility_integration.rs
@@ -1,0 +1,202 @@
+#![cfg(feature = "test-support")]
+
+mod common;
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode, header};
+use common::{body_json, connect_pool, create_test_app, now_unix, seed_test_user};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+fn git(repo: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .expect("git command should run");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn commit(repo: &Path, contents: &str, message: &str) -> String {
+    fs::write(repo.join("revision.txt"), contents).expect("write fixture");
+    git(repo, &["add", "revision.txt"]);
+    git(repo, &["commit", "--quiet", "-m", message]);
+    git(repo, &["rev-parse", "HEAD"])
+}
+
+async fn session_token(pool: &sqlx::SqlitePool, user_id: &str) -> String {
+    let token = oored::token::generate_session_token();
+    sqlx::query(
+        "INSERT INTO sessions (token_hash, user_id, created_at, expires_at) VALUES (?1, ?2, ?3, ?4)",
+    )
+    .bind(oored::token::hash_token(&token))
+    .bind(user_id)
+    .bind(now_unix())
+    .bind(now_unix() + 3600)
+    .execute(pool)
+    .await
+    .expect("create session");
+    token
+}
+
+async fn seed_local_project(
+    pool: &sqlx::SqlitePool,
+    user_id: &str,
+    repo: &Path,
+) -> (String, String) {
+    let integration_id = Uuid::new_v4().to_string();
+    let installation_id = Uuid::new_v4().to_string();
+    let repository_id = Uuid::new_v4().to_string();
+    let project_id = Uuid::new_v4().to_string();
+    let pipeline_id = Uuid::new_v4().to_string();
+    let path = repo.to_string_lossy();
+    let now = now_unix();
+
+    sqlx::query(
+        "INSERT INTO integrations (id, provider, host_url, auth_mode, status, display_name, created_by, created_at, updated_at) \
+         VALUES (?1, 'local_git', 'local://filesystem', 'local_path', 'active', 'Fixture', ?2, ?3, ?3)",
+    )
+    .bind(&integration_id)
+    .bind(user_id)
+    .bind(now)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO integration_installations (id, integration_id, external_id, account_name, account_type, created_at, updated_at) \
+         VALUES (?1, ?2, ?3, 'local', 'filesystem', ?4, ?4)",
+    )
+    .bind(&installation_id)
+    .bind(&integration_id)
+    .bind(path.as_ref())
+    .bind(now)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO integration_repositories (id, installation_id, external_id, full_name, default_branch, is_private, html_url, created_at, updated_at) \
+         VALUES (?1, ?2, ?3, 'fixture', 'main', 1, ?3, ?4, ?4)",
+    )
+    .bind(&repository_id)
+    .bind(&installation_id)
+    .bind(path.as_ref())
+    .bind(now)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO projects (id, name, repository_id, default_branch, created_by, created_at, updated_at) \
+         VALUES (?1, 'Fixture', ?2, 'main', ?3, ?4, ?4)",
+    )
+    .bind(&project_id)
+    .bind(&repository_id)
+    .bind(user_id)
+    .bind(now)
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO pipelines (id, project_id, name, config_path, trigger_config, concurrency, enabled, created_at, updated_at) \
+         VALUES (?1, ?2, 'Default', '.oore.yml', '{}', '{}', 1, ?3, ?3)",
+    )
+    .bind(&pipeline_id)
+    .bind(&project_id)
+    .bind(now)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    (project_id, pipeline_id)
+}
+
+async fn post_json(
+    app: &axum::Router,
+    token: &str,
+    uri: &str,
+    body: serde_json::Value,
+) -> (StatusCode, serde_json::Value) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    (status, body_json(response.into_body()).await)
+}
+
+#[tokio::test]
+async fn branch_builds_are_pinned_and_reruns_keep_the_original_commit() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let repo = tmp.path().join("repo");
+    fs::create_dir(&repo).unwrap();
+    git(&repo, &["init", "--quiet"]);
+    git(&repo, &["config", "user.name", "Oore Tests"]);
+    git(&repo, &["config", "user.email", "tests@oore.build"]);
+    git(&repo, &["checkout", "-q", "-b", "main"]);
+    let first_sha = commit(&repo, "first\n", "first");
+
+    let db_path = tmp.path().join("oore.db");
+    let app = create_test_app(&db_path).await;
+    let pool = connect_pool(&db_path).await;
+    let user_id = seed_test_user(&pool).await;
+    let token = session_token(&pool, &user_id).await;
+    let (project_id, pipeline_id) = seed_local_project(&pool, &user_id, &repo).await;
+
+    let (status, first) = post_json(
+        &app,
+        &token,
+        &format!("/v1/projects/{project_id}/builds"),
+        serde_json::json!({ "pipeline_id": pipeline_id }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(first["build"]["commit_sha"], first_sha);
+    assert_eq!(first["build"]["config_snapshot"]["commit_sha"], first_sha);
+
+    let second_sha = commit(&repo, "second\n", "second");
+    let first_build_id = first["build"]["id"].as_str().unwrap();
+    sqlx::query("UPDATE builds SET status = 'failed' WHERE id = ?1")
+        .bind(first_build_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let (status, rerun) = post_json(
+        &app,
+        &token,
+        &format!("/v1/builds/{first_build_id}/rerun"),
+        serde_json::json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(rerun["build"]["commit_sha"], first_sha);
+    assert_eq!(rerun["build"]["config_snapshot"]["commit_sha"], first_sha);
+
+    let (status, fresh) = post_json(
+        &app,
+        &token,
+        &format!("/v1/projects/{project_id}/builds"),
+        serde_json::json!({ "pipeline_id": pipeline_id }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(fresh["build"]["commit_sha"], second_sha);
+}

--- a/crates/oored/tests/project_pipeline_integration.rs
+++ b/crates/oored/tests/project_pipeline_integration.rs
@@ -748,6 +748,214 @@ async fn test_update_pipeline() {
 }
 
 #[tokio::test]
+async fn test_pipeline_config_path_rejects_unsafe_values() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo_path = init_test_git_repo(dir.path());
+    let db_path = dir.path().join("test.db");
+    let app = create_test_app(&db_path).await;
+    let pool = connect_pool(&db_path).await;
+    let user_id = seed_test_user(&pool).await;
+    let token = create_session_token(&pool, &user_id).await;
+
+    let (_, json) = json_request(
+        &app,
+        "POST",
+        "/v1/projects",
+        &token,
+        Some(serde_json::json!({
+            "name": "Config Path Project",
+            "local_repository_path": repo_path.to_string_lossy().to_string(),
+        })),
+    )
+    .await;
+    let project_id = json["project"]["id"].as_str().unwrap();
+
+    let (status, json) = json_request(
+        &app,
+        "POST",
+        &format!("/v1/projects/{project_id}/pipelines"),
+        &token,
+        Some(serde_json::json!({
+            "name": "Unsafe Create",
+            "config_path": "../.oore.yaml",
+            "config_path_explicit": true,
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "create: {json}");
+    assert_eq!(json["code"].as_str(), Some("invalid_config_path"));
+
+    let (_, json) = json_request(
+        &app,
+        "POST",
+        &format!("/v1/projects/{project_id}/pipelines"),
+        &token,
+        Some(serde_json::json!({
+            "name": "Safe Pipeline",
+            "config_path": ".oore/mobile.yaml",
+            "config_path_explicit": true,
+        })),
+    )
+    .await;
+    let pipeline_id = json["pipeline"]["id"].as_str().unwrap();
+
+    let (status, json) = json_request(
+        &app,
+        "PATCH",
+        &format!("/v1/pipelines/{pipeline_id}"),
+        &token,
+        Some(serde_json::json!({ "config_path": "/etc/oore.yaml" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "update: {json}");
+    assert_eq!(json["code"].as_str(), Some("invalid_config_path"));
+
+    let (status, json) = json_request(
+        &app,
+        "POST",
+        "/v1/pipelines/validate",
+        &token,
+        Some(serde_json::json!({
+            "config_path": ".oore\\mobile.yaml",
+            "config_path_explicit": true,
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "validate: {json}");
+    assert!(!json["valid"].as_bool().unwrap());
+    assert!(json["errors"].as_array().unwrap().iter().any(|error| {
+        error
+            .as_str()
+            .is_some_and(|value| value.contains("separators"))
+    }));
+}
+
+#[tokio::test]
+async fn test_local_repository_workflow_discovery_is_bounded_sanitized_and_rbac_protected() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo_path = init_test_git_repo(dir.path());
+    Command::new("git")
+        .args([
+            "-C",
+            repo_path.to_str().unwrap(),
+            "checkout",
+            "-b",
+            "develop",
+        ])
+        .output()
+        .expect("create develop branch");
+    std::fs::create_dir_all(repo_path.join(".oore")).unwrap();
+    std::fs::create_dir_all(repo_path.join("ci")).unwrap();
+    std::fs::write(
+        repo_path.join(".oore.yaml"),
+        "version: 1\nplatforms: [android]\nenv:\n  - key: API_TOKEN\n    value: never-return-this\n",
+    )
+    .unwrap();
+    std::fs::write(
+        repo_path.join(".oore/ios.yml"),
+        "version: 1\nplatforms: [ios]\nunsupported: true\n",
+    )
+    .unwrap();
+    std::fs::write(
+        repo_path.join("ci/release.yml"),
+        "version: 1\nplatforms: [android, ios]\n",
+    )
+    .unwrap();
+    let commit = Command::new("git")
+        .args([
+            "-C",
+            repo_path.to_str().unwrap(),
+            "-c",
+            "user.name=Oore Test",
+            "-c",
+            "user.email=oore@example.com",
+            "add",
+            ".",
+        ])
+        .output()
+        .expect("stage repository configs");
+    assert!(commit.status.success());
+    let commit = Command::new("git")
+        .args([
+            "-C",
+            repo_path.to_str().unwrap(),
+            "-c",
+            "user.name=Oore Test",
+            "-c",
+            "user.email=oore@example.com",
+            "commit",
+            "-m",
+            "test configs",
+        ])
+        .output()
+        .expect("commit repository configs");
+    assert!(commit.status.success());
+
+    let db_path = dir.path().join("test.db");
+    let app = create_test_app(&db_path).await;
+    let pool = connect_pool(&db_path).await;
+    let user_id = seed_test_user(&pool).await;
+    let token = create_session_token(&pool, &user_id).await;
+    let (status, project) = json_request(
+        &app,
+        "POST",
+        "/v1/projects",
+        &token,
+        Some(serde_json::json!({
+            "name": "Workflow discovery",
+            "local_repository_path": repo_path.to_string_lossy(),
+            "default_branch": "develop",
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "create project: {project}");
+    let project_id = project["project"]["id"].as_str().unwrap();
+
+    let (status, discovery) = json_request(
+        &app,
+        "GET",
+        &format!(
+            "/v1/projects/{project_id}/repository-workflows?path=ci%2Frelease.yml&ref=develop"
+        ),
+        &token,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "discover workflows: {discovery}");
+    assert_eq!(discovery["provider"].as_str(), Some("local_git"));
+    assert_eq!(discovery["reference"].as_str(), Some("develop"));
+    assert_eq!(discovery["workflows"].as_array().unwrap().len(), 3);
+    assert!(!discovery.to_string().contains("never-return-this"));
+    let root = discovery["workflows"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|workflow| workflow["path"] == ".oore.yaml")
+        .unwrap();
+    assert_eq!(root["execution"]["env_keys"][0], "API_TOKEN");
+    let invalid = discovery["workflows"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|workflow| workflow["path"] == ".oore/ios.yml")
+        .unwrap();
+    assert_eq!(invalid["valid"].as_bool(), Some(false));
+
+    let viewer_id = seed_user_with_role(&pool, "viewer@example.com", "qa_viewer").await;
+    seed_project_member(&pool, project_id, &viewer_id, &user_id, "viewer").await;
+    let viewer_token = create_session_token(&pool, &viewer_id).await;
+    let (status, _) = json_request(
+        &app,
+        "GET",
+        &format!("/v1/projects/{project_id}/repository-workflows"),
+        &viewer_token,
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
 async fn test_non_member_cannot_use_direct_pipeline_or_signing_routes() {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("test.db");

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -14,6 +14,20 @@ Rules:
 
 ## 2026-07-13
 
+- **Repository-first build setup**:
+  - Empty projects now inspect the linked repository before asking users to configure a pipeline. Valid checked-in workflows are recommended with a secret-free preview; missing, invalid, loading, and provider-error states lead to an explicit next action instead of a dense blank form.
+  - Repository execution fields stay read-only in the setup form so the checked-in file remains the single source of truth. Manual templates remain available as a deliberate fallback.
+  - Linear feature doc: https://linear.app/oorebuild/document/feature-frontend-product-quality-and-build-experience-overhaul-c257decee5c5
+- **Reproducible manual build revisions**:
+  - Manual and API builds that select a branch now resolve and store its exact commit before entering the queue. Config snapshots, reruns, and runner checkout retain that SHA even if the branch advances later.
+  - Linear feature doc: https://linear.app/oorebuild/document/feature-frontend-product-quality-and-build-experience-overhaul-c257decee5c5
+- **Read-only repository workflow discovery API**:
+  - Project maintainers can discover and semantically validate root `.oore.yaml`/`.oore.yml`, bounded `.oore/*.yaml|yml`, and an explicit repository-relative workflow path at a selected ref across GitHub, GitLab.com, self-managed GitLab, and local Git.
+  - Discovery is protected by project `ManagePipelines` permission, limits file counts and response sizes, rejects unsafe paths and refs, and returns only secret-free execution previews: environment keys are visible but raw YAML, environment values, and provider credentials are never returned.
+  - Linear feature doc: https://linear.app/oorebuild/document/feature-frontend-product-quality-and-build-experience-overhaul-c257decee5c5
+- **Repository workflow config path safety**:
+  - Explicit repository workflow paths now use one workspace-relative path contract across pipeline create, update, dry-run validation, and runner execution. Absolute paths, traversal, dot or empty segments, backslash separators, oversized paths, and symlink escapes are rejected before the runner reads them.
+  - Linear feature doc: https://linear.app/oorebuild/document/feature-frontend-product-quality-and-build-experience-overhaul-c257decee5c5
 - **Managed frontend onboarding and real Flutter migration fixes**:
   - A paired same-origin `oore-web` frontend now becomes the browser's instance automatically when no instance has been saved, so invited users can proceed directly to authentication; manual instance management remains available for generic and multi-instance clients.
   - Remote project creation now requires an explicitly selected connected repository and fills its editable name and default branch, while local project paths stay confined to Local Only mode.


### PR DESCRIPTION
## Summary
- discover and validate repository-owned Oore workflows before pipeline creation across GitHub, GitLab, self-managed GitLab, and Local Git
- guide empty projects through valid, missing, invalid, loading, and provider-error states while keeping checked-in execution settings read-only
- pin manual builds and reruns to an exact commit, and contain workflow paths to the checkout including symlink escapes
- expose only bounded, secret-free workflow previews and keep Kite strictly read-only

## Validation
- make validate
- bunx react-doctor@latest --verbose --scope changed --base alpha (97/100; only existing large-component warnings)
- focused repository discovery, RBAC, sanitization, commit-pinning, runner path, API, and frontend tests
- docs gate and Linear feature document updated