### PR TITLE
fix: harden alpha release and build fallbacks

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -8,6 +8,10 @@ concurrency:
   group: autotag-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  actions: write
+  contents: write
+
 jobs:
   autotag:
     name: Cut release tag
@@ -18,11 +22,18 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Autotag
+        id: autotag
         env:
           AUTOTAG_CHANNEL: ${{ github.ref_name }}
           AUTOTAG_BRANCH: ${{ github.ref_name }}
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: bash tools/autotag.sh
+
+      - name: Start release
+        if: steps.autotag.outputs.tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.autotag.outputs.tag }}
+        run: gh workflow run release.yml --ref "${AUTOTAG_BRANCH}" --field tag="${TAG}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,19 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to build and publish
+        required: true
+        type: string
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ inputs.tag || github.ref_name }}
   cancel-in-progress: false
+
+env:
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
   deploy:
@@ -16,6 +25,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -29,7 +39,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           set -euo pipefail
-          tag="${GITHUB_REF_NAME}"
+          tag="${RELEASE_TAG}"
 
           pages_branch="stable"
           if echo "$tag" | grep -q -- '-alpha\.'; then
@@ -98,6 +108,8 @@ jobs:
             target: x86_64-apple-darwin
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Build Rust
         run: |
@@ -123,6 +135,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -154,7 +167,7 @@ jobs:
       - name: Package release tarballs
         run: |
           set -euo pipefail
-          tag="${GITHUB_REF_NAME}"
+          tag="${RELEASE_TAG}"
           ver="${tag#v}"
           mkdir -p "dist/releases/$tag"
 
@@ -222,7 +235,7 @@ jobs:
       - name: Generate release notes
         run: |
           set -euo pipefail
-          tag="${GITHUB_REF_NAME}"
+          tag="${RELEASE_TAG}"
 
           channel="prod"
           if echo "$tag" | grep -q -- '-alpha\.'; then
@@ -269,7 +282,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          tag="${GITHUB_REF_NAME}"
+          tag="${RELEASE_TAG}"
 
           prerelease_flag=""
           if echo "$tag" | grep -q -- '-alpha\.'; then

--- a/apps/docs-site/docs/guides/signing/android-gradle.md
+++ b/apps/docs-site/docs/guides/signing/android-gradle.md
@@ -1,6 +1,6 @@
 ---
 status: implemented
-description: "Configure Gradle signing for Android builds in Oore CI pipelines."
+description: 'Configure Gradle signing for Android builds in Oore CI pipelines.'
 ---
 
 # Configure Gradle Signing
@@ -18,25 +18,37 @@ This guide covers advanced Gradle signing configuration for Android builds in Oo
 When a pipeline has Android signing configured, the runner:
 
 1. Retrieves the keystore file and credentials from the daemon at build time
-2. Places the keystore in a temporary location on the runner
-3. Sets the signing configuration so Gradle can find it
+2. Writes `android/app/oore-upload-keystore.jks` and a compatible
+   `android/key.properties` inside the runner's temporary checkout
+3. Exposes the same signing values through `OORE_ANDROID_*` environment variables
 4. Executes the build command (e.g., `flutter build apk --release`)
 5. Cleans up the keystore after the build completes
 
-You don't need to modify your `build.gradle` for basic signing — Oore CI handles it automatically.
+You don't need to modify the conventional Flutter `build.gradle` for basic
+signing. Oore's generated files exist only in the temporary checkout and never
+change or get pushed to your repository.
 
 ## Custom Gradle configuration
 
-If your project requires custom signing configuration (e.g., multiple flavors with different keystores), you can reference environment variables in your `build.gradle`:
+For an explicit CI/local boundary, or for custom signing such as multiple
+flavors, select Oore's environment variables when `CI=true` and retain your
+existing local configuration otherwise:
 
 ```groovy
 android {
     signingConfigs {
         release {
-            storeFile file(System.getenv("OORE_KEYSTORE_PATH"))
-            storePassword System.getenv("OORE_KEYSTORE_PASSWORD")
-            keyAlias System.getenv("OORE_KEY_ALIAS")
-            keyPassword System.getenv("OORE_KEY_PASSWORD")
+            if (System.getenv("CI")?.toBoolean() && System.getenv("OORE_ANDROID_KEYSTORE_PATH")) {
+                storeFile file(System.getenv("OORE_ANDROID_KEYSTORE_PATH"))
+                storePassword System.getenv("OORE_ANDROID_KEYSTORE_PASSWORD")
+                keyAlias System.getenv("OORE_ANDROID_KEY_ALIAS")
+                keyPassword System.getenv("OORE_ANDROID_KEY_PASSWORD")
+            } else {
+                storeFile file(keystoreProperties["storeFile"])
+                storePassword keystoreProperties["storePassword"]
+                keyAlias keystoreProperties["keyAlias"]
+                keyPassword keystoreProperties["keyPassword"]
+            }
         }
     }
     buildTypes {
@@ -47,7 +59,9 @@ android {
 }
 ```
 
-These environment variables are set by the runner when Android signing is configured for the pipeline.
+The runner sets `CI=true` and these environment variables when Android signing
+is configured for the pipeline. Oore still creates the conventional temporary
+files so projects without this branch continue to work with zero configuration.
 
 ## Verify
 

--- a/apps/web/src/components/build-details/build-detail-page.tsx
+++ b/apps/web/src/components/build-details/build-detail-page.tsx
@@ -68,16 +68,16 @@ export function BuildDetailPage({ buildId }: { buildId: string }) {
   useBuildNotification(data?.build, isTerminal)
 
   const streamEnabled = !isTerminal
-  const {
-    logs: streamLogs,
-    isStreaming,
-    error: streamError,
-  } = useLogStream(buildId, streamEnabled, {
-    onDone: useCallback(() => {
-      void refetchBuild()
-      void refetchArtifacts()
-    }, [refetchBuild, refetchArtifacts]),
-  })
+  const { logs: streamLogs, isStreaming } = useLogStream(
+    buildId,
+    streamEnabled,
+    {
+      onDone: useCallback(() => {
+        void refetchBuild()
+        void refetchArtifacts()
+      }, [refetchBuild, refetchArtifacts]),
+    },
+  )
   const fullLogsQuery = useBuildLogs(buildId, { enabled: isTerminal })
   const { data: fullLogsData } = fullLogsQuery
 
@@ -228,7 +228,6 @@ export function BuildDetailPage({ buildId }: { buildId: string }) {
           stepResults={build.step_results ?? []}
           isStreaming={isStreaming && !isTerminal}
           isLoading={isTerminal && fullLogsQuery.isLoading}
-          streamError={isTerminal ? undefined : (streamError ?? undefined)}
           logsUnavailable={fullLogsQuery.isError}
           isTerminal={isTerminal}
         />

--- a/apps/web/src/components/terminal-log-viewer/terminal-log-viewer.tsx
+++ b/apps/web/src/components/terminal-log-viewer/terminal-log-viewer.tsx
@@ -1,6 +1,4 @@
 import { useCallback, useMemo, useRef, useState } from 'react'
-import { AlertCircleIcon } from '@hugeicons/core-free-icons'
-import { HugeiconsIcon } from '@hugeicons/react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 
 import { LogOutput } from './log-output'
@@ -15,13 +13,11 @@ import type { SelectedStepMeta, TerminalLogViewerProps } from './types'
 import { useWindowEvent } from '@/hooks/use-window-event'
 import { useMountEffect } from '@/hooks/use-mount-effect'
 import { useAutoScroll } from '@/hooks/use-auto-scroll'
-import { Alert, AlertDescription } from '@/components/ui/alert'
 
 export default function TerminalLogViewer({
   logs,
   stepResults,
   isStreaming,
-  streamError,
   isLoading = false,
   logsUnavailable = false,
   isTerminal = false,
@@ -167,13 +163,6 @@ export default function TerminalLogViewer({
         onDownload={downloadRawLogs}
         onScrollLatest={scrollToLatest}
       />
-
-      {streamError ? (
-        <Alert variant="destructive" className="rounded-none border-b-0 py-2">
-          <HugeiconsIcon icon={AlertCircleIcon} />
-          <AlertDescription>{streamError}</AlertDescription>
-        </Alert>
-      ) : null}
 
       {hasSteps ? (
         <MobileStepSelector

--- a/apps/web/src/components/terminal-log-viewer/types.ts
+++ b/apps/web/src/components/terminal-log-viewer/types.ts
@@ -4,7 +4,6 @@ export interface TerminalLogViewerProps {
   logs: Array<BuildLogChunk>
   stepResults: Array<StepResult>
   isStreaming: boolean
-  streamError?: string
   isLoading?: boolean
   logsUnavailable?: boolean
   isTerminal?: boolean

--- a/apps/web/src/hooks/use-log-stream.ts
+++ b/apps/web/src/hooks/use-log-stream.ts
@@ -11,7 +11,6 @@ interface UseLogStreamResult {
   logs: Array<BuildLogChunk>
   isStreaming: boolean
   isDone: boolean
-  error: string | null
 }
 
 interface UseLogStreamOptions {
@@ -28,7 +27,6 @@ const initialStreamState: StreamState = {
   logs: [],
   isStreaming: false,
   isDone: false,
-  error: null,
 }
 
 function streamReducer(state: StreamState, action: StreamAction): StreamState {
@@ -137,11 +135,7 @@ export function useLogStream(
         const response = await createStreamToken(baseUrl, token, buildId)
         streamToken = response.token
       } catch {
-        if (!abort.signal.aborted) {
-          updateStream({
-            error: 'Live stream unavailable. Using polling fallback.',
-          })
-        }
+        // Polling is already active and is a supported transport fallback.
         return
       }
 
@@ -158,7 +152,7 @@ export function useLogStream(
         es.addEventListener('open', () => {
           // SSE is healthy, so suspend polling reconciliation until disconnect.
           stopPolling()
-          updateStream({ isStreaming: true, error: null })
+          updateStream({ isStreaming: true })
         })
 
         es.addEventListener('log', (event: MessageEvent) => {
@@ -182,19 +176,11 @@ export function useLogStream(
         es.addEventListener('error', () => {
           es.close()
           eventSourceRef.current = null
-          updateStream({
-            isStreaming: false,
-            error: 'Live stream disconnected. Continuing with polling.',
-          })
+          updateStream({ isStreaming: false })
           startPolling()
         })
       } catch {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- abort may happen concurrently
-        if (!abort.signal.aborted) {
-          updateStream({
-            error: 'Failed to connect live stream. Using polling fallback.',
-          })
-        }
+        // Polling remains active if EventSource cannot be constructed.
       }
     })()
 

--- a/crates/oore-runner/src/lib.rs
+++ b/crates/oore-runner/src/lib.rs
@@ -278,7 +278,12 @@ fn materialize_android_signing_files(
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = fs::Permissions::from_mode(0o600);
-        let _ = fs::set_permissions(&keystore_path, perms);
+        fs::set_permissions(&keystore_path, perms).map_err(|e| {
+            anyhow::anyhow!(
+                "failed to secure Android keystore {}: {e}",
+                keystore_path.display()
+            )
+        })?;
     }
 
     let key_properties_path = android_dir.join("key.properties");
@@ -293,6 +298,18 @@ fn materialize_android_signing_files(
             key_properties_path.display()
         )
     })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = fs::Permissions::from_mode(0o600);
+        fs::set_permissions(&key_properties_path, perms).map_err(|e| {
+            anyhow::anyhow!(
+                "failed to secure Android key.properties {}: {e}",
+                key_properties_path.display()
+            )
+        })?;
+    }
 
     Ok(AndroidSigningMaterialization {
         keystore_path,
@@ -3435,6 +3452,27 @@ mod tests {
         assert!(key_properties.contains("keyPassword=key-pass"));
         assert!(key_properties.contains("keyAlias=upload"));
         assert!(key_properties.contains("storeFile=oore-upload-keystore.jks"));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&keystore_path)
+                    .expect("keystore metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+            assert_eq!(
+                fs::metadata(&key_properties_path)
+                    .expect("key.properties metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
 
         cleanup_workspace(&workspace);
     }

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -14,6 +14,10 @@ Rules:
 
 ## 2026-07-13
 
+- **PAT-free alpha release dispatch**:
+  - Autotag now uses the repository-scoped GitHub Actions token to push release tags and explicitly dispatches the tag-aware Release workflow, removing the expired `RELEASE_PAT` bottleneck without losing downstream release execution to GitHub's recursion guard.
+  - Release smoke coverage enforces the required token permissions, dispatch path, and absence of personal access-token coupling.
+  - Linear release channels doc: https://linear.app/oorebuild/document/release-channels-alpha-beta-stable-via-github-actions-993db297927a
 - **Graceful build-log transport fallback and explicit Android signing guidance**:
   - Build logs now treat SSE-to-polling fallback as a normal transport change instead of showing a persistent error while polling continues successfully.
   - Generated Android signing credentials use owner-only file permissions, and the signing guide now documents both zero-configuration temporary files and an explicit `CI=true` / `OORE_ANDROID_*` Gradle path.

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -14,6 +14,11 @@ Rules:
 
 ## 2026-07-13
 
+- **Graceful build-log transport fallback and explicit Android signing guidance**:
+  - Build logs now treat SSE-to-polling fallback as a normal transport change instead of showing a persistent error while polling continues successfully.
+  - Generated Android signing credentials use owner-only file permissions, and the signing guide now documents both zero-configuration temporary files and an explicit `CI=true` / `OORE_ANDROID_*` Gradle path.
+  - Linear feature doc: https://linear.app/oorebuild/document/feature-frontend-product-quality-and-build-experience-overhaul-c257decee5c5
+
 - **Repository-first build setup**:
   - Empty projects now inspect the linked repository before asking users to configure a pipeline. Valid checked-in workflows are recommended with a secret-free preview; missing, invalid, loading, and provider-error states lead to an explicit next action instead of a dense blank form.
   - Repository execution fields stay read-only in the setup form so the checked-in file remains the single source of truth. Manual templates remain available as a deliberate fallback.

--- a/tools/autotag.sh
+++ b/tools/autotag.sh
@@ -75,6 +75,12 @@ maybe_configure_github_token_remote() {
   fi
 }
 
+emit_tag() {
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    printf 'tag=%s\n' "$1" >>"$GITHUB_OUTPUT"
+  fi
+}
+
 latest_prod_version() {
   local latest_prod_tag latest_prod_ver
   latest_prod_tag="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -v -- '-' | head -n1 || true)"
@@ -132,6 +138,7 @@ if [[ "$CHANNEL" == "stable" ]]; then
   echo "[autotag:stable] cutting $tag"
   git tag -a "$tag" -m "Release $tag"
   git push origin "$tag"
+  emit_tag "$tag"
   exit 0
 fi
 
@@ -163,3 +170,4 @@ fi
 echo "[autotag:$CHANNEL] cutting $tag"
 git tag -a "$tag" -m "$label $tag"
 git push origin "$tag"
+emit_tag "$tag"

--- a/tools/release-smoke.sh
+++ b/tools/release-smoke.sh
@@ -8,6 +8,15 @@ echo "[release-smoke] Running local-first regression smoke checks..."
 
 # Release automation must remain taggable and resilient to transient Pages outages.
 grep -q '^  push:' .github/workflows/autotag.yml
+grep -q '^  actions: write' .github/workflows/autotag.yml
+grep -q '^  contents: write' .github/workflows/autotag.yml
+grep -q 'gh workflow run release.yml' .github/workflows/autotag.yml
+grep -q '^  workflow_dispatch:' .github/workflows/release.yml
+grep -q 'RELEASE_TAG:' .github/workflows/release.yml
+if grep -q 'RELEASE_PAT' .github/workflows/autotag.yml; then
+  echo "[release-smoke] Autotag must not depend on a personal access token." >&2
+  exit 1
+fi
 grep -q 'deploy_pages deploy-site-only' .github/workflows/release.yml
 grep -q 'deploy_pages deploy-docs-only' .github/workflows/release.yml
 grep -q 'deploy_pages deploy-web-only' .github/workflows/release.yml


### PR DESCRIPTION
## Summary
- replace expired RELEASE_PAT coupling with repository-token tag creation plus explicit tag-aware Release dispatch
- treat SSE-to-polling log fallback as normal and remove the persistent error banner
- secure generated Android keystore and key.properties files with enforced owner-only permissions on Unix
- document zero-config signing alongside the explicit CI and OORE_ANDROID_* path

## Validation
- make validate
- actionlint .github/workflows/autotag.yml .github/workflows/release.yml
- make release-smoke
- bunx react-doctor@latest --verbose --diff (no issues)
- cargo test -p oore-runner android_signing_materializes_keystore_and_key_properties

## Release
Merge to alpha should cut the next prerelease tag and explicitly dispatch its Release workflow.