### PR TITLE
feat(web): surface runtime updates in sidebar

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -8,6 +8,7 @@ import {
 import InstanceSwitcher from '@/components/InstanceSwitcher'
 import NavMain from '@/components/nav-main'
 import NavUser from '@/components/nav-user'
+import RuntimeUpdateNotice from '@/components/runtime-update-notice'
 import { useActiveInstance } from '@/stores/instance-store'
 import { useAuthStore } from '@/stores/auth-store'
 
@@ -29,6 +30,7 @@ export default function AppSidebar(
         <NavMain />
       </SidebarContent>
       <SidebarFooter>
+        <RuntimeUpdateNotice />
         <NavUser />
       </SidebarFooter>
       <SidebarRail />

--- a/apps/web/src/components/runtime-update-dialog.tsx
+++ b/apps/web/src/components/runtime-update-dialog.tsx
@@ -1,0 +1,238 @@
+import {
+  ArrowRight01Icon,
+  ArrowUpRight01Icon,
+  Download04Icon,
+} from '@hugeicons/core-free-icons'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { toast } from 'sonner'
+import type { RuntimeReleaseStatus } from '@/lib/types'
+import { useRuntimeUpdates } from '@/hooks/use-runtime-updates'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Spinner } from '@/components/ui/spinner'
+
+export function formatReleaseNotes(notes: string): string {
+  return notes
+    .replace(/^#{1,6}\s+.*(?:\r?\n)+/, '')
+    .replace(/^\*\*Full Changelog\*\*:.*$/gim, '')
+    .replace(/\[([^\]]+)]\([^)]+\)/g, '$1')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .trim()
+}
+
+function updateButtonLabel(phase: string | undefined, pending: boolean) {
+  if (pending) return 'Starting...'
+  if (phase === 'restarting') return 'Restarting...'
+  if (phase === 'updating') return 'Updating...'
+  return 'Update now'
+}
+
+function RuntimeUpdateCard({
+  name,
+  release,
+  phase,
+  pending,
+  managed,
+  onUpdate,
+}: {
+  name: string
+  release: RuntimeReleaseStatus
+  phase?: string
+  pending: boolean
+  managed: boolean
+  onUpdate: () => void
+}) {
+  const busy = phase === 'updating' || phase === 'restarting' || pending
+
+  return (
+    <Card size="sm">
+      <CardHeader>
+        <CardTitle className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
+          {name}
+        </CardTitle>
+        <CardDescription>{release.channel} channel</CardDescription>
+        <CardAction>
+          <Badge variant="warning">Update available</Badge>
+        </CardAction>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-xs text-muted-foreground">
+            {release.version}
+          </span>
+          <HugeiconsIcon
+            icon={ArrowRight01Icon}
+            size={14}
+            className="shrink-0 text-muted-foreground"
+          />
+          <span className="font-mono text-xs font-medium">
+            {release.latest_version}
+          </span>
+        </div>
+        {!managed ? (
+          <p className="mt-2 text-xs text-muted-foreground">
+            Install this runtime as a managed service to update it here.
+          </p>
+        ) : null}
+      </CardContent>
+      <CardFooter>
+        <Button
+          size="sm"
+          className="w-full"
+          disabled={!managed || busy}
+          onClick={onUpdate}
+        >
+          {busy ? (
+            <Spinner />
+          ) : (
+            <HugeiconsIcon icon={Download04Icon} data-icon="inline-start" />
+          )}
+          {updateButtonLabel(phase, pending)}
+        </Button>
+      </CardFooter>
+    </Card>
+  )
+}
+
+export default function RuntimeUpdateDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const updates = useRuntimeUpdates()
+  const frontend = updates.frontendRelease.data
+  const backend = updates.backendRelease.data
+  const frontendAvailable = frontend?.update_available === true
+  const backendAvailable = backend?.update_available === true
+  const releases = [
+    frontendAvailable ? frontend : null,
+    backendAvailable ? backend : null,
+  ]
+    .filter((release): release is RuntimeReleaseStatus => release !== null)
+    .filter(
+      (release, index, all) =>
+        all.findIndex(
+          (candidate) => candidate.release_url === release.release_url,
+        ) === index,
+    )
+  const frontendPhase =
+    updates.startFrontendUpdate.data?.phase ?? frontend?.phase
+  const backendPhase =
+    updates.startBackendUpdate.data?.phase ?? updates.backendUpdate.data?.phase
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Updates available</DialogTitle>
+          <DialogDescription>
+            Review what changed before updating this Oore installation.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          {frontendAvailable ? (
+            <RuntimeUpdateCard
+              name="Frontend"
+              release={frontend}
+              phase={frontendPhase}
+              pending={updates.startFrontendUpdate.isPending}
+              managed={frontend.managed_service}
+              onUpdate={() =>
+                updates.startFrontendUpdate.mutate(undefined, {
+                  onSuccess: () =>
+                    toast.success(
+                      'Frontend update started. The UI will reconnect after restart.',
+                    ),
+                  onError: (error) => toast.error(error.message),
+                })
+              }
+            />
+          ) : null}
+          {backendAvailable ? (
+            <RuntimeUpdateCard
+              name="Backend"
+              release={backend}
+              phase={backendPhase}
+              pending={updates.startBackendUpdate.isPending}
+              managed={updates.backendUpdate.data?.managed_service === true}
+              onUpdate={() =>
+                updates.startBackendUpdate.mutate(undefined, {
+                  onSuccess: () =>
+                    toast.success(
+                      'Backend update started. Readiness will recover after restart.',
+                    ),
+                  onError: (error) => toast.error(error.message),
+                })
+              }
+            />
+          ) : null}
+        </div>
+
+        <div className="flex flex-col gap-4">
+          {releases.map((release) => {
+            const notes = formatReleaseNotes(release.release_notes)
+            return (
+              <section
+                key={release.release_url}
+                className="flex flex-col gap-2"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-medium">
+                      {release.release_name}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      What changed in {release.latest_version}
+                    </p>
+                  </div>
+                  <Badge
+                    variant="link"
+                    render={
+                      <a
+                        href={release.changelog_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      />
+                    }
+                  >
+                    Full changelog
+                    <HugeiconsIcon
+                      icon={ArrowUpRight01Icon}
+                      data-icon="inline-end"
+                    />
+                  </Badge>
+                </div>
+                <ScrollArea className="max-h-52 border bg-muted/30">
+                  <p className="whitespace-pre-wrap p-4 text-sm leading-6">
+                    {notes ||
+                      'No release notes were published for this version.'}
+                  </p>
+                </ScrollArea>
+              </section>
+            )
+          })}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/runtime-update-notice.test.tsx
+++ b/apps/web/src/components/runtime-update-notice.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import RuntimeUpdateNotice from './runtime-update-notice'
+import { formatReleaseNotes } from './runtime-update-dialog'
+import { SidebarProvider } from '@/components/ui/sidebar'
+
+const { useRuntimeUpdates } = vi.hoisted(() => ({
+  useRuntimeUpdates: vi.fn(),
+}))
+
+vi.mock('@/hooks/use-runtime-updates', () => ({ useRuntimeUpdates }))
+
+const release = {
+  phase: 'idle' as const,
+  error: null,
+  managed_service: true,
+  version: '1.2.3-alpha.1',
+  latest_version: '1.2.3-alpha.2',
+  channel: 'alpha',
+  github_repo: 'example/oore',
+  update_available: true,
+  release_name: 'Alpha 2',
+  release_notes: '- fix(web): show updates everywhere',
+  release_url: 'https://github.com/example/oore/releases/tag/v1.2.3-alpha.2',
+  changelog_url:
+    'https://github.com/example/oore/compare/v1.2.3-alpha.1...v1.2.3-alpha.2',
+}
+
+beforeEach(() => {
+  window.matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  })
+  useRuntimeUpdates.mockReturnValue({
+    frontendRelease: { data: release },
+    backendRelease: { data: release },
+    backendUpdate: { data: { managed_service: true, phase: 'idle' } },
+    startFrontendUpdate: { data: undefined, isPending: false, mutate: vi.fn() },
+    startBackendUpdate: { data: undefined, isPending: false, mutate: vi.fn() },
+  })
+})
+
+describe('formatReleaseNotes', () => {
+  it('keeps the useful release summary without duplicate headings and links', () => {
+    expect(
+      formatReleaseNotes(`# v1.2.3
+
+Changes since v1.2.2:
+
+- fix(web): show updates everywhere
+
+**Full Changelog**: https://github.com/example/oore/compare/v1.2.2...v1.2.3`),
+    ).toBe('Changes since v1.2.2:\n\n- fix(web): show updates everywhere')
+  })
+})
+
+describe('RuntimeUpdateNotice', () => {
+  it('opens a dialog with both runtimes and one shared changelog', async () => {
+    render(
+      <SidebarProvider>
+        <RuntimeUpdateNotice />
+      </SidebarProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /Updates available/i }))
+
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByText('Frontend')).toBeTruthy()
+    expect(within(dialog).getByText('Backend')).toBeTruthy()
+    expect(within(dialog).getAllByText('1.2.3-alpha.1')).toHaveLength(2)
+    expect(within(dialog).getAllByText('1.2.3-alpha.2')).toHaveLength(2)
+    expect(within(dialog).getAllByText(/show updates everywhere/)).toHaveLength(
+      1,
+    )
+    expect(
+      within(dialog)
+        .getByRole('link', { name: /Full changelog/i })
+        .getAttribute('href'),
+    ).toBe(release.changelog_url)
+  })
+})

--- a/apps/web/src/components/runtime-update-notice.tsx
+++ b/apps/web/src/components/runtime-update-notice.tsx
@@ -1,0 +1,46 @@
+import { Suspense, lazy, useState } from 'react'
+import { WorkUpdateIcon } from '@hugeicons/core-free-icons'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { useRuntimeUpdates } from '@/hooks/use-runtime-updates'
+import {
+  SidebarMenu,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from '@/components/ui/sidebar'
+
+const RuntimeUpdateDialog = lazy(() => import('./runtime-update-dialog'))
+
+export default function RuntimeUpdateNotice() {
+  const [open, setOpen] = useState(false)
+  const updates = useRuntimeUpdates()
+  const updateCount =
+    Number(updates.frontendRelease.data?.update_available === true) +
+    Number(updates.backendRelease.data?.update_available === true)
+
+  if (updateCount === 0) return null
+
+  return (
+    <>
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            variant="outline"
+            tooltip={`${updateCount} update${updateCount === 1 ? '' : 's'} available`}
+            onClick={() => setOpen(true)}
+          >
+            <HugeiconsIcon icon={WorkUpdateIcon} size={18} />
+            <span>Updates available</span>
+          </SidebarMenuButton>
+          <SidebarMenuBadge>{updateCount}</SidebarMenuBadge>
+        </SidebarMenuItem>
+      </SidebarMenu>
+
+      {open ? (
+        <Suspense fallback={null}>
+          <RuntimeUpdateDialog open={open} onOpenChange={setOpen} />
+        </Suspense>
+      ) : null}
+    </>
+  )
+}

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -515,7 +515,7 @@ function SidebarMenuButton({
       },
       props,
     ),
-    render: !tooltip ? render : TooltipTrigger,
+    render: !tooltip ? render : <TooltipTrigger />,
     state: {
       slot: 'sidebar-menu-button',
       sidebar: 'menu-button',

--- a/apps/web/src/hooks/use-runtime-updates.ts
+++ b/apps/web/src/hooks/use-runtime-updates.ts
@@ -12,6 +12,22 @@ interface BackendRelease {
   github_repo?: string | null
 }
 
+const HEALTH_REFRESH_INTERVAL = 60_000
+const RELEASE_REFRESH_INTERVAL = 5 * 60_000
+
+export interface RuntimeHealth extends BackendRelease {
+  ok?: boolean
+  package_version?: string
+}
+
+async function fetchRuntimeHealth(path: string): Promise<RuntimeHealth> {
+  const response = await fetch(path, { cache: 'no-store' })
+  if (!response.ok) {
+    throw new Error(`Health check failed (${response.status})`)
+  }
+  return (await response.json()) as RuntimeHealth
+}
+
 async function localUpdateRequest<T>(
   token: string,
   method: 'GET' | 'POST',
@@ -34,13 +50,35 @@ async function localUpdateRequest<T>(
   return (await response.json()) as T
 }
 
-export function useRuntimeUpdates(backend: BackendRelease) {
+export function useRuntimeUpdates() {
   const queryClient = useQueryClient()
   const instance = useActiveInstance()
   const baseUrl = resolveInstanceApiBaseUrl(instance)
   const token = useAuthStore((state) => state.token)
   const isOwner = useAuthStore((state) => state.user?.role === 'owner')
   const instanceKey = instance?.id ?? '__none__'
+
+  const frontendHealth = useQuery({
+    queryKey: ['runtime-health', 'oore-web'],
+    queryFn: () => fetchRuntimeHealth('/__oore_web_healthz'),
+    retry: false,
+    staleTime: 30_000,
+    refetchInterval: HEALTH_REFRESH_INTERVAL,
+  })
+
+  const backendHealth = useQuery({
+    queryKey: [instanceKey, 'runtime-health', 'oored'],
+    queryFn: () => {
+      if (!baseUrl) throw new Error('No active instance URL')
+      return fetchRuntimeHealth(new URL('/healthz', baseUrl).toString())
+    },
+    enabled: !!baseUrl,
+    retry: false,
+    staleTime: 30_000,
+    refetchInterval: HEALTH_REFRESH_INTERVAL,
+  })
+
+  const backend = backendHealth.data ?? {}
 
   const frontendRelease = useQuery({
     queryKey: [instanceKey, 'runtime-update', 'frontend-release'],
@@ -51,7 +89,7 @@ export function useRuntimeUpdates(backend: BackendRelease) {
       query.state.data?.phase === 'updating' ||
       query.state.data?.phase === 'restarting'
         ? 2_000
-        : false,
+        : RELEASE_REFRESH_INTERVAL,
   })
 
   const backendRelease = useQuery({
@@ -80,6 +118,7 @@ export function useRuntimeUpdates(backend: BackendRelease) {
       !!backend.channel &&
       !!backend.github_repo,
     staleTime: 60_000,
+    refetchInterval: RELEASE_REFRESH_INTERVAL,
   })
 
   const backendUpdate = useQuery({
@@ -112,6 +151,8 @@ export function useRuntimeUpdates(backend: BackendRelease) {
   })
 
   return {
+    frontendHealth,
+    backendHealth,
     frontendRelease,
     backendRelease,
     backendUpdate,

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -210,6 +210,10 @@ export interface RuntimeReleaseStatus extends RuntimeUpdateStatus {
   channel: string
   github_repo: string
   update_available: boolean
+  release_name: string
+  release_notes: string
+  release_url: string
+  changelog_url: string
 }
 
 // ── Structured API error ────────────────────────────────────────

--- a/apps/web/src/routes/settings/preferences.tsx
+++ b/apps/web/src/routes/settings/preferences.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState } from 'react'
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router'
-import { useQuery } from '@tanstack/react-query'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import z from 'zod'
@@ -227,24 +226,8 @@ type ExternalAccessNetworkFormValues = z.infer<
   typeof externalAccessNetworkSchema
 >
 
-interface RuntimeHealth {
-  ok?: boolean
-  version?: string
-  channel?: string | null
-  github_repo?: string | null
-  package_version?: string
-}
-
-async function fetchRuntimeHealth(path: string): Promise<RuntimeHealth> {
-  const response = await fetch(path, { cache: 'no-store' })
-  if (!response.ok) {
-    throw new Error(`Health check failed (${response.status})`)
-  }
-  return (await response.json()) as RuntimeHealth
-}
-
 function healthVersionLabel(
-  health: RuntimeHealth | undefined,
+  health: { version?: string } | undefined,
   isLoading: boolean,
   isError: boolean,
 ): string {
@@ -303,24 +286,9 @@ function PreferencesPage() {
   const canBrowseLocalFs = uiIsLoopback && backendIsLoopback
   const settingsQuery = useArtifactStorageSettings()
   const preferencesQuery = useInstancePreferences()
-  const webHealthQuery = useQuery({
-    queryKey: ['runtime-health', 'oore-web'],
-    queryFn: () => fetchRuntimeHealth('/__oore_web_healthz'),
-    retry: false,
-    staleTime: 30_000,
-  })
-  const backendHealthQuery = useQuery({
-    queryKey: [instance?.id ?? '__none__', 'runtime-health', 'oored'],
-    queryFn: () => {
-      const baseUrl = instanceApiBaseUrl
-      if (!baseUrl) throw new Error('No active instance URL')
-      return fetchRuntimeHealth(new URL('/healthz', baseUrl).toString())
-    },
-    enabled: !!instanceApiBaseUrl,
-    retry: false,
-    staleTime: 30_000,
-  })
-  const runtimeUpdates = useRuntimeUpdates(backendHealthQuery.data ?? {})
+  const runtimeUpdates = useRuntimeUpdates()
+  const webHealthQuery = runtimeUpdates.frontendHealth
+  const backendHealthQuery = runtimeUpdates.backendHealth
   const frontendUpdatePhase =
     runtimeUpdates.startFrontendUpdate.data?.phase ??
     runtimeUpdates.frontendRelease.data?.phase

--- a/apps/web/tools/oore-web.js
+++ b/apps/web/tools/oore-web.js
@@ -565,6 +565,18 @@ function findAssetUrl(release, name) {
   return asset.browser_download_url
 }
 
+function releaseChangelogUrl(release, repo) {
+  const fallback =
+    release.html_url ||
+    `https://github.com/${repo}/releases/tag/${release.tag_name}`
+  const candidate = release.body?.match(
+    /\*\*Full Changelog\*\*:\s*(https:\/\/github\.com\/\S+)/,
+  )?.[1]
+  return candidate?.startsWith(`https://github.com/${repo}/compare/`)
+    ? candidate
+    : fallback
+}
+
 function releasePlatform() {
   if (process.platform === 'darwin') return 'darwin'
   if (process.platform === 'linux') return 'linux'
@@ -930,7 +942,7 @@ export async function authorizeOwner(
   return profile?.user?.role === 'owner'
 }
 
-async function getWebUpdateStatus(updateState, searchParams) {
+export async function getWebUpdateStatus(updateState, searchParams) {
   const metadata = readInstalledMetadata()
   const current = parseVersion(searchParams.get('current') || metadata.version)
   const channel = parseChannel(
@@ -948,6 +960,12 @@ async function getWebUpdateStatus(updateState, searchParams) {
     github_repo: repo,
     latest_version: latest.raw,
     update_available: compareVersions(current, latest) < 0,
+    release_name: release.name || release.tag_name,
+    release_notes: release.body || '',
+    release_url:
+      release.html_url ||
+      `https://github.com/${repo}/releases/tag/${release.tag_name}`,
+    changelog_url: releaseChangelogUrl(release, repo),
     managed_service: hasManagedWebService(),
     ...updateState,
   }

--- a/apps/web/tools/oore-web.test.js
+++ b/apps/web/tools/oore-web.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import path from 'node:path'
 import { spawn } from 'node:child_process'
 import { createServer } from 'node:http'
@@ -6,6 +6,7 @@ import { createServer } from 'node:http'
 import {
   applyTrustedProxyHeaders,
   authorizeOwner,
+  getWebUpdateStatus,
   isApiPath,
 } from './oore-web.js'
 
@@ -47,6 +48,51 @@ function sendJson(response, data, proxied = false) {
   if (proxied) response.setHeader('x-oore-web-proxy', '1')
   response.end(JSON.stringify(data))
 }
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('oore-web runtime release metadata', () => {
+  it('returns the changelog and release URL with update availability', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        Response.json([
+          {
+            tag_name: 'v1.2.3-alpha.2',
+            name: 'Alpha 2',
+            body: '- Faster builds\n\n**Full Changelog**: https://github.com/example/oore/compare/v1.2.3-alpha.1...v1.2.3-alpha.2',
+            html_url:
+              'https://github.com/example/oore/releases/tag/v1.2.3-alpha.2',
+            draft: false,
+            prerelease: true,
+          },
+        ]),
+      ),
+    )
+
+    const status = await getWebUpdateStatus(
+      { phase: 'idle', error: null },
+      new URLSearchParams({
+        current: '1.2.3-alpha.1',
+        channel: 'alpha',
+        repo: 'example/oore',
+      }),
+    )
+
+    expect(status).toMatchObject({
+      version: '1.2.3-alpha.1',
+      latest_version: '1.2.3-alpha.2',
+      update_available: true,
+      release_name: 'Alpha 2',
+      release_notes:
+        '- Faster builds\n\n**Full Changelog**: https://github.com/example/oore/compare/v1.2.3-alpha.1...v1.2.3-alpha.2',
+      release_url:
+        'https://github.com/example/oore/releases/tag/v1.2.3-alpha.2',
+      changelog_url:
+        'https://github.com/example/oore/compare/v1.2.3-alpha.1...v1.2.3-alpha.2',
+    })
+  })
+})
 
 describe('oore-web trusted proxy contract', () => {
   it('proxies the backend readiness endpoint', () => {

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -14,6 +14,11 @@ Rules:
 
 ## 2026-07-13
 
+- **Persistent runtime update notice**:
+  - Instance owners now see available frontend and backend updates directly above the sidebar user menu instead of needing to discover them in Preferences.
+  - The update dialog shows each runtime's current and target versions, managed-service readiness, generated release notes, and the GitHub comparison changelog before starting an update.
+  - Runtime health and release checks now share one TanStack Query path across the sidebar and Preferences, with lightweight periodic refreshes so newly published updates appear without navigating away.
+  - Linear feature doc: https://linear.app/oorebuild/document/feature-runtime-updates-from-the-web-ui-6b648f19a3f9
 - **Faster release builds**:
   - macOS release jobs now restore target-specific Cargo caches, including unchanged workspace crates, instead of compiling the complete Rust dependency graph twice for every release.
   - The daemon no longer pulls the unused AWS configuration, SSO, SSO-OIDC, and STS dependency chain merely to access the S3 behavior-version type.


### PR DESCRIPTION
## What changed

- show frontend and backend updates above the sidebar user menu
- present versions, release notes, changelog links, and update actions in an accessible dialog
- share runtime health/update queries with Preferences and lazy-load the dialog to preserve the initial bundle budget

## Validation

- make validate
- React Doctor: no changed-scope issues
- initial bundle: 226.65 KiB JS / 19.63 KiB CSS gzip