### PR TITLE
fix(gitlab): proxy private repository avatars

### DIFF
--- a/apps/docs-site/docs/public/openapi.json
+++ b/apps/docs-site/docs/public/openapi.json
@@ -1441,6 +1441,59 @@
         }
       }
     },
+    "/v1/integration-repositories/{id}/avatar": {
+      "get": {
+        "tags": [
+          "Integrations"
+        ],
+        "summary": "Fetch a private GitLab repository avatar through Oore",
+        "operationId": "repository_avatar",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Integration repository ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Repository avatar image",
+            "content": {
+              "image/*": {}
+            }
+          },
+          "404": {
+            "description": "Avatar not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "GitLab avatar unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/v1/integrations": {
       "get": {
         "tags": [
@@ -9609,6 +9662,12 @@
             ]
           },
           "repository_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "repository_provider": {
             "type": [
               "string",
               "null"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "test": "vitest run",
     "lint": "oxlint . && bun run lint:effects",
-    "lint:effects": "! grep -RInE '\\b(React\\.)?useEffect\\b' src --include='*.ts' --include='*.tsx' --exclude='use-mount-effect.ts' --exclude='use-breadcrumb-label.ts' --exclude='use-auto-scroll.ts' --exclude='use-build-notification.ts' --exclude='use-session-countdown.ts' --exclude='use-log-stream.ts' --exclude='use-index-auth-guard.ts' --exclude='use-trusted-proxy-auto-login.ts' --exclude='use-setup-route-transitions.ts' --exclude='use-window-event.ts'",
+    "lint:effects": "! grep -RInE '\\b(React\\.)?useEffect\\b' src --include='*.ts' --include='*.tsx' --exclude='use-mount-effect.ts' --exclude='use-breadcrumb-label.ts' --exclude='use-auto-scroll.ts' --exclude='use-build-notification.ts' --exclude='use-session-countdown.ts' --exclude='use-log-stream.ts' --exclude='use-index-auth-guard.ts' --exclude='use-trusted-proxy-auto-login.ts' --exclude='use-setup-route-transitions.ts' --exclude='use-window-event.ts' --exclude='use-repository-avatar-url.ts'",
     "format": "prettier",
     "check": "prettier --write . && oxlint --fix . && bun run lint:effects"
   },

--- a/apps/web/src/components/project-card.tsx
+++ b/apps/web/src/components/project-card.tsx
@@ -31,6 +31,8 @@ export default function ProjectCard({
               <RepositoryAvatar
                 fullName={project.repository_full_name}
                 avatarUrl={project.repository_avatar_url}
+                repositoryId={project.repository_id}
+                provider={project.repository_provider}
               />
             ) : null}
             <div className="min-w-0">

--- a/apps/web/src/components/repository-avatar.test.tsx
+++ b/apps/web/src/components/repository-avatar.test.tsx
@@ -1,7 +1,14 @@
 import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
-
+import { describe, expect, it, vi } from 'vitest'
 import RepositoryAvatar, { repositoryInitials } from './repository-avatar'
+
+const { mockUseRepositoryAvatarUrl } = vi.hoisted(() => ({
+  mockUseRepositoryAvatarUrl: vi.fn(),
+}))
+
+vi.mock('@/hooks/use-repository-avatar-url', () => ({
+  useRepositoryAvatarUrl: mockUseRepositoryAvatarUrl,
+}))
 
 describe('RepositoryAvatar', () => {
   it('derives a visible fallback from the repository name', () => {
@@ -10,5 +17,20 @@ describe('RepositoryAvatar', () => {
     expect(screen.getByText('OO')).toBeTruthy()
     expect(repositoryInitials('oore-ci/oore.build')).toBe('OO')
     expect(repositoryInitials('---')).toBe('R')
+  })
+
+  it('uses Oore for GitLab avatars', () => {
+    mockUseRepositoryAvatarUrl.mockReturnValue('blob:gitlab-avatar')
+
+    render(
+      <RepositoryAvatar
+        fullName="oore-ci/oore.build"
+        avatarUrl="https://gitlab.example/uploads/avatar.png"
+        repositoryId="repo-1"
+        provider="gitlab"
+      />,
+    )
+
+    expect(mockUseRepositoryAvatarUrl).toHaveBeenCalledWith('repo-1', true)
   })
 })

--- a/apps/web/src/components/repository-avatar.tsx
+++ b/apps/web/src/components/repository-avatar.tsx
@@ -1,4 +1,6 @@
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { useRepositoryAvatarUrl } from '@/hooks/use-repository-avatar-url'
+import type { ScmProvider } from '@/lib/types'
 
 export function repositoryInitials(fullName: string): string {
   const repositoryName = fullName.split('/').filter(Boolean).at(-1) ?? fullName
@@ -13,18 +15,31 @@ export function repositoryInitials(fullName: string): string {
 export default function RepositoryAvatar({
   fullName,
   avatarUrl,
+  repositoryId,
+  provider,
   size = 'sm',
 }: {
   fullName: string
   avatarUrl?: string
+  repositoryId?: string
+  provider?: ScmProvider
   size?: 'sm' | 'default' | 'lg'
 }) {
+  const useGitLabProxy = provider === 'gitlab' && !!repositoryId && !!avatarUrl
+
   return (
     <Avatar size={size} aria-hidden="true">
-      {avatarUrl ? (
+      {useGitLabProxy ? (
+        <GitLabAvatarImage repositoryId={repositoryId} />
+      ) : avatarUrl ? (
         <AvatarImage src={avatarUrl} alt="" referrerPolicy="no-referrer" />
       ) : null}
       <AvatarFallback>{repositoryInitials(fullName)}</AvatarFallback>
     </Avatar>
   )
+}
+
+function GitLabAvatarImage({ repositoryId }: { repositoryId: string }) {
+  const avatarUrl = useRepositoryAvatarUrl(repositoryId, true)
+  return avatarUrl ? <AvatarImage src={avatarUrl} alt="" /> : null
 }

--- a/apps/web/src/hooks/use-repository-avatar-url.ts
+++ b/apps/web/src/hooks/use-repository-avatar-url.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+
+import { getRepositoryAvatar } from '@/lib/api'
+import { resolveInstanceApiBaseUrl } from '@/lib/instance-url'
+import { useAuthStore } from '@/stores/auth-store'
+import { useActiveInstance } from '@/stores/instance-store'
+
+export function useRepositoryAvatarUrl(
+  repositoryId: string,
+  enabled: boolean,
+): string | undefined {
+  const instance = useActiveInstance()
+  const baseUrl = resolveInstanceApiBaseUrl(instance)
+  const token = useAuthStore((state) => state.token)
+  const expiresAt = useAuthStore((state) => state.expiresAt)
+  const authenticated =
+    !!token && expiresAt != null && expiresAt > Math.floor(Date.now() / 1000)
+  const { data } = useQuery({
+    queryKey: [instance?.id ?? '__none__', 'repository-avatar', repositoryId],
+    queryFn: ({ signal }) =>
+      getRepositoryAvatar(baseUrl!, token!, repositoryId, { signal }),
+    enabled: enabled && !!baseUrl && authenticated,
+    staleTime: 60 * 60 * 1000,
+  })
+  const [objectUrl, setObjectUrl] = useState<string>()
+
+  useEffect(() => {
+    if (!data) return
+    const nextUrl = URL.createObjectURL(data)
+    setObjectUrl(nextUrl)
+    return () => URL.revokeObjectURL(nextUrl)
+  }, [data])
+
+  return objectUrl
+}

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -15,6 +15,7 @@ import {
   getExternalAccessOidc,
   getInstancePreferences,
   getPipeline,
+  getRepositoryAvatar,
   getSetupStatus,
   listBuilds,
   listProjectMembers,
@@ -244,6 +245,34 @@ describe('QA project access', () => {
         headers: { ...auth, 'Content-Type': 'application/json' },
       }),
     )
+  })
+})
+
+describe('repository avatars', () => {
+  it('fetches the image through Oore with the session token', async () => {
+    const controller = new AbortController()
+    const avatar = new Blob(['avatar'], { type: 'image/png' })
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      blob: () => Promise.resolve(avatar),
+    })
+
+    const result = await getRepositoryAvatar(
+      'https://oore.example.com',
+      'session-token',
+      'repo-1',
+      { signal: controller.signal },
+    )
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://oore.example.com/v1/integration-repositories/repo-1/avatar',
+      {
+        headers: { Authorization: 'Bearer session-token' },
+        signal: controller.signal,
+      },
+    )
+    expect(result).toBe(avatar)
   })
 })
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -173,6 +173,27 @@ async function request<T>(
   return (await res.json()) as T
 }
 
+async function requestBlob(
+  baseUrl: string,
+  path: string,
+  options: RequestInit = {},
+): Promise<Blob> {
+  const res = await fetch(`${baseUrl}${path}`, options)
+  if (!res.ok) {
+    let body: ApiError
+    try {
+      body = (await res.json()) as ApiError
+    } catch {
+      body = {
+        error: `Request failed with status ${res.status}`,
+        code: 'unknown_error',
+      }
+    }
+    throw new ApiClientError(res.status, body)
+  }
+  return res.blob()
+}
+
 function authHeaders(token: string): Record<string, string> {
   return { Authorization: `Bearer ${token}` }
 }
@@ -502,6 +523,19 @@ export function listIntegrationRepos(
   return request<ListRepositoriesResponse>(
     baseUrl,
     `/v1/integrations/${integrationId}/repositories`,
+    { headers: authHeaders(token), signal: options?.signal },
+  )
+}
+
+export function getRepositoryAvatar(
+  baseUrl: string,
+  token: string,
+  repositoryId: string,
+  options?: RequestOptions,
+): Promise<Blob> {
+  return requestBlob(
+    baseUrl,
+    `/v1/integration-repositories/${repositoryId}/avatar`,
     { headers: authHeaders(token), signal: options?.signal },
   )
 }

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -729,6 +729,7 @@ export interface Project {
   repository_id?: string
   repository_full_name?: string
   repository_avatar_url?: string
+  repository_provider?: ScmProvider
   settings: Record<string, unknown>
   default_branch?: string
   created_by: string

--- a/apps/web/src/routes/projects/$projectId/index.tsx
+++ b/apps/web/src/routes/projects/$projectId/index.tsx
@@ -286,6 +286,8 @@ function ProjectDetailPage() {
                 <RepositoryAvatar
                   fullName={project.repository_full_name}
                   avatarUrl={project.repository_avatar_url}
+                  repositoryId={project.repository_id}
+                  provider={project.repository_provider}
                 />
                 {project.repository_full_name}
               </span>

--- a/apps/web/src/routes/projects/-create-project-dialog.tsx
+++ b/apps/web/src/routes/projects/-create-project-dialog.tsx
@@ -126,6 +126,8 @@ export default function CreateProjectDialog({
                                 <RepositoryAvatar
                                   fullName={repo.full_name}
                                   avatarUrl={repo.avatar_url}
+                                  repositoryId={repo.id}
+                                  provider={repo.provider}
                                 />
                                 <span>{repo.full_name}</span>
                               </SelectItem>

--- a/apps/web/src/routes/projects/index.tsx
+++ b/apps/web/src/routes/projects/index.tsx
@@ -249,6 +249,8 @@ function ProjectsListPage() {
                           <RepositoryAvatar
                             fullName={project.repository_full_name}
                             avatarUrl={project.repository_avatar_url}
+                            repositoryId={project.repository_id}
+                            provider={project.repository_provider}
                           />
                         ) : null}
                         <div>

--- a/apps/web/src/routes/settings/integrations/integration-inventory.tsx
+++ b/apps/web/src/routes/settings/integrations/integration-inventory.tsx
@@ -105,6 +105,8 @@ export function IntegrationInventory({
                         <RepositoryAvatar
                           fullName={repository.full_name}
                           avatarUrl={repository.avatar_url}
+                          repositoryId={repository.id}
+                          provider={integration.provider}
                         />
                         <span>{repository.full_name}</span>
                       </div>

--- a/crates/oore-contract/src/lib.rs
+++ b/crates/oore-contract/src/lib.rs
@@ -1687,6 +1687,8 @@ pub struct Project {
     pub repository_full_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repository_avatar_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repository_provider: Option<String>,
     #[schema(value_type = Object)]
     pub settings: serde_json::Value,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/oored/src/bin/openapi_export.rs
+++ b/crates/oored/src/bin/openapi_export.rs
@@ -83,6 +83,7 @@ use utoipa::OpenApi;
         paths::get_integration,
         paths::delete_integration,
         paths::list_repositories,
+        paths::repository_avatar,
         paths::list_installations,
         paths::sync_installations,
         paths::github_start,
@@ -1120,6 +1121,18 @@ mod paths {
         )
     )]
     pub(super) async fn list_repositories() {}
+
+    /// Fetch a private GitLab repository avatar through Oore
+    #[utoipa::path(get, path = "/v1/integration-repositories/{id}/avatar", tag = "Integrations",
+        params(("id" = String, Path, description = "Integration repository ID")),
+        security(("bearer_auth" = [])),
+        responses(
+            (status = 200, description = "Repository avatar image", content_type = "image/*"),
+            (status = 404, description = "Avatar not found", body = ApiError),
+            (status = 502, description = "GitLab avatar unavailable", body = ApiError),
+        )
+    )]
+    pub(super) async fn repository_avatar() {}
 
     /// List integration installations
     #[utoipa::path(get, path = "/v1/integrations/{id}/installations", tag = "Integrations",

--- a/crates/oored/src/integrations/gitlab.rs
+++ b/crates/oored/src/integrations/gitlab.rs
@@ -29,6 +29,7 @@ type ApiResult<T> = Result<Json<T>, (StatusCode, Json<ApiError>)>;
 
 /// Maximum age (seconds) for a GitLab OAuth state token.
 const STATE_MAX_AGE_SECS: i64 = 600; // 10 minutes
+const MAX_AVATAR_BYTES: usize = 2 * 1024 * 1024;
 
 fn build_http_client() -> Result<reqwest::Client, reqwest::Error> {
     reqwest::Client::builder()
@@ -72,6 +73,148 @@ async fn access_token(
             "Failed to decrypt source credentials",
         )
     })
+}
+
+pub(crate) async fn fetch_repository_avatar(
+    pool: &sqlx::SqlitePool,
+    encryption_key: &[u8],
+    integration_id: &str,
+    host_url: &str,
+    auth_mode: &str,
+    repository_external_id: &str,
+    avatar_url: &str,
+) -> Result<(String, Vec<u8>), (StatusCode, Json<ApiError>)> {
+    let host_origin = normalize_gitlab_host_url(host_url)?;
+    let parsed_avatar_url = url::Url::parse(avatar_url).map_err(|_| {
+        api_err(
+            StatusCode::BAD_GATEWAY,
+            "gitlab_avatar_invalid",
+            "GitLab returned an invalid repository avatar URL",
+        )
+    })?;
+    if !matches!(parsed_avatar_url.scheme(), "http" | "https")
+        || parsed_avatar_url.host_str().is_none()
+        || !parsed_avatar_url.username().is_empty()
+        || parsed_avatar_url.password().is_some()
+        || parsed_avatar_url.origin().ascii_serialization() != host_origin
+    {
+        return Err(api_err(
+            StatusCode::BAD_GATEWAY,
+            "gitlab_avatar_invalid",
+            "GitLab returned an untrusted repository avatar URL",
+        ));
+    }
+
+    let path_segments = parsed_avatar_url
+        .path_segments()
+        .map(Iterator::collect::<Vec<_>>)
+        .unwrap_or_default();
+    let group_id = path_segments
+        .windows(3)
+        .find(|segments| segments[0] == "group" && segments[1] == "avatar")
+        .map(|segments| segments[2])
+        .filter(|id| !id.is_empty() && id.chars().all(|character| character.is_ascii_digit()));
+    let avatar_api_url = if let Some(group_id) = group_id {
+        format!("{host_origin}/api/v4/groups/{group_id}/avatar")
+    } else {
+        format!(
+            "{host_origin}/api/v4/projects/{}/avatar",
+            urlencoding::encode(repository_external_id)
+        )
+    };
+
+    let token = access_token(pool, encryption_key, integration_id).await?;
+    let client = build_http_client().map_err(|e| {
+        error!(error = %e, "failed to build GitLab avatar client");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "http_client_error",
+            "Failed to create GitLab client",
+        )
+    })?;
+    let mut request = client
+        .get(avatar_api_url)
+        .header("User-Agent", "oore-ci")
+        .header("Accept", "image/*");
+    request = if auth_mode == "oauth_app" {
+        request.header("Authorization", format!("Bearer {token}"))
+    } else {
+        request.header("PRIVATE-TOKEN", token)
+    };
+
+    let mut response = request.send().await.map_err(|e| {
+        error!(error = %e, "failed to fetch GitLab repository avatar");
+        api_err(
+            StatusCode::BAD_GATEWAY,
+            "gitlab_avatar_unavailable",
+            "Failed to fetch the GitLab repository avatar",
+        )
+    })?;
+    if !response.status().is_success() {
+        error!(status = %response.status(), "GitLab repository avatar request failed");
+        return Err(api_err(
+            StatusCode::BAD_GATEWAY,
+            "gitlab_avatar_unavailable",
+            "Failed to fetch the GitLab repository avatar",
+        ));
+    }
+    if response
+        .content_length()
+        .is_some_and(|size| size > MAX_AVATAR_BYTES as u64)
+    {
+        return Err(api_err(
+            StatusCode::BAD_GATEWAY,
+            "gitlab_avatar_too_large",
+            "GitLab repository avatar exceeds the size limit",
+        ));
+    }
+
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(';').next())
+        .map(str::trim)
+        .filter(|value| {
+            matches!(
+                *value,
+                "image/png"
+                    | "image/jpeg"
+                    | "image/gif"
+                    | "image/webp"
+                    | "image/avif"
+                    | "image/svg+xml"
+            )
+        })
+        .ok_or_else(|| {
+            api_err(
+                StatusCode::BAD_GATEWAY,
+                "gitlab_avatar_invalid",
+                "GitLab returned an unsupported repository avatar",
+            )
+        })?
+        .to_string();
+
+    let mut body = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(|e| {
+        error!(error = %e, "failed to read GitLab repository avatar");
+        api_err(
+            StatusCode::BAD_GATEWAY,
+            "gitlab_avatar_unavailable",
+            "Failed to fetch the GitLab repository avatar",
+        )
+    })? {
+        if body.len() + chunk.len() > MAX_AVATAR_BYTES {
+            return Err(api_err(
+                StatusCode::BAD_GATEWAY,
+                "gitlab_avatar_too_large",
+                "GitLab repository avatar exceeds the size limit",
+            ));
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    Ok((content_type, body))
 }
 
 pub(crate) async fn resolve_branch_commit(
@@ -1597,12 +1740,14 @@ async fn exchange_gitlab_code(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_http_client, git_checkout_request_allowed, normalize_gitlab_host_url,
-        oauth_callback_url, sync_gitlab_projects, validate_redirect_origin,
+        build_http_client, fetch_repository_avatar, git_checkout_request_allowed,
+        normalize_gitlab_host_url, oauth_callback_url, sync_gitlab_projects,
+        validate_redirect_origin,
     };
+    use crate::crypto;
     use axum::Json;
     use axum::extract::Query;
-    use axum::http::Method;
+    use axum::http::{HeaderMap, Method};
     use axum::routing::get;
     use std::collections::HashMap;
 
@@ -1629,6 +1774,61 @@ mod tests {
         ] {
             assert!(normalize_gitlab_host_url(host).is_err(), "accepted {host}");
         }
+    }
+
+    #[tokio::test]
+    async fn repository_avatar_uses_gitlab_credentials() {
+        let app = axum::Router::new().route(
+            "/api/v4/projects/42/avatar",
+            get(|headers: HeaderMap| async move {
+                assert_eq!(
+                    headers
+                        .get("PRIVATE-TOKEN")
+                        .and_then(|value| value.to_str().ok()),
+                    Some("gitlab-token")
+                );
+                ([("content-type", "image/png")], vec![1_u8, 2, 3])
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let host = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query(
+            "CREATE TABLE integration_credentials (
+                integration_id TEXT NOT NULL, credential_type TEXT NOT NULL,
+                encrypted_value TEXT NOT NULL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        let key = [7_u8; 32];
+        let encrypted = crypto::encrypt("gitlab-token", &key).unwrap();
+        sqlx::query(
+            "INSERT INTO integration_credentials VALUES ('integration-1', 'access_token', ?1)",
+        )
+        .bind(encrypted)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let (content_type, body) = fetch_repository_avatar(
+            &pool,
+            &key,
+            "integration-1",
+            &host,
+            "personal_token",
+            "42",
+            &format!("{host}/uploads/avatar.png"),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(content_type, "image/png");
+        assert_eq!(body, vec![1, 2, 3]);
+        server.abort();
     }
 
     #[test]

--- a/crates/oored/src/integrations/mod.rs
+++ b/crates/oored/src/integrations/mod.rs
@@ -59,8 +59,10 @@ pub(crate) fn error_page(title: &str, message: &str) -> String {
 }
 
 use axum::Json;
+use axum::body::Body;
 use axum::extract::{Path, Query, State};
-use axum::http::StatusCode;
+use axum::http::{StatusCode, header};
+use axum::response::Response;
 use oore_contract::{
     ApiError, Integration, IntegrationDetailResponse, IntegrationInstallation,
     IntegrationRepository, ListInstallationsResponse, ListIntegrationsResponse,
@@ -511,6 +513,80 @@ pub async fn list_repositories(
     let repositories = rows.iter().map(row_to_repository).collect();
 
     Ok(Json(ListRepositoriesResponse { repositories }))
+}
+
+/// `GET /v1/integration-repositories/{id}/avatar` — proxy a private GitLab avatar.
+pub async fn repository_avatar(
+    State(state): State<Arc<AppState>>,
+    auth: AuthUser,
+    Path(id): Path<String>,
+) -> Result<Response, (StatusCode, Json<ApiError>)> {
+    check_permission(&state.enforcer, &auth.0.role, "integrations", "read").await?;
+
+    let pool = {
+        let store = state.store.lock().await;
+        store.pool().clone()
+    };
+    let row = sqlx::query(
+        "SELECT i.id AS integration_id, i.host_url, i.auth_mode, r.external_id, r.avatar_url \
+         FROM integration_repositories r \
+         JOIN integration_installations inst ON inst.id = r.installation_id \
+         JOIN integrations i ON i.id = inst.integration_id \
+         WHERE r.id = ?1 AND i.provider = 'gitlab' AND i.status = 'active'",
+    )
+    .bind(&id)
+    .fetch_optional(&pool)
+    .await
+    .map_err(|e| {
+        error!(error = %e, repository_id = %id, "failed to load GitLab repository avatar");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to load the repository avatar",
+        )
+    })?
+    .ok_or_else(|| {
+        api_err(
+            StatusCode::NOT_FOUND,
+            "not_found",
+            "GitLab repository avatar not found",
+        )
+    })?;
+
+    let avatar_url: Option<String> = row.get("avatar_url");
+    let avatar_url = avatar_url
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            api_err(
+                StatusCode::NOT_FOUND,
+                "not_found",
+                "GitLab repository avatar not found",
+            )
+        })?;
+    let (content_type, body) = gitlab::fetch_repository_avatar(
+        &pool,
+        &state.encryption_key,
+        row.get("integration_id"),
+        row.get("host_url"),
+        row.get("auth_mode"),
+        row.get("external_id"),
+        &avatar_url,
+    )
+    .await?;
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, content_type)
+        .header(header::CACHE_CONTROL, "private, max-age=3600")
+        .body(Body::from(body))
+        .map_err(|e| {
+            error!(error = %e, "failed to build repository avatar response");
+            api_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "response_error",
+                "Failed to return the repository avatar",
+            )
+        })
 }
 
 /// `GET /v1/integrations/{id}/installations` — list installations for an integration.

--- a/crates/oored/src/lib.rs
+++ b/crates/oored/src/lib.rs
@@ -2292,6 +2292,10 @@ async fn build_router_inner(
             get(integrations::list_repositories),
         )
         .route(
+            "/v1/integration-repositories/{id}/avatar",
+            get(integrations::repository_avatar),
+        )
+        .route(
             "/v1/integrations/github/start",
             post(integrations::github::github_start),
         )

--- a/crates/oored/src/projects.rs
+++ b/crates/oored/src/projects.rs
@@ -26,8 +26,11 @@ use crate::util::{api_err, now_unix};
 
 type ApiResult<T> = Result<Json<T>, (StatusCode, Json<ApiError>)>;
 
-const PROJECT_SELECT: &str = "SELECT p.*, r.full_name AS repository_full_name, r.avatar_url AS repository_avatar_url \
-    FROM projects p LEFT JOIN integration_repositories r ON r.id = p.repository_id";
+const PROJECT_SELECT: &str = "SELECT p.*, r.full_name AS repository_full_name, r.avatar_url AS repository_avatar_url, \
+    i.provider AS repository_provider FROM projects p \
+    LEFT JOIN integration_repositories r ON r.id = p.repository_id \
+    LEFT JOIN integration_installations inst ON inst.id = r.installation_id \
+    LEFT JOIN integrations i ON i.id = inst.integration_id";
 
 // ── Row conversion ──────────────────────────────────────────────
 
@@ -43,6 +46,7 @@ fn row_to_project(row: &sqlx::sqlite::SqliteRow) -> Project {
         repository_id: row.get("repository_id"),
         repository_full_name: row.get("repository_full_name"),
         repository_avatar_url: row.get("repository_avatar_url"),
+        repository_provider: row.get("repository_provider"),
         settings,
         default_branch: row.get("default_branch"),
         created_by: row.get("created_by"),
@@ -420,6 +424,7 @@ pub async fn create_project(
         repository_id,
         repository_full_name: None,
         repository_avatar_url: None,
+        repository_provider: None,
         settings: serde_json::json!({}),
         default_branch,
         created_by: auth.0.user_id,

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -21,6 +21,11 @@ Rules:
   - Linear feature doc: https://linear.app/oorebuild/document/feature-ad-hoc-app-installation-18011ca32086
   - Linear RBAC ADR: https://linear.app/oorebuild/document/adr-0002-rbac-implementation-strategy-28554f736e4a
 
+- **Authenticated private GitLab repository avatars**:
+  - Private GitLab repository avatars now load through a bearer-authenticated Oore endpoint instead of depending on each browser's GitLab cookies. GitHub avatars continue using their public URLs, while missing or unavailable images retain the existing initials fallback.
+  - The backend applies the stored GitLab credential through GitLab's project/group avatar APIs, restricts requests to the configured GitLab origin, disables redirects, validates image types, and enforces a 2 MiB response limit.
+  - Linear feature doc: https://linear.app/oorebuild/document/authenticated-gitlab-repository-avatars-3eab35144db0
+
 - **Ad-hoc Android and iOS app installation**:
   - Build artifacts now expose a dedicated mobile-first install page. APKs use protected scoped downloads; signed ad-hoc IPAs use a short-lived tokenized Apple OTA manifest and `itms-services` install URL. The page detects iPhone Safari, blocks misleading install attempts in other iPhone browsers, and gives platform-specific device guidance.
   - The macOS runner attaches bundle identifier, app name, marketing version, and build number to newly signed IPA artifacts, allowing the backend to verify manifest readiness before issuing an install link. Older IPAs remain downloadable and become install-ready after one rebuild.


### PR DESCRIPTION
## Summary

- proxy private GitLab project and group avatars through the authenticated Oore backend
- keep GitLab credentials server-side and validate origin, content type, size, and redirects
- load proxied images through the shared repository avatar UI while preserving GitHub and initials fallbacks
- document the endpoint in OpenAPI and the Linear feature doc

## Validation

- make validate
- post-rebase result: 158 web tests passed, Rust workspace tests passed, clippy passed, bundle/docs/site/workspace builds passed

## Docs

- https://linear.app/oorebuild/document/authenticated-gitlab-repository-avatars-3eab35144db0