### PR TITLE
fix(release): dispatch from channel branch

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -36,4 +36,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.autotag.outputs.tag }}
-        run: gh workflow run release.yml --ref "${AUTOTAG_BRANCH}" --field tag="${TAG}"
+        run: gh workflow run release.yml --ref "${GITHUB_REF_NAME}" --field tag="${TAG}"

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -14,6 +14,10 @@ Rules:
 
 ## 2026-07-13
 
+- **Release dispatch branch propagation fix**:
+  - Autotag now dispatches the Release workflow from GitHub's built-in branch ref instead of a step-local variable that was unavailable during dispatch, preventing alpha tags from accidentally starting the default-branch release definition.
+  - Release smoke coverage locks the dispatch ref to `GITHUB_REF_NAME`.
+  - Linear release channels doc: https://linear.app/oorebuild/document/release-channels-alpha-beta-stable-via-github-actions-993db297927a
 - **Retention settings authorization fix**:
   - Global retention reads and writes now use the registered `instance_settings` RBAC resource, so owners and admins can load and manage retention instead of receiving a false `permission_denied` response.
   - Linear feature doc: https://linear.app/oorebuild/document/feature-product-trust-hardening-release-592dfc525e77

--- a/tools/release-smoke.sh
+++ b/tools/release-smoke.sh
@@ -11,6 +11,7 @@ grep -q '^  push:' .github/workflows/autotag.yml
 grep -q '^  actions: write' .github/workflows/autotag.yml
 grep -q '^  contents: write' .github/workflows/autotag.yml
 grep -q 'gh workflow run release.yml' .github/workflows/autotag.yml
+grep -q -- '--ref "${GITHUB_REF_NAME}"' .github/workflows/autotag.yml
 grep -q '^  workflow_dispatch:' .github/workflows/release.yml
 grep -q 'RELEASE_TAG:' .github/workflows/release.yml
 if grep -q 'RELEASE_PAT' .github/workflows/autotag.yml; then


### PR DESCRIPTION
## Summary
- dispatch release workflows from GitHub's built-in channel ref
- prevent alpha tags from falling back to the default-branch release definition
- lock the behavior in release smoke coverage

## Validation
- actionlint .github/workflows/autotag.yml .github/workflows/release.yml
- make release-smoke
- bun run docs:check