### PR TITLE
perf(release): cache Rust builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,9 +111,18 @@ jobs:
         with:
           ref: ${{ env.RELEASE_TAG }}
 
+      - name: Setup Rust target
+        run: rustup target add "${{ matrix.target }}"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
+          cache-on-failure: true
+          cache-workspace-crates: true
+          key: ${{ matrix.target }}
+
       - name: Build Rust
         run: |
-          rustup target add "${{ matrix.target }}"
           cargo build --release -p oored -p oore --target "${{ matrix.target }}"
           mkdir -p dist/rust
           cp "target/${{ matrix.target }}/release/oored" dist/rust/oored

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,36 +166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-config"
-version = "1.8.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c456581cb3c77fafcc8c67204a70680d40b61112d6da78c77bd31d945b65f1b5"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-sdk-sso",
- "aws-sdk-ssooidc",
- "aws-sdk-sts",
- "aws-smithy-async",
- "aws-smithy-http 0.63.3",
- "aws-smithy-json 0.62.3",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "hex",
- "http 1.4.0",
- "ring",
- "time",
- "tokio",
- "tracing",
- "url",
- "zeroize",
-]
-
-[[package]]
 name = "aws-credential-types"
 version = "1.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,7 +239,7 @@ dependencies = [
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
  "aws-smithy-http 0.62.6",
- "aws-smithy-json 0.61.9",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -288,79 +258,6 @@ dependencies = [
  "sha2",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "aws-sdk-sso"
-version = "1.93.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcb38bb33fc0a11f1ffc3e3e85669e0a11a37690b86f77e75306d8f369146a0"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http 0.63.3",
- "aws-smithy-json 0.62.3",
- "aws-smithy-observability",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.0",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-ssooidc"
-version = "1.95.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ada8ffbea7bd1be1f53df1dadb0f8fdb04badb13185b3321b929d1ee3caad09"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http 0.63.3",
- "aws-smithy-json 0.62.3",
- "aws-smithy-observability",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "http 1.4.0",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-sts"
-version = "1.97.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6443ccadc777095d5ed13e21f5c364878c9f5bad4e35187a6cdbd863b0afcad"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http 0.63.3",
- "aws-smithy-json 0.62.3",
- "aws-smithy-observability",
- "aws-smithy-query",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
- "fastrand",
- "http 0.2.12",
- "http 1.4.0",
- "regex-lite",
- "tracing",
 ]
 
 [[package]]
@@ -516,31 +413,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-json"
-version = "0.62.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb96aa208d62ee94104645f7b2ecaf77bf27edf161590b6224bfbac2832f979"
-dependencies = [
- "aws-smithy-types",
-]
-
-[[package]]
 name = "aws-smithy-observability"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0a46543fbc94621080b3cf553eb4cbbdc41dd9780a30c4756400f0139440a1d"
 dependencies = [
  "aws-smithy-runtime-api",
-]
-
-[[package]]
-name = "aws-smithy-query"
-version = "0.60.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cebbddb6f3a5bd81553643e9c7daf3cc3dc5b0b5f398ac668630e8a84e6fff0"
-dependencies = [
- "aws-smithy-types",
- "urlencoding",
 ]
 
 [[package]]
@@ -2697,7 +2575,6 @@ version = "0.1.10"
 dependencies = [
  "anyhow",
  "async-stream",
- "aws-config",
  "aws-sdk-s3",
  "axum 0.8.8",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ base64 = "0.22"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
 zeroize = { version = "1", features = ["derive"] }
 aws-sdk-s3 = "1"
-aws-config = { version = "1", features = ["behavior-version-latest"] }
 
 # Observability: OpenTelemetry + Prometheus
 opentelemetry = "0.28"

--- a/apps/docs-site/docs/operations/release-automation-mac-mini.md
+++ b/apps/docs-site/docs/operations/release-automation-mac-mini.md
@@ -1,41 +1,35 @@
 ---
 status: implemented
-description: "Automate Oore CI releases using GitHub Actions on a self-hosted Mac mini runner."
+description: "Automate Oore CI releases using GitHub Actions with hosted or self-hosted runners."
 ---
 
 # Release Automation
 
-CI/CD is driven by GitHub Actions running on a self-hosted Mac mini runner (`jarvis`). All workflows — validation, autotagging, and release — run on the same machine with zero billable GitHub Actions minutes.
+CI/CD is driven by GitHub Actions. Workflows use GitHub-hosted runners by default and can be routed to self-hosted runners through the `RUNNER_LINUX` and `RUNNER_MACOS` repository variables.
 
 ## Runner Setup
 
-The GitHub Actions runner is installed at `~/actions-runner` on jarvis and runs as a launchd user agent (`actions.runner.devaryakjha-oore.build.jarvis`). It auto-starts on login.
-
-Toolchain installed via Homebrew: `rustup`, `bun`, `gh`.
-
-Runner labels: `self-hosted`, `macOS`, `ARM64`, `jarvis`.
+GitHub-hosted runners require no setup. A self-hosted macOS runner must provide `rustup`, Bun, and GitHub CLI, then its label can be assigned to `RUNNER_MACOS`.
 
 ## Workflow
 
 - PR/push validation (`validate.yml`):
-  - Two parallel jobs on jarvis: Frontend & Docs (bun), Rust (cargo)
+  - Change-aware Frontend, Docs, and Rust jobs
 - Merge to `alpha` / `beta` / `stable` (`autotag.yml`):
   - CI auto-cuts the appropriate semver tag
 - Tag push `v*` (`release.yml`):
-  - Single job on jarvis: build web, cross-compile Rust (arm64 + x86_64), package tarballs, generate release notes, deploy to Cloudflare Pages, create GitHub Release with artifacts
+  - Parallel macOS arm64 and x86_64 Rust builds with target-specific Cargo caches
+  - Parallel Cloudflare Pages deployment
+  - Final web build, packaging, release notes, and GitHub Release publication
 
 ## Required Secrets
 
 Set these in GitHub repo settings (Settings > Secrets and variables > Actions):
 
-- `RELEASE_PAT`:
-  - Fine-grained PAT with `contents: write` on this repo.
-  - Used by the autotag workflow to push tags that trigger the release workflow.
-  - (Tags pushed by the automatic `GITHUB_TOKEN` do not trigger downstream workflows.)
 - `CLOUDFLARE_API_TOKEN`:
   - Used by `wrangler pages deploy`.
 
-`GITHUB_TOKEN` is automatic and used for GitHub Releases and general CI operations.
+`GITHUB_TOKEN` is automatic. Autotag uses it to push the tag and explicitly dispatch the Release workflow, so no personal access token is required.
 
 ## Before Promoting to Stable
 

--- a/crates/oored/Cargo.toml
+++ b/crates/oored/Cargo.toml
@@ -39,7 +39,6 @@ base64.workspace = true
 sqlx.workspace = true
 zeroize.workspace = true
 aws-sdk-s3.workspace = true
-aws-config.workspace = true
 utoipa.workspace = true
 ipnet.workspace = true
 

--- a/crates/oored/src/storage.rs
+++ b/crates/oored/src/storage.rs
@@ -5,8 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
-use aws_config::BehaviorVersion;
-use aws_sdk_s3::config::{Credentials, Region};
+use aws_sdk_s3::config::{BehaviorVersion, Credentials, Region};
 use aws_sdk_s3::presigning::PresigningConfig;
 use oore_contract::{ArtifactStorageProvider, ArtifactStorageSettings, ArtifactStorageSource};
 use sqlx::Row;

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -14,6 +14,11 @@ Rules:
 
 ## 2026-07-13
 
+- **Faster release builds**:
+  - macOS release jobs now restore target-specific Cargo caches, including unchanged workspace crates, instead of compiling the complete Rust dependency graph twice for every release.
+  - The daemon no longer pulls the unused AWS configuration, SSO, SSO-OIDC, and STS dependency chain merely to access the S3 behavior-version type.
+  - Release operations documentation now reflects the PAT-free GitHub Actions flow and hosted-runner defaults.
+  - Linear release channels doc: https://linear.app/oorebuild/document/release-channels-alpha-beta-stable-via-github-actions-993db297927a
 - **Release dispatch branch propagation fix**:
   - Autotag now dispatches the Release workflow from GitHub's built-in branch ref instead of a step-local variable that was unavailable during dispatch, preventing alpha tags from accidentally starting the default-branch release definition.
   - Release smoke coverage locks the dispatch ref to `GITHUB_REF_NAME`.

--- a/tools/release-smoke.sh
+++ b/tools/release-smoke.sh
@@ -14,6 +14,9 @@ grep -q 'gh workflow run release.yml' .github/workflows/autotag.yml
 grep -q -- '--ref "${GITHUB_REF_NAME}"' .github/workflows/autotag.yml
 grep -q '^  workflow_dispatch:' .github/workflows/release.yml
 grep -q 'RELEASE_TAG:' .github/workflows/release.yml
+grep -q 'uses: Swatinem/rust-cache@v2' .github/workflows/release.yml
+grep -q 'cache-workspace-crates: true' .github/workflows/release.yml
+grep -Fq 'key: ${{ matrix.target }}' .github/workflows/release.yml
 if grep -q 'RELEASE_PAT' .github/workflows/autotag.yml; then
   echo "[release-smoke] Autotag must not depend on a personal access token." >&2
   exit 1


### PR DESCRIPTION
## What changed
- restore target-specific Rust caches for the macOS release matrix, including unchanged workspace crates
- remove the unused aws-config/SSO/STS dependency chain from oored
- correct release operations docs and lock the cache contract into release smoke coverage

## Validation
- make validate
- make release-smoke
- actionlint .github/workflows/release.yml .github/workflows/autotag.yml

The first release populates the new per-target caches; the next normal release is the representative warm-cache measurement.