### PR TITLE
fix(release): enable default-branch dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to build and publish
+        required: true
+        type: string
 
 concurrency:
   group: release-${{ github.ref }}

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -10,6 +10,12 @@ Rules:
 - Any code change under `apps/`, `crates/`, `tools/`, etc. must add an entry here.
 - Include a Linear issue/doc link for each entry.
 
+## 2026-07-13
+
+- **Default-branch release dispatch compatibility**:
+  - The default branch now declares the tag input used by channel Autotag workflows, allowing GitHub to accept release dispatches whose executable workflow revision lives on `alpha`, `beta`, or `stable`.
+  - Linear release channels doc: https://linear.app/oorebuild/document/release-channels-alpha-beta-stable-via-github-actions-993db297927a
+
 ## 2026-05-22
 
 - **Frontend guided setup hints**:


### PR DESCRIPTION
## Summary
- declare the release workflow dispatch and required tag input on the GitHub default branch
- unblock alpha, beta, and stable workflows from dispatching their tag-aware workflow revisions

## Context
Autotag successfully pushed v0.1.29-alpha.37, but GitHub rejected dispatch with HTTP 422 because workflow_dispatch was absent from master.

## Validation
- actionlint (excluding two pre-existing master-only jarvis/shellcheck findings)
- bun run docs:check
- git diff --check