### PR TITLE
feat(distribution): add QA app testing portal

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,6 +36,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-hook-form": "^7.81.0",
+    "react-markdown": "^10.1.0",
     "shadcn": "^4.13.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",

--- a/apps/web/src/components/build-details/artifact-install-page.tsx
+++ b/apps/web/src/components/build-details/artifact-install-page.tsx
@@ -3,34 +3,38 @@ import { HugeiconsIcon } from '@hugeicons/react'
 import {
   ArrowLeft01Icon,
   Copy01Icon,
-  Download04Icon,
   Globe02Icon,
   InformationCircleIcon,
   SmartPhone01Icon,
 } from '@hugeicons/core-free-icons'
 import { toast } from 'sonner'
+import ReactMarkdown from 'react-markdown'
 
 import {
   artifactInstallReadiness,
   detectInstallDevice,
   getIosAppMetadata,
+  selectInstallArtifact,
 } from '@/lib/artifact-install'
 import {
-  useArtifactDownloadLink,
   useArtifactInstallLink,
   useArtifacts,
   useBuild,
+  useProjectArtifacts,
 } from '@/hooks/use-builds'
+import { useProject } from '@/hooks/use-projects'
 import { formatFileSize } from '@/lib/format-utils'
+import { qaBuildVersion, qaProjectVersionBase } from '@/lib/qa-releases'
 import { PageMeta } from '@/lib/seo'
 import { useBreadcrumbLabel } from '@/hooks/use-breadcrumb-label'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import PageLayout from '@/components/page-layout'
+import RepositoryAvatar from '@/components/repository-avatar'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Spinner } from '@/components/ui/spinner'
+import { useAuthStore } from '@/stores/auth-store'
 
 function expiryLabel(expiresAt: number | undefined): string {
   if (expiresAt == null) return 'No scheduled expiry'
@@ -49,21 +53,38 @@ export function ArtifactInstallPage({
   artifactId,
 }: {
   buildId: string
-  artifactId: string
+  artifactId?: string
 }) {
   useBreadcrumbLabel('/builds/$buildId', 'Install')
   const buildQuery = useBuild(buildId)
   const artifactsQuery = useArtifacts(buildId)
   const installMutation = useArtifactInstallLink()
-  const downloadMutation = useArtifactDownloadLink()
-  const artifact = artifactsQuery.data?.artifacts.find(
-    (candidate) => candidate.id === artifactId,
+  const isQaViewer = useAuthStore((state) => state.user?.role === 'qa_viewer')
+  const projectQuery = useProject(
+    isQaViewer ? (buildQuery.data?.build.project_id ?? '') : '',
+  )
+  const projectArtifactsQuery = useProjectArtifacts(
+    buildQuery.data?.build.project_id ?? '',
   )
   const device = detectInstallDevice(
     typeof navigator === 'undefined' ? '' : navigator.userAgent,
   )
+  const artifact = isQaViewer
+    ? selectInstallArtifact(
+        artifactsQuery.data?.artifacts ?? [],
+        device,
+        artifactId,
+      )
+    : artifactsQuery.data?.artifacts.find(
+        (candidate) => candidate.id === artifactId,
+      )
 
-  if (buildQuery.isLoading || artifactsQuery.isLoading) {
+  if (
+    buildQuery.isLoading ||
+    artifactsQuery.isLoading ||
+    (isQaViewer &&
+      (projectQuery.isLoading || projectArtifactsQuery.isLoading))
+  ) {
     return (
       <PageLayout width="narrow">
         <PageMeta title="Install artifact" noindex />
@@ -74,14 +95,18 @@ export function ArtifactInstallPage({
   }
 
   const queryError = buildQuery.error ?? artifactsQuery.error
-  if (queryError) {
+  const qaQueryError = isQaViewer
+    ? (projectQuery.error ?? projectArtifactsQuery.error)
+    : null
+  if (queryError || qaQueryError) {
     return (
       <PageLayout width="narrow">
         <PageMeta title="Install artifact" noindex />
         <Alert variant="destructive">
           <HugeiconsIcon icon={InformationCircleIcon} />
           <AlertDescription>
-            Failed to load this artifact: {queryError.message}
+            Failed to load this artifact:{' '}
+            {(queryError ?? qaQueryError)?.message}
           </AlertDescription>
         </Alert>
       </PageLayout>
@@ -103,6 +128,7 @@ export function ArtifactInstallPage({
   }
 
   const { build } = buildQuery.data
+  const project = projectQuery.data?.project
   const readiness = artifactInstallReadiness(artifact)
   const iosApp = getIosAppMetadata(artifact)
   const isIos = artifact.artifact_type === 'ipa'
@@ -117,26 +143,22 @@ export function ArtifactInstallPage({
   const isDesktopIos = isIos && device === 'other'
   const canInstall =
     readiness.ready && !expired && !wrongPhone && !needsSafari && !isDesktopIos
-  const appName = iosApp?.displayName ?? displayName(artifact.name)
+  const appName = isQaViewer
+    ? qaBuildVersion(
+        build,
+        artifactsQuery.data?.artifacts ?? [],
+        qaProjectVersionBase(projectArtifactsQuery.data?.artifacts ?? []),
+      )
+    : (iosApp?.displayName ?? displayName(artifact.name))
+  const selectedArtifactId = artifact.id
 
   function handleInstall() {
-    installMutation.mutate(artifactId, {
+    installMutation.mutate(selectedArtifactId, {
       onSuccess: (response) => {
         window.location.assign(response.install_url)
       },
       onError: (error) => {
         toast.error(`Could not start installation: ${error.message}`)
-      },
-    })
-  }
-
-  function handleDownload() {
-    downloadMutation.mutate(artifactId, {
-      onSuccess: (response) => {
-        window.open(response.download_url, '_blank', 'noopener,noreferrer')
-      },
-      onError: (error) => {
-        toast.error(`Could not download artifact: ${error.message}`)
       },
     })
   }
@@ -149,139 +171,198 @@ export function ArtifactInstallPage({
   }
 
   const primaryLabel = isIos
-    ? 'Install on iPhone'
+    ? 'Install'
     : device === 'other'
       ? 'Download APK'
-      : 'Install APK'
+      : 'Install'
 
   return (
-    <PageLayout width="narrow" className="py-6 sm:py-10">
-      <PageMeta title={`Install ${appName}`} noindex />
+    <PageLayout width="narrow" className="px-4 pt-4 pb-28 sm:px-6 sm:py-10">
+      <PageMeta
+        title={`Install ${project ? `${project.name} ${appName}` : appName}`}
+        noindex
+      />
 
       <Button
         variant="ghost"
         size="sm"
-        render={<Link to="/builds/$buildId" params={{ buildId }} search={{}} />}
+        render={
+          isQaViewer ? (
+            <Link to="/" resetScroll />
+          ) : (
+            <Link
+              to="/builds/$buildId"
+              params={{ buildId }}
+              search={{}}
+              resetScroll
+            />
+          )
+        }
         nativeButton={false}
-        className="w-fit"
+        className="hidden w-fit sm:inline-flex"
       >
         <HugeiconsIcon icon={ArrowLeft01Icon} />
-        Build #{build.build_number}
+        {isQaViewer ? 'Back to apps' : `Build #${build.build_number}`}
       </Button>
 
-      <Card>
-        <CardHeader className="border-b">
-          <div className="flex items-start gap-4">
-            <div className="flex size-12 shrink-0 items-center justify-center border bg-muted">
-              <HugeiconsIcon icon={SmartPhone01Icon} size={24} />
-            </div>
-            <div className="min-w-0 flex-1">
-              <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Device installation
-              </p>
-              <h1 className="mt-1 truncate text-2xl font-bold tracking-tight">
-                {appName}
+      <section className="flex flex-col gap-5 pt-2 sm:pt-6">
+        <header>
+          {isQaViewer && project ? (
+            <div className="mb-6 flex items-center gap-3">
+              <RepositoryAvatar
+                fullName={project.repository_full_name ?? project.name}
+                avatarUrl={project.repository_avatar_url}
+                repositoryId={project.repository_id}
+                provider={project.repository_provider}
+                size="lg"
+              />
+              <h1 className="truncate text-xl font-semibold tracking-tight">
+                {project.name}
               </h1>
-              <div className="mt-2 flex flex-wrap items-center gap-2">
-                <Badge variant={isIos ? 'success' : 'info'}>
-                  {isIos ? 'iOS' : 'Android'}
-                </Badge>
-                {iosApp ? (
-                  <span className="text-xs text-muted-foreground">
-                    Version {iosApp.version} ({iosApp.buildNumber})
-                  </span>
-                ) : null}
-              </div>
             </div>
-          </div>
-        </CardHeader>
-        <CardContent className="space-y-5">
-          <dl className="grid grid-cols-2 gap-x-4 gap-y-3 text-xs">
-            <div>
-              <dt className="text-muted-foreground">Build</dt>
-              <dd className="mt-0.5 font-medium">#{build.build_number}</dd>
-            </div>
-            <div>
-              <dt className="text-muted-foreground">Size</dt>
-              <dd className="mt-0.5 font-medium">
-                {artifact.file_size != null
-                  ? formatFileSize(artifact.file_size)
-                  : '—'}
-              </dd>
-            </div>
-            <div className="col-span-2">
-              <dt className="text-muted-foreground">Availability</dt>
-              <dd className="mt-0.5 font-medium">
-                {expiryLabel(artifact.expires_at)}
-              </dd>
-            </div>
-            {build.commit_sha ? (
-              <div className="col-span-2">
-                <dt className="text-muted-foreground">Commit</dt>
-                <dd className="mt-0.5 font-mono font-medium">
-                  {build.commit_sha.slice(0, 12)}
-                </dd>
-              </div>
-            ) : null}
-          </dl>
-
-          {!readiness.ready ? (
-            <Alert variant="destructive">
-              <HugeiconsIcon icon={InformationCircleIcon} />
-              <AlertTitle>Not install-ready</AlertTitle>
-              <AlertDescription>{readiness.reason}</AlertDescription>
-            </Alert>
           ) : null}
-
-          {expired ? (
-            <Alert variant="destructive">
-              <HugeiconsIcon icon={InformationCircleIcon} />
-              <AlertTitle>Artifact expired</AlertTitle>
-              <AlertDescription>
-                Ask a developer to run a fresh build before installing.
-              </AlertDescription>
-            </Alert>
+          <Badge variant={isIos ? 'success' : 'info'}>
+            {isIos ? 'iOS' : 'Android'}
+          </Badge>
+          {isQaViewer ? (
+            <p className="mt-3 break-words text-2xl font-bold tracking-tight sm:text-3xl">
+              {appName}
+            </p>
+          ) : (
+            <h1 className="mt-3 break-words text-2xl font-bold tracking-tight sm:text-3xl">
+              {appName}
+            </h1>
+          )}
+          <p className="mt-2 text-sm text-muted-foreground">
+            {artifact.file_size != null
+              ? formatFileSize(artifact.file_size)
+              : 'Size unavailable'}
+            {artifact.expires_at != null
+              ? ` · ${expiryLabel(artifact.expires_at)}`
+              : ''}
+          </p>
+          {!isQaViewer && iosApp ? (
+            <p className="mt-1 text-xs text-muted-foreground">
+              {iosApp.version}+{iosApp.buildNumber}
+            </p>
           ) : null}
+        </header>
 
-          {needsSafari ? (
-            <Alert>
-              <HugeiconsIcon icon={Globe02Icon} />
-              <AlertTitle>Open this page in Safari</AlertTitle>
-              <AlertDescription>
-                iOS app installation can only start from Safari. Copy this page
-                link, then paste it into Safari on this iPhone.
-              </AlertDescription>
-            </Alert>
-          ) : null}
+        {isQaViewer && build.changelog ? (
+          <section>
+            <h2 className="text-sm font-medium">What’s new</h2>
+            <ReactMarkdown
+              skipHtml
+              components={{
+                a: ({ children, ...props }) => (
+                  <a
+                    {...props}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="underline underline-offset-4"
+                  >
+                    {children}
+                  </a>
+                ),
+                ol: ({ children }) => (
+                  <ol className="mt-2 flex list-decimal flex-col gap-1 pl-5 text-sm text-muted-foreground">
+                    {children}
+                  </ol>
+                ),
+                p: ({ children }) => (
+                  <p className="mt-2 whitespace-pre-wrap text-sm text-muted-foreground">
+                    {children}
+                  </p>
+                ),
+                ul: ({ children }) => (
+                  <ul className="mt-2 flex list-disc flex-col gap-1 pl-5 text-sm text-muted-foreground">
+                    {children}
+                  </ul>
+                ),
+              }}
+            >
+              {build.changelog}
+            </ReactMarkdown>
+          </section>
+        ) : null}
 
-          {isDesktopIos ? (
-            <Alert>
-              <HugeiconsIcon icon={SmartPhone01Icon} />
-              <AlertTitle>Continue on your iPhone</AlertTitle>
-              <AlertDescription>
-                Open this page in Safari on an iPhone included in the app’s
-                provisioning profile.
-              </AlertDescription>
-            </Alert>
-          ) : null}
+        {!readiness.ready ? (
+          <Alert variant="destructive">
+            <HugeiconsIcon icon={InformationCircleIcon} />
+            <AlertTitle>Not install-ready</AlertTitle>
+            <AlertDescription>{readiness.reason}</AlertDescription>
+          </Alert>
+        ) : null}
 
-          {wrongPhone ? (
-            <Alert>
-              <HugeiconsIcon icon={InformationCircleIcon} />
-              <AlertTitle>Different platform required</AlertTitle>
-              <AlertDescription>
-                Open this page on {isIos ? 'an iPhone' : 'an Android phone'} to
-                install this build.
-              </AlertDescription>
-            </Alert>
-          ) : null}
+        {expired ? (
+          <Alert variant="destructive">
+            <HugeiconsIcon icon={InformationCircleIcon} />
+            <AlertTitle>Artifact expired</AlertTitle>
+            <AlertDescription>
+              Ask a developer to run a fresh build before installing.
+            </AlertDescription>
+          </Alert>
+        ) : null}
 
-          <div className="grid gap-2 sm:grid-cols-2">
+        {needsSafari ? (
+          <Alert>
+            <HugeiconsIcon icon={Globe02Icon} />
+            <AlertTitle>Open this page in Safari</AlertTitle>
+            <AlertDescription>
+              iOS installation can only start from Safari on this iPhone.
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        {isDesktopIos ? (
+          <Alert>
+            <HugeiconsIcon icon={SmartPhone01Icon} />
+            <AlertTitle>Open this page on the registered iPhone</AlertTitle>
+            <AlertDescription>
+              Use Safari on a device included in this version’s provisioning
+              profile.
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        {wrongPhone ? (
+          <Alert>
+            <HugeiconsIcon icon={InformationCircleIcon} />
+            <AlertTitle>Open this page on the right device</AlertTitle>
+            <AlertDescription>
+              This version is for {isIos ? 'iOS' : 'Android'}.
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        <div className="fixed inset-x-0 bottom-0 z-[60] border-t bg-background/95 px-4 pt-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] backdrop-blur sm:static sm:border-0 sm:bg-transparent sm:p-0 sm:backdrop-blur-none">
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="icon-lg"
+              render={
+                isQaViewer ? (
+                  <Link to="/" resetScroll />
+                ) : (
+                  <Link
+                    to="/builds/$buildId"
+                    params={{ buildId }}
+                    search={{}}
+                    resetScroll
+                  />
+                )
+              }
+              nativeButton={false}
+              aria-label={isQaViewer ? 'Back to apps' : 'Back to build'}
+              className="min-h-11 sm:hidden"
+            >
+              <HugeiconsIcon icon={ArrowLeft01Icon} />
+            </Button>
             <Button
               size="lg"
               onClick={handleInstall}
               disabled={!canInstall || installMutation.isPending}
-              className="sm:col-span-2"
+              className="min-h-11 min-w-0 flex-1 sm:w-full"
             >
               {installMutation.isPending ? (
                 <Spinner />
@@ -290,73 +371,57 @@ export function ArtifactInstallPage({
               )}
               {primaryLabel}
             </Button>
-            <Button variant="outline" onClick={handleCopyPageLink}>
-              <HugeiconsIcon icon={Copy01Icon} />
-              Copy page link
-            </Button>
-            <Button
-              variant="outline"
-              onClick={handleDownload}
-              disabled={expired || downloadMutation.isPending}
-            >
-              {downloadMutation.isPending ? (
-                <Spinner />
-              ) : (
-                <HugeiconsIcon icon={Download04Icon} />
-              )}
-              Download file
-            </Button>
           </div>
-        </CardContent>
-      </Card>
+          {!isQaViewer ? (
+            <Button
+              variant="ghost"
+              onClick={handleCopyPageLink}
+              className="mt-2 w-full"
+            >
+              <HugeiconsIcon icon={Copy01Icon} />
+              Copy install page link
+            </Button>
+          ) : null}
+        </div>
+      </section>
 
-      <Card size="sm">
-        <CardHeader>
-          <CardTitle className="text-sm uppercase tracking-wider text-muted-foreground">
-            Before you install
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {isIos ? (
-            <ol className="space-y-3 text-sm text-muted-foreground">
-              <li className="flex gap-3">
-                <span className="font-mono text-foreground">01</span>
-                <span>Use Safari on the registered iPhone.</span>
-              </li>
-              <li className="flex gap-3">
-                <span className="font-mono text-foreground">02</span>
-                <span>
-                  Tap Install and confirm the iOS installation prompt.
-                </span>
-              </li>
-              <li className="flex gap-3">
-                <span className="font-mono text-foreground">03</span>
-                <span>
-                  Before opening the app, enable Developer Mode if iOS asks. The
-                  phone’s UDID must be in this build’s provisioning profile.
-                </span>
-              </li>
-            </ol>
-          ) : (
-            <ol className="space-y-3 text-sm text-muted-foreground">
-              <li className="flex gap-3">
-                <span className="font-mono text-foreground">01</span>
-                <span>Tap Install APK to download the build.</span>
-              </li>
-              <li className="flex gap-3">
-                <span className="font-mono text-foreground">02</span>
-                <span>
-                  Allow this browser to install unknown apps if Android asks.
-                </span>
-              </li>
-              <li className="flex gap-3">
-                <span className="font-mono text-foreground">03</span>
-                <span>Open the downloaded APK and confirm installation.</span>
-              </li>
-            </ol>
-          )}
-        </CardContent>
-      </Card>
+      <section className="flex flex-col gap-4 pt-1">
+        <h2 className="text-sm font-medium">Before you install</h2>
+        {isIos ? (
+          <ol className="flex flex-col gap-3 text-sm text-muted-foreground">
+            <li className="flex gap-3">
+              <span className="font-mono text-foreground">01</span>
+              <span>Use Safari on the registered iPhone.</span>
+            </li>
+            <li className="flex gap-3">
+              <span className="font-mono text-foreground">02</span>
+              <span>Tap Install and confirm the iOS prompt.</span>
+            </li>
+            <li className="flex gap-3">
+              <span className="font-mono text-foreground">03</span>
+              <span>
+                Enable Developer Mode if iOS asks. The device must be included
+                in this version’s provisioning profile.
+              </span>
+            </li>
+          </ol>
+        ) : (
+          <ol className="flex flex-col gap-3 text-sm text-muted-foreground">
+            <li className="flex gap-3">
+              <span className="font-mono text-foreground">01</span>
+              <span>Tap Install to download the APK.</span>
+            </li>
+            <li className="flex gap-3">
+              <span className="font-mono text-foreground">02</span>
+              <span>Allow this browser to install unknown apps if asked.</span>
+            </li>
+            <li className="flex gap-3">
+              <span className="font-mono text-foreground">03</span>
+              <span>Open the APK and confirm installation.</span>
+            </li>
+          </ol>
+        )}
+      </section>
     </PageLayout>
   )
 }

--- a/apps/web/src/components/build-details/build-detail-route.tsx
+++ b/apps/web/src/components/build-details/build-detail-route.tsx
@@ -2,14 +2,16 @@ import { useParams, useSearch } from '@tanstack/react-router'
 
 import { ArtifactInstallPage } from './artifact-install-page'
 import { BuildDetailPage } from './build-detail-page'
+import { useAuthStore } from '@/stores/auth-store'
 
 export function BuildDetailRoute() {
   const { buildId } = useParams({ from: '/builds/$buildId' })
   const { install: artifactId } = useSearch({ from: '/builds/$buildId' })
-  if (artifactId) {
+  const isQaViewer = useAuthStore((state) => state.user?.role === 'qa_viewer')
+  if (artifactId || isQaViewer) {
     return (
       <ArtifactInstallPage
-        key={`${buildId}:${artifactId}`}
+        key={`${buildId}:${artifactId ?? 'auto'}`}
         buildId={buildId}
         artifactId={artifactId}
       />

--- a/apps/web/src/components/qa-app-header.tsx
+++ b/apps/web/src/components/qa-app-header.tsx
@@ -1,0 +1,51 @@
+import { Link } from '@tanstack/react-router'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { Logout03Icon } from '@hugeicons/core-free-icons'
+
+import { Button } from '@/components/ui/button'
+import { useLogout } from '@/hooks/use-auth'
+import { useAuthStore } from '@/stores/auth-store'
+import { useActiveInstance, useInstanceStore } from '@/stores/instance-store'
+
+export default function QaAppHeader() {
+  const user = useAuthStore((state) => state.user)
+  const instance = useActiveInstance()
+  const removeInstance = useInstanceStore((state) => state.removeInstance)
+  const logoutMutation = useLogout()
+  const isPreview = !!instance?.qaPreviewSourceId
+
+  return (
+    <header className="sticky top-0 z-30 border-b bg-background">
+      <div className="mx-auto flex h-16 w-full max-w-6xl items-center gap-3 px-4 sm:px-6 lg:px-10">
+        <Link to="/" className="flex min-w-0 items-center gap-3">
+          <img src="/logo.svg" alt="Oore CI" className="size-8" />
+          <span className="font-semibold tracking-tight">Oore</span>
+        </Link>
+
+        <div className="ml-auto flex min-w-0 items-center gap-3">
+          <span className="hidden max-w-64 truncate text-xs text-muted-foreground md:block">
+            {user?.email}
+          </span>
+          {isPreview ? (
+            <Button
+              variant="outline"
+              onClick={() => removeInstance(instance.id)}
+            >
+              End preview
+            </Button>
+          ) : (
+            <Button
+              variant="ghost"
+              aria-label="Sign out"
+              onClick={() => logoutMutation.mutate()}
+              disabled={logoutMutation.isPending}
+            >
+              <HugeiconsIcon icon={Logout03Icon} />
+              <span className="hidden sm:inline">Sign out</span>
+            </Button>
+          )}
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/apps/web/src/components/qa-releases-page.tsx
+++ b/apps/web/src/components/qa-releases-page.tsx
@@ -1,0 +1,333 @@
+import { useMemo, useState } from 'react'
+import { Link } from '@tanstack/react-router'
+import { HugeiconsIcon } from '@hugeicons/react'
+import {
+  ArrowRight01Icon,
+  Loading03Icon,
+  SmartPhone01Icon,
+} from '@hugeicons/core-free-icons'
+
+import type { Build } from '@/lib/types'
+import type { InstallDevice } from '@/lib/artifact-install'
+import type { QaRelease } from '@/lib/qa-releases'
+import { useArtifactsForProjects, useBuilds } from '@/hooks/use-builds'
+import { useProjects } from '@/hooks/use-projects'
+import {
+  detectInstallDevice,
+  selectInstallArtifact,
+} from '@/lib/artifact-install'
+import { relativeTime } from '@/lib/format-utils'
+import {
+  changelogSummary,
+  qaBuildVersion,
+  qaProjectVersionBase,
+  selectQaProjectReleases,
+} from '@/lib/qa-releases'
+import { PageMeta } from '@/lib/seo'
+import PageLayout from '@/components/page-layout'
+import RepositoryAvatar from '@/components/repository-avatar'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/components/ui/pagination'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@/components/ui/empty'
+import { Skeleton } from '@/components/ui/skeleton'
+
+const RELEASES_PER_PAGE = 5
+
+export function QaReleaseRow({
+  device,
+  isLatest,
+  release,
+}: {
+  device: InstallDevice
+  isLatest: boolean
+  release: QaRelease
+}) {
+  const artifact = selectInstallArtifact(release.artifacts, device)!
+
+  return (
+    <Link
+      to="/builds/$buildId"
+      params={{ buildId: release.build.id }}
+      search={{ install: artifact.id }}
+      resetScroll
+      aria-label={`Open ${release.version}`}
+      className="flex min-h-16 items-center justify-between gap-3 px-3 py-2 transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset sm:px-4"
+    >
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <p className="text-base font-semibold tracking-tight">
+            {release.version}
+          </p>
+          {isLatest ? <Badge variant="secondary">Latest</Badge> : null}
+          <span className="text-xs text-muted-foreground">
+            {relativeTime(
+              release.build.finished_at ?? release.build.created_at,
+            )}
+          </span>
+        </div>
+        {release.build.changelog ? (
+          <p className="mt-1 line-clamp-1 text-xs text-muted-foreground">
+            {changelogSummary(release.build.changelog)}
+          </p>
+        ) : null}
+      </div>
+      <HugeiconsIcon
+        icon={ArrowRight01Icon}
+        className="shrink-0 text-muted-foreground"
+        aria-hidden
+      />
+    </Link>
+  )
+}
+
+function AppTabPanel({
+  activeBuild,
+  releases,
+  device,
+  versionBase,
+}: {
+  activeBuild?: Build
+  releases: Array<QaRelease>
+  device: InstallDevice
+  versionBase: string | null
+}) {
+  const [page, setPage] = useState(1)
+  const totalPages = Math.max(1, Math.ceil(releases.length / RELEASES_PER_PAGE))
+  const currentPage = Math.min(page, totalPages)
+  const pageStart = (currentPage - 1) * RELEASES_PER_PAGE
+  const visibleReleases = releases.slice(
+    pageStart,
+    pageStart + RELEASES_PER_PAGE,
+  )
+
+  return (
+    <section className="space-y-3 pt-3">
+      <div className="divide-y border-y">
+        {activeBuild ? (
+          <div className="flex items-center gap-2.5 px-3 py-3 sm:px-4">
+            <HugeiconsIcon
+              icon={Loading03Icon}
+              className="shrink-0 animate-spin text-info"
+              size={16}
+            />
+            <div className="min-w-0">
+              <p className="truncate text-sm">
+                <span className="font-medium">
+                  {qaBuildVersion(activeBuild, [], versionBase)}
+                </span>{' '}
+                <span className="text-muted-foreground">
+                  is being prepared
+                </span>
+              </p>
+              {activeBuild.changelog ? (
+                <p className="mt-1 line-clamp-1 text-xs text-muted-foreground">
+                  {changelogSummary(activeBuild.changelog)}
+                </p>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+        {visibleReleases.length > 0 ? (
+          visibleReleases.map((release, index) => (
+            <QaReleaseRow
+              key={release.build.id}
+              release={release}
+              device={device}
+              isLatest={pageStart + index === 0}
+            />
+          ))
+        ) : (
+          <div className="px-4 py-3">
+            <p className="text-sm text-muted-foreground">
+              Nothing to install yet. A version will appear automatically.
+            </p>
+          </div>
+        )}
+      </div>
+      {totalPages > 1 ? (
+        <Pagination>
+          <PaginationContent>
+            {currentPage > 1 ? (
+              <PaginationItem>
+                <PaginationPrevious
+                  href="#"
+                  onClick={(event) => {
+                    event.preventDefault()
+                    setPage(currentPage - 1)
+                  }}
+                />
+              </PaginationItem>
+            ) : null}
+            <PaginationItem>
+              <span className="px-2 text-xs text-muted-foreground">
+                {currentPage} of {totalPages}
+              </span>
+            </PaginationItem>
+            {currentPage < totalPages ? (
+              <PaginationItem>
+                <PaginationNext
+                  href="#"
+                  onClick={(event) => {
+                    event.preventDefault()
+                    setPage(currentPage + 1)
+                  }}
+                />
+              </PaginationItem>
+            ) : null}
+          </PaginationContent>
+        </Pagination>
+      ) : null}
+    </section>
+  )
+}
+
+export default function QaReleasesPage() {
+  const projectsQuery = useProjects({ limit: 200 })
+  const buildsQuery = useBuilds({ limit: 200 })
+  const projects = useMemo(
+    () => projectsQuery.data?.projects ?? [],
+    [projectsQuery.data?.projects],
+  )
+  const builds = useMemo(
+    () => buildsQuery.data?.builds ?? [],
+    [buildsQuery.data?.builds],
+  )
+  const artifactQueries = useArtifactsForProjects(
+    projects.map((project) => project.id),
+  )
+  const artifactsByProject = new Map(
+    projects.map((project, index) => [
+      project.id,
+      artifactQueries[index]?.data?.artifacts ?? [],
+    ]),
+  )
+  const versionByProject = new Map(
+    projects.map((project) => [
+      project.id,
+      qaProjectVersionBase(artifactsByProject.get(project.id) ?? []),
+    ]),
+  )
+  const releasesByProject = new Map(
+    projects.map((project) => [
+      project.id,
+      selectQaProjectReleases(
+        project.id,
+        builds,
+        artifactsByProject.get(project.id) ?? [],
+      ),
+    ]),
+  )
+  const activeBuildByProject = new Map<string, Build>()
+  for (const build of builds) {
+    if (
+      ['queued', 'scheduled', 'assigned', 'running'].includes(build.status) &&
+      (!activeBuildByProject.has(build.project_id) ||
+        build.created_at >
+          activeBuildByProject.get(build.project_id)!.created_at)
+    ) {
+      activeBuildByProject.set(build.project_id, build)
+    }
+  }
+  const device = detectInstallDevice(
+    typeof navigator === 'undefined' ? '' : navigator.userAgent,
+  )
+  const isLoading =
+    projectsQuery.isLoading ||
+    buildsQuery.isLoading ||
+    artifactQueries.some((query) => query.isLoading)
+  const error =
+    projectsQuery.error ??
+    buildsQuery.error ??
+    artifactQueries.find((query) => query.error)?.error
+
+  return (
+    <PageLayout width="wide" className="max-w-4xl px-4 py-6 sm:px-6 sm:py-10">
+      <PageMeta title="Your apps" noindex />
+      <header className="space-y-1">
+        <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+          Your apps
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Versions ready for you to test.
+        </p>
+      </header>
+
+      {error ? (
+        <Alert variant="destructive">
+          <AlertDescription>
+            Your apps could not be loaded. Refresh the page to try again.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {isLoading ? (
+        <div className="space-y-4">
+          <Skeleton className="h-64 w-full" />
+          <Skeleton className="h-64 w-full" />
+        </div>
+      ) : null}
+
+      {!isLoading && !error && projects.length === 0 ? (
+        <div className="border">
+          <Empty className="py-12">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <HugeiconsIcon icon={SmartPhone01Icon} />
+              </EmptyMedia>
+              <EmptyTitle>No apps shared with you yet</EmptyTitle>
+              <EmptyDescription>
+                Ask an owner or admin to add you to an app. It will appear here
+                as soon as a version is ready.
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        </div>
+      ) : null}
+
+      {!isLoading && !error && projects.length > 0 ? (
+        <Tabs defaultValue={projects[0].id} aria-label="Apps">
+          <div className="no-scrollbar -mx-4 overflow-x-auto px-4 sm:mx-0 sm:px-0">
+            <TabsList variant="line" className="min-w-max justify-start">
+              {projects.map((project) => (
+                <TabsTrigger key={project.id} value={project.id}>
+                  <RepositoryAvatar
+                    fullName={project.repository_full_name ?? project.name}
+                    avatarUrl={project.repository_avatar_url}
+                    repositoryId={project.repository_id}
+                    provider={project.repository_provider}
+                    size="sm"
+                  />
+                  {project.name}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </div>
+          {projects.map((project) => (
+            <TabsContent key={project.id} value={project.id}>
+              <AppTabPanel
+                activeBuild={activeBuildByProject.get(project.id)}
+                releases={releasesByProject.get(project.id) ?? []}
+                device={device}
+                versionBase={versionByProject.get(project.id) ?? null}
+              />
+            </TabsContent>
+          ))}
+        </Tabs>
+      ) : null}
+    </PageLayout>
+  )
+}

--- a/apps/web/src/components/trigger-build-dialog.tsx
+++ b/apps/web/src/components/trigger-build-dialog.tsx
@@ -6,7 +6,10 @@ import z from 'zod'
 import { toast } from 'sonner'
 import { useMountEffect } from '@/hooks/use-mount-effect'
 
-import { useCreateBuild } from '@/hooks/use-builds'
+import {
+  useBuildChangelogPreview,
+  useCreateBuild,
+} from '@/hooks/use-builds'
 import { usePipelines } from '@/hooks/use-pipelines'
 import { useProjects } from '@/hooks/use-projects'
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -38,6 +41,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Spinner } from '@/components/ui/spinner'
+import { Textarea } from '@/components/ui/textarea'
 import { READ_ONLY_REASON, isDemoMode } from '@/lib/demo-mode'
 import type { BuildPlatform } from '@/lib/types'
 
@@ -54,6 +58,7 @@ const triggerBuildSchema = z
     platforms: z.array(z.enum(['android', 'ios', 'macos'])),
     branch: z.string().optional(),
     commit_sha: z.string().optional(),
+    changelog: z.string().max(4000, 'Keep the changelog under 4,000 characters').optional(),
   })
   .superRefine((data, ctx) => {
     const branch = data.branch?.trim()
@@ -157,6 +162,7 @@ function defaults(
     platforms,
     branch: defaultBranch ?? '',
     commit_sha: '',
+    changelog: undefined,
   }
 }
 
@@ -230,6 +236,11 @@ function useTriggerBuildDialogState({
     () => selectedPipeline?.execution_config.platforms ?? [],
     [selectedPipeline],
   )
+  const changelogPreviewQuery = useBuildChangelogPreview(projectId, {
+    pipeline_id: selectedPipelineId,
+    branch: form.watch('branch')?.trim() || undefined,
+    commit_sha: form.watch('commit_sha')?.trim() || undefined,
+  }, { enabled: open })
 
   // Auto-select pipeline when project changes
   useMountEffect(() => {
@@ -265,7 +276,15 @@ function useTriggerBuildDialogState({
       return
     }
     const branch = data.branch?.trim() || undefined
-    const commitSha = data.commit_sha?.trim() || undefined
+    const commitSha =
+      data.commit_sha?.trim() ||
+      changelogPreviewQuery.data?.target_commit ||
+      undefined
+    const changelog = (
+      data.changelog === undefined
+        ? changelogPreviewQuery.data?.markdown
+        : data.changelog
+    )?.trim() || undefined
 
     createBuildMutation.mutate(
       {
@@ -275,6 +294,7 @@ function useTriggerBuildDialogState({
           branch,
           commit_sha: commitSha,
           trigger_ref: branch,
+          changelog,
           platforms:
             availablePlatforms.length > 1
               ? data.platforms.length > 0
@@ -310,6 +330,7 @@ function useTriggerBuildDialogState({
 
   return {
     createBuildMutation,
+    changelogPreviewQuery,
     defaultBranch,
     defaultPipelineId,
     description,
@@ -339,6 +360,7 @@ function useTriggerBuildDialogState({
 export default function TriggerBuildDialog(props: TriggerBuildDialogProps) {
   const {
     createBuildMutation,
+    changelogPreviewQuery,
     defaultBranch,
     defaultPipelineId,
     description,
@@ -537,6 +559,36 @@ export default function TriggerBuildDialog(props: TriggerBuildDialogProps) {
                   <p className="text-xs text-muted-foreground">
                     If set, the runner checks out this exact commit.
                   </p>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="changelog"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>What changed? (optional)</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      {...field}
+                      value={
+                        field.value ??
+                        changelogPreviewQuery.data?.markdown ??
+                        ''
+                      }
+                      placeholder="No changes found since the previous build."
+                      rows={5}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    {changelogPreviewQuery.isFetching
+                      ? 'Drafting from commits since the previous successful build…'
+                      : changelogPreviewQuery.error
+                        ? 'Could not generate a draft. You can still write one.'
+                        : 'Markdown draft generated from commit titles and authors. Edit or clear it before running.'}
+                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/apps/web/src/demo/data/artifacts.ts
+++ b/apps/web/src/demo/data/artifacts.ts
@@ -4,6 +4,28 @@ import type { Artifact } from '@/lib/types'
 export const demoArtifacts: Record<string, Array<Artifact>> = {
   [BUILD_IDS.succeeded1]: [
     {
+      id: 'art-005',
+      build_id: BUILD_IDS.succeeded1,
+      name: 'FlutterShop.ipa',
+      artifact_type: 'ipa',
+      file_path: 'build/ios/ipa/FlutterShop.ipa',
+      file_size: 32505856,
+      checksum: 'sha256:c3d4e5f6a7b8...',
+      metadata: {
+        ios_app: {
+          bundle_identifier: 'build.oore.fluttershop',
+          display_name: 'Flutter Shop',
+          version: '1.4.1',
+          build_number: '85',
+        },
+        ios_signing: {
+          bundle_ids: ['build.oore.fluttershop'],
+          effective_export_method: 'release-testing',
+        },
+      },
+      created_at: ago(7020),
+    },
+    {
       id: 'art-001',
       build_id: BUILD_IDS.succeeded1,
       name: 'app-armeabi-v7a-release.apk',
@@ -11,7 +33,11 @@ export const demoArtifacts: Record<string, Array<Artifact>> = {
       file_path: 'build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk',
       file_size: 19084288,
       checksum: 'sha256:a1b2c3d4e5f6...',
-      metadata: { abi: 'armeabi-v7a', minSdk: 21 },
+      metadata: {
+        abi: 'armeabi-v7a',
+        minSdk: 21,
+        android_app: { version_name: '1.4.1', version_code: '85' },
+      },
       created_at: ago(7020),
     },
     {
@@ -22,7 +48,11 @@ export const demoArtifacts: Record<string, Array<Artifact>> = {
       file_path: 'build/app/outputs/flutter-apk/app-arm64-v8a-release.apk',
       file_size: 20054016,
       checksum: 'sha256:b2c3d4e5f6a7...',
-      metadata: { abi: 'arm64-v8a', minSdk: 21 },
+      metadata: {
+        abi: 'arm64-v8a',
+        minSdk: 21,
+        android_app: { version_name: '1.4.1', version_code: '85' },
+      },
       created_at: ago(7020),
     },
   ],
@@ -34,7 +64,10 @@ export const demoArtifacts: Record<string, Array<Artifact>> = {
       artifact_type: 'apk',
       file_path: 'build/app/outputs/flutter-apk/app-debug.apk',
       file_size: 44695552,
-      metadata: { buildType: 'debug' },
+      metadata: {
+        buildType: 'debug',
+        android_app: { version_name: '2.7.0', version_code: '46' },
+      },
       created_at: ago(14160),
     },
   ],

--- a/apps/web/src/demo/data/builds.ts
+++ b/apps/web/src/demo/data/builds.ts
@@ -56,6 +56,7 @@ export const demoBuilds: Array<Build> = [
     trigger_actor: USER_IDS.developer,
     commit_sha: 'f0e1d2c3b4a5f6e7d8c9b0a1f2e3d4c5b6a7f8e9',
     branch: 'main',
+    changelog: 'Adds receipt sharing and improves payment retry messaging.',
     config_snapshot: {},
     runner_id: RUNNER_IDS.macMini,
     step_results: [
@@ -86,6 +87,7 @@ export const demoBuilds: Array<Build> = [
     trigger_ref: 'refs/heads/main',
     commit_sha: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0',
     branch: 'main',
+    changelog: 'Adds wishlist sharing and smoother cart updates.',
     config_snapshot: {},
     queued_at: ago(60),
     created_at: ago(60),
@@ -104,6 +106,8 @@ export const demoBuilds: Array<Build> = [
     trigger_ref: 'refs/heads/main',
     commit_sha: 'b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1',
     branch: 'main',
+    changelog:
+      'Faster checkout, clearer payment errors, and fixes for saved delivery addresses.',
     config_snapshot: {},
     runner_id: RUNNER_IDS.macStudio,
     step_results: [
@@ -194,6 +198,8 @@ export const demoBuilds: Array<Build> = [
     trigger_actor: USER_IDS.owner,
     commit_sha: 'd4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3',
     branch: 'main',
+    changelog:
+      'Faster checkout, clearer payment errors, and fixes for saved delivery addresses.',
     config_snapshot: {},
     runner_id: RUNNER_IDS.macStudio,
     step_results: [

--- a/apps/web/src/demo/handlers/builds.ts
+++ b/apps/web/src/demo/handlers/builds.ts
@@ -5,6 +5,22 @@ import { demoArtifacts } from '../data/artifacts'
 import { USER_IDS, ago } from '../seed'
 
 export const buildHandlers = [
+  http.get(
+    '/v1/projects/:projectId/builds/changelog-preview',
+    async ({ request }) => {
+      await delay(200)
+      const url = new URL(request.url)
+      return HttpResponse.json({
+        base_commit: 'b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1',
+        target_commit:
+          url.searchParams.get('commit_sha') ??
+          'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0',
+        markdown:
+          '- Faster checkout validation — Alex Morgan\n- Clearer payment retry messaging — Priya Shah\n- Fixed saved delivery addresses — Sam Lee',
+      })
+    },
+  ),
+
   http.get('/v1/builds', async ({ request }) => {
     await delay(150)
     const url = new URL(request.url)
@@ -59,6 +75,7 @@ export const buildHandlers = [
       pipeline_id: string
       branch?: string
       commit_sha?: string
+      changelog?: string
     }
     return HttpResponse.json({
       build: {
@@ -71,6 +88,7 @@ export const buildHandlers = [
         trigger_actor: USER_IDS.owner,
         branch: body.branch ?? 'main',
         commit_sha: body.commit_sha,
+        changelog: body.changelog,
         config_snapshot: {},
         queued_at: ago(0),
         created_at: ago(0),
@@ -124,6 +142,18 @@ export const buildHandlers = [
     const buildId = params.buildId as string
     return HttpResponse.json({
       artifacts: demoArtifacts[buildId] ?? [],
+    })
+  }),
+
+  http.get('/v1/projects/:projectId/artifacts', async ({ params }) => {
+    await delay(150)
+    const projectBuildIds = demoBuilds
+      .filter((build) => build.project_id === params.projectId)
+      .map((build) => build.id)
+    return HttpResponse.json({
+      artifacts: projectBuildIds.flatMap(
+        (buildId) => demoArtifacts[buildId] ?? [],
+      ),
     })
   }),
 ]

--- a/apps/web/src/hooks/use-builds.ts
+++ b/apps/web/src/hooks/use-builds.ts
@@ -3,10 +3,12 @@ import {
   useMutation,
   useQuery,
   useQueryClient,
+  useQueries,
 } from '@tanstack/react-query'
 import type { UseQueryOptions } from '@tanstack/react-query'
 import type {
   Build,
+  BuildChangelogPreviewResponse,
   BuildDetailResponse,
   BuildLogChunk,
   BuildStatus,
@@ -21,8 +23,10 @@ import {
   createScopedDownloadToken,
   getArtifactDownloadLink,
   getBuild,
+  getBuildChangelogPreview,
   getBuildLogs,
   listArtifacts,
+  listProjectArtifacts,
   listBuilds,
   rerunBuild,
 } from '@/lib/api'
@@ -143,6 +147,7 @@ export function useCreateBuild() {
         branch: data.branch,
         commit_sha: data.commit_sha,
         trigger_ref: data.trigger_ref,
+        changelog: data.changelog,
         config_snapshot: {},
         queued_at: Math.floor(Date.now() / 1000),
         created_at: Math.floor(Date.now() / 1000),
@@ -172,6 +177,36 @@ export function useCreateBuild() {
         queryKey: [instanceId, 'builds'],
       })
     },
+  })
+}
+
+export function useBuildChangelogPreview(
+  projectId: string,
+  params: { pipeline_id: string; branch?: string; commit_sha?: string },
+  options?: { enabled?: boolean },
+) {
+  const baseUrl = useBaseUrl()
+  const token = useAuthToken()
+  const instance = useActiveInstance()
+
+  return useQuery<BuildChangelogPreviewResponse>({
+    queryKey: [
+      instance?.id ?? '__none__',
+      'build-changelog-preview',
+      projectId,
+      params,
+    ],
+    queryFn: ({ signal }) =>
+      getBuildChangelogPreview(baseUrl!, token!, projectId, params, { signal }),
+    enabled:
+      !!baseUrl &&
+      !!token &&
+      (options?.enabled ?? true) &&
+      !!projectId &&
+      !!params.pipeline_id &&
+      (!!params.branch || !!params.commit_sha),
+    staleTime: 30_000,
+    retry: false,
   })
 }
 
@@ -277,6 +312,36 @@ export function useArtifacts(
     enabled: !!baseUrl && !!token && !!buildId,
     staleTime: 5_000,
     refetchInterval: options?.refetchInterval,
+  })
+}
+
+export function useProjectArtifacts(projectId: string) {
+  const baseUrl = useBaseUrl()
+  const token = useAuthToken()
+  const instance = useActiveInstance()
+
+  return useQuery({
+    queryKey: [instance?.id ?? '__none__', 'project-artifacts', projectId],
+    queryFn: ({ signal }) =>
+      listProjectArtifacts(baseUrl!, token!, projectId, { signal }),
+    enabled: !!baseUrl && !!token && !!projectId,
+    staleTime: 5_000,
+  })
+}
+
+export function useArtifactsForProjects(projectIds: Array<string>) {
+  const baseUrl = useBaseUrl()
+  const token = useAuthToken()
+  const instance = useActiveInstance()
+
+  return useQueries({
+    queries: projectIds.map((projectId) => ({
+      queryKey: [instance?.id ?? '__none__', 'project-artifacts', projectId],
+      queryFn: ({ signal }: { signal: AbortSignal }) =>
+        listProjectArtifacts(baseUrl!, token!, projectId, { signal }),
+      enabled: !!baseUrl && !!token,
+      staleTime: 5_000,
+    })),
   })
 }
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -7,6 +7,7 @@ import type {
   AddProjectMemberResponse,
   BootstrapTokenVerifyResponse,
   BrowseLocalGitDirectoriesResponse,
+  BuildChangelogPreviewResponse,
   BuildDetailResponse,
   BuildLogsResponse,
   CancelBuildResponse,
@@ -852,6 +853,23 @@ export function createBuild(
   )
 }
 
+export function getBuildChangelogPreview(
+  baseUrl: string,
+  token: string,
+  projectId: string,
+  params: { pipeline_id: string; branch?: string; commit_sha?: string },
+  options?: RequestOptions,
+): Promise<BuildChangelogPreviewResponse> {
+  const query = new URLSearchParams({ pipeline_id: params.pipeline_id })
+  if (params.branch) query.set('branch', params.branch)
+  if (params.commit_sha) query.set('commit_sha', params.commit_sha)
+  return request<BuildChangelogPreviewResponse>(
+    baseUrl,
+    `/v1/projects/${projectId}/builds/changelog-preview?${query}`,
+    { headers: authHeaders(token), signal: options?.signal },
+  )
+}
+
 export function listBuilds(
   baseUrl: string,
   token: string,
@@ -976,6 +994,19 @@ export function listArtifacts(
   return request<ListArtifactsResponse>(
     baseUrl,
     `/v1/builds/${buildId}/artifacts`,
+    { headers: authHeaders(token), signal: options?.signal },
+  )
+}
+
+export function listProjectArtifacts(
+  baseUrl: string,
+  token: string,
+  projectId: string,
+  options?: RequestOptions,
+): Promise<ListArtifactsResponse> {
+  return request<ListArtifactsResponse>(
+    baseUrl,
+    `/v1/projects/${projectId}/artifacts`,
     { headers: authHeaders(token), signal: options?.signal },
   )
 }

--- a/apps/web/src/lib/artifact-install.test.ts
+++ b/apps/web/src/lib/artifact-install.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   artifactInstallReadiness,
   detectInstallDevice,
+  selectInstallArtifact,
 } from './artifact-install'
 import type { Artifact } from '@/lib/types'
 
@@ -78,5 +79,19 @@ describe('install device detection', () => {
     expect(detectInstallDevice('Mozilla/5.0 (Macintosh; Intel Mac OS X)')).toBe(
       'other',
     )
+  })
+})
+
+describe('combined install artifact selection', () => {
+  const apk = { ...ipa({}), id: 'apk', artifact_type: 'apk' as const }
+  const ios = ipa({})
+
+  it('prefers the current phone and otherwise keeps the intended artifact', () => {
+    expect(selectInstallArtifact([ios, apk], 'android', ios.id)?.id).toBe('apk')
+    expect(selectInstallArtifact([ios, apk], 'iphone-safari', apk.id)?.id).toBe(
+      ios.id,
+    )
+    expect(selectInstallArtifact([ios, apk], 'other', ios.id)?.id).toBe(ios.id)
+    expect(selectInstallArtifact([ios, apk], 'other')?.id).toBe('apk')
   })
 })

--- a/apps/web/src/lib/artifact-install.ts
+++ b/apps/web/src/lib/artifact-install.ts
@@ -10,6 +10,23 @@ export interface IosAppMetadata {
 export type InstallDevice =
   'iphone-safari' | 'iphone-other' | 'android' | 'other'
 
+export function selectInstallArtifact(
+  artifacts: Array<Artifact>,
+  device: InstallDevice,
+  requestedId?: string,
+): Artifact | undefined {
+  return (
+    artifacts.find(
+      (artifact) =>
+        (device.startsWith('iphone') && artifact.artifact_type === 'ipa') ||
+        (device === 'android' && artifact.artifact_type === 'apk'),
+    ) ??
+    artifacts.find((artifact) => artifact.id === requestedId) ??
+    artifacts.find((artifact) => artifact.artifact_type === 'apk') ??
+    artifacts.find((artifact) => artifact.artifact_type === 'ipa')
+  )
+}
+
 function metadataString(
   value: Record<string, unknown>,
   key: string,

--- a/apps/web/src/lib/qa-releases.test.ts
+++ b/apps/web/src/lib/qa-releases.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Artifact, Build } from '@/lib/types'
+import {
+  changelogSummary,
+  qaBuildVersion,
+  qaProjectVersionBase,
+  selectQaProjectReleases,
+} from '@/lib/qa-releases'
+
+function build(id: string, projectId: string, createdAt: number): Build {
+  return {
+    id,
+    project_id: projectId,
+    pipeline_id: 'pipeline-1',
+    build_number: createdAt,
+    status: 'succeeded',
+    trigger_type: 'manual',
+    config_snapshot: {},
+    queued_at: createdAt,
+    created_at: createdAt,
+    updated_at: createdAt,
+  }
+}
+
+function artifact(
+  id: string,
+  buildId: string,
+  type: 'apk' | 'ipa',
+  name: string,
+  createdAt: number,
+  buildNumber = '12',
+): Artifact {
+  return {
+    id,
+    build_id: buildId,
+    name,
+    artifact_type: type,
+    file_path: name,
+    metadata:
+      type === 'ipa'
+        ? {
+            ios_app: {
+              bundle_identifier: 'build.oore.app',
+              display_name: 'Oore App',
+              version: '1.2.0',
+              build_number: buildNumber,
+            },
+            ios_signing: {
+              bundle_ids: ['build.oore.app'],
+              effective_export_method: 'release-testing',
+            },
+          }
+        : {},
+    created_at: createdAt,
+  }
+}
+
+describe('QA release selection', () => {
+  it('reduces Markdown changelogs to a quiet one-line summary', () => {
+    expect(
+      changelogSummary('- **Faster checkout** — Alex\n- Fixed receipts — Sam'),
+    ).toBe('Faster checkout — Alex')
+  })
+
+  it('keeps every artifact-bearing build and groups its installable platforms under one version', () => {
+    const builds = [build('new', 'kite', 13), build('older', 'kite', 12)]
+    const artifacts = [
+      artifact('new-ipa', 'new', 'ipa', 'Kite.ipa', 13, '13'),
+      artifact('apk-32', 'new', 'apk', 'app-armeabi-v7a.apk', 13),
+      artifact('apk-64', 'new', 'apk', 'app-arm64-v8a.apk', 13),
+      artifact('older-ipa', 'older', 'ipa', 'Kite.ipa', 12),
+    ]
+    const releases = selectQaProjectReleases('kite', builds, artifacts, 200)
+
+    expect(qaProjectVersionBase(artifacts)).toBe('1.2.0')
+    expect(qaBuildVersion(builds[0], artifacts.slice(0, 2), '1.2.0')).toBe(
+      '1.2.0+13',
+    )
+    expect(releases.map((release) => release.version)).toEqual([
+      '1.2.0+13',
+      '1.2.0+12',
+    ])
+    expect(releases[0].artifacts.map((candidate) => candidate.id)).toEqual([
+      'new-ipa',
+      'apk-64',
+    ])
+    expect(releases[1].artifacts.map((candidate) => candidate.id)).toEqual([
+      'older-ipa',
+    ])
+  })
+})

--- a/apps/web/src/lib/qa-releases.ts
+++ b/apps/web/src/lib/qa-releases.ts
@@ -1,0 +1,144 @@
+import type { Artifact, Build } from '@/lib/types'
+import {
+  artifactInstallReadiness,
+  getIosAppMetadata,
+} from '@/lib/artifact-install'
+
+export interface QaRelease {
+  artifacts: Array<Artifact>
+  build: Build
+  version: string
+}
+
+export function changelogSummary(markdown: string): string {
+  const firstLine = markdown
+    .split('\n')
+    .map((line) => line.trim())
+    .find(Boolean)
+  return (firstLine ?? '')
+    .replace(/^[-*+]\s+/, '')
+    .replace(/[*_`#>[\]]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function metadataObject(
+  value: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | null {
+  const candidate = value[key]
+  return candidate !== null &&
+    typeof candidate === 'object' &&
+    !Array.isArray(candidate)
+    ? (candidate as Record<string, unknown>)
+    : null
+}
+
+function metadataString(
+  value: Record<string, unknown>,
+  ...keys: Array<string>
+): string | null {
+  for (const key of keys) {
+    const candidate = value[key]
+    if (typeof candidate === 'string' && candidate.trim())
+      return candidate.trim()
+    if (typeof candidate === 'number' && Number.isFinite(candidate))
+      return String(candidate)
+  }
+  return null
+}
+
+function artifactVersion(
+  artifact: Artifact,
+): { name: string; number: string } | null {
+  const ios = getIosAppMetadata(artifact)
+  if (ios) return { name: ios.version, number: ios.buildNumber }
+
+  const android = metadataObject(artifact.metadata, 'android_app')
+  if (!android) return null
+  const name = metadataString(android, 'version_name', 'version')
+  const number = metadataString(android, 'version_code', 'build_number')
+  return name && number ? { name, number } : null
+}
+
+export function qaProjectVersionBase(
+  artifacts: Array<Artifact>,
+): string | null {
+  return (
+    [...artifacts]
+      .sort((left, right) => right.created_at - left.created_at)
+      .map(artifactVersion)
+      .find((version) => version !== null)?.name ?? null
+  )
+}
+
+export function qaBuildVersion(
+  build: Build,
+  artifacts: Array<Artifact>,
+  fallbackVersion: string | null,
+): string {
+  const exact = artifacts
+    .map(artifactVersion)
+    .find((version) => version !== null)
+  return exact
+    ? `${exact.name}+${exact.number}`
+    : fallbackVersion
+      ? `${fallbackVersion}+${build.build_number}`
+      : `Build ${build.build_number}`
+}
+
+function bestArtifact(
+  artifacts: Array<Artifact>,
+  type: 'apk' | 'ipa',
+  now: number,
+): Artifact | undefined {
+  return artifacts
+    .filter(
+      (artifact) =>
+        artifact.artifact_type === type &&
+        (artifact.expires_at == null || artifact.expires_at > now) &&
+        artifactInstallReadiness(artifact).ready,
+    )
+    .sort((left, right) => {
+      if (type !== 'apk') return right.created_at - left.created_at
+      const rank = (name: string) =>
+        /universal/i.test(name) ? 2 : /arm64[-_]v8a|arm64/i.test(name) ? 1 : 0
+      return rank(right.name) - rank(left.name)
+    })[0]
+}
+
+export function selectQaProjectReleases(
+  projectId: string,
+  builds: Array<Build>,
+  projectArtifacts: Array<Artifact>,
+  now = Math.floor(Date.now() / 1000),
+): Array<QaRelease> {
+  const fallbackVersion = qaProjectVersionBase(projectArtifacts)
+  const artifactsByBuild = new Map<string, Array<Artifact>>()
+  for (const artifact of projectArtifacts) {
+    const artifacts = artifactsByBuild.get(artifact.build_id) ?? []
+    artifacts.push(artifact)
+    artifactsByBuild.set(artifact.build_id, artifacts)
+  }
+
+  return builds
+    .filter(
+      (build) => build.project_id === projectId && build.status === 'succeeded',
+    )
+    .sort((left, right) => right.created_at - left.created_at)
+    .flatMap((build) => {
+      const buildArtifacts = artifactsByBuild.get(build.id) ?? []
+      const artifacts = (['ipa', 'apk'] as const)
+        .map((type) => bestArtifact(buildArtifacts, type, now))
+        .filter((artifact): artifact is Artifact => artifact !== undefined)
+      return artifacts.length > 0
+        ? [
+            {
+              artifacts,
+              build,
+              version: qaBuildVersion(build, buildArtifacts, fallbackVersion),
+            },
+          ]
+        : []
+    })
+}

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -430,6 +430,7 @@ export interface Build {
   trigger_ref?: string
   commit_sha?: string
   branch?: string
+  changelog?: string
   source_build_id?: string
   config_snapshot: Record<string, unknown>
   runner_id?: string
@@ -466,10 +467,17 @@ export interface CreateBuildRequest {
   branch?: string
   commit_sha?: string
   trigger_ref?: string
+  changelog?: string
 }
 
 export interface CreateBuildResponse {
   build: Build
+}
+
+export interface BuildChangelogPreviewResponse {
+  base_commit?: string
+  target_commit: string
+  markdown: string
 }
 
 export interface BuildDetailResponse {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -8,13 +8,12 @@ import {
 import { QueryClientProvider } from '@tanstack/react-query'
 import { ThemeProvider } from 'next-themes'
 import { HugeiconsIcon } from '@hugeicons/react'
-import {
-  Search01Icon,
-} from '@hugeicons/core-free-icons'
+import { Search01Icon } from '@hugeicons/core-free-icons'
 
 import AppSidebar from '@/components/app-sidebar'
 import ConnectivityBanner from '@/components/connectivity-banner'
 import PageBreadcrumb from '@/components/page-breadcrumb'
+import QaAppHeader from '@/components/qa-app-header'
 import { Separator } from '@/components/ui/separator'
 import {
   SidebarInset,
@@ -116,6 +115,7 @@ function RootLayout() {
     !!activeInstanceId &&
     !!authToken &&
     !!authUser
+  const showQaChrome = showAppChrome && authUser.role === 'qa_viewer'
 
   useSessionMonitor()
 
@@ -123,7 +123,15 @@ function RootLayout() {
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
       <QueryClientProvider client={queryClient}>
         <RouteTransitionBar />
-        {showAppChrome ? (
+        {showQaChrome ? (
+          <div className="flex min-h-screen flex-col bg-surface">
+            <QaAppHeader />
+            <ConnectivityBanner />
+            <main className="flex flex-1 flex-col">
+              <Outlet />
+            </main>
+          </div>
+        ) : showAppChrome ? (
           <SidebarProvider open={sidebarOpen} onOpenChange={setSidebarOpen}>
             <AppSidebar />
             <SidebarInset>
@@ -162,7 +170,7 @@ function RootLayout() {
           </div>
         )}
         <Toaster />
-        {showAppChrome ? (
+        {showAppChrome && !showQaChrome ? (
           <Suspense fallback={null}>
             <CommandPalette />
           </Suspense>

--- a/apps/web/src/routes/builds/index.tsx
+++ b/apps/web/src/routes/builds/index.tsx
@@ -39,6 +39,7 @@ import {
 } from '@/components/ui/select'
 import PageHeader from '@/components/page-header'
 import PageLayout from '@/components/page-layout'
+import QaReleasesPage from '@/components/qa-releases-page'
 import SetupHint from '@/components/setup-hint'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
@@ -293,6 +294,11 @@ function useBuildsListPageState() {
 }
 
 function BuildsListPage() {
+  const isQaViewer = useAuthStore((state) => state.user?.role === 'qa_viewer')
+  return isQaViewer ? <QaReleasesPage /> : <OperationsBuildsPage />
+}
+
+function OperationsBuildsPage() {
   const pageState = useBuildsListPageState()
   const {
     branchFilter,

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -14,6 +14,7 @@ import { useMountEffect } from '@/hooks/use-mount-effect'
 import ActiveBuildBanner from '@/components/active-build-banner'
 import AddInstanceDialog from '@/components/AddInstanceDialog'
 import ProjectCard from '@/components/project-card'
+import QaReleasesPage from '@/components/qa-releases-page'
 import TriggerBuildDialog from '@/components/trigger-build-dialog'
 import {
   DashboardGettingStarted,
@@ -240,7 +241,7 @@ function IndexPage() {
 
   if (status?.is_configured) {
     if (authUser?.role === 'qa_viewer') {
-      return <QaBuildRedirect />
+      return <QaReleasesPage />
     }
     return (
       <>
@@ -259,23 +260,6 @@ function IndexPage() {
       <div className="flex items-center gap-3">
         <Spinner className="size-5" />
         <p className="text-sm text-muted-foreground">Loading...</p>
-      </div>
-    </div>
-  )
-}
-
-function QaBuildRedirect() {
-  const navigate = useNavigate()
-  useMountEffect(() => {
-    void navigate({ to: '/builds', replace: true })
-  })
-
-  return (
-    <div className="flex flex-1 items-center justify-center">
-      <PageMeta />
-      <div className="flex items-center gap-3">
-        <Spinner className="size-5" />
-        <p className="text-sm text-muted-foreground">Loading builds...</p>
       </div>
     </div>
   )

--- a/bun.lock
+++ b/bun.lock
@@ -81,6 +81,7 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-hook-form": "^7.81.0",
+        "react-markdown": "^10.1.0",
         "shadcn": "^4.13.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
@@ -792,9 +793,13 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
+    "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
@@ -805,6 +810,8 @@
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
     "@types/mdurl": ["@types/mdurl@2.0.0", "", {}, "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
@@ -940,6 +947,8 @@
 
     "babel-dead-code-elimination": ["babel-dead-code-elimination@1.0.12", "", { "dependencies": { "@babel/core": "^7.23.7", "@babel/parser": "^7.23.6", "@babel/traverse": "^7.23.7", "@babel/types": "^7.23.6" } }, "sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig=="],
 
+    "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.19", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg=="],
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
@@ -972,9 +981,13 @@
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
+    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
+
     "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
 
     "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
 
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
@@ -1037,6 +1050,8 @@
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
 
     "dedent": ["dedent@1.7.1", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg=="],
 
@@ -1108,6 +1123,8 @@
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
+    "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
+
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
@@ -1123,6 +1140,8 @@
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
     "express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -1194,6 +1213,8 @@
 
     "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
 
+    "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
+
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
     "headers-polyfill": ["headers-polyfill@5.0.1", "", { "dependencies": { "@types/set-cookie-parser": "^2.4.10", "set-cookie-parser": "^3.0.1" } }, "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA=="],
@@ -1203,6 +1224,8 @@
     "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
+    "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
@@ -1218,11 +1241,19 @@
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
+    "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
+
     "ip-address": ["ip-address@10.0.1", "", {}, "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
+    "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
+
+    "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
+
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
+
+    "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
 
     "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
 
@@ -1231,6 +1262,8 @@
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
 
     "is-in-ssh": ["is-in-ssh@1.0.0", "", {}, "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw=="],
 
@@ -1318,6 +1351,8 @@
 
     "log-symbols": ["log-symbols@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "is-unicode-supported": "^1.3.0" } }, "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw=="],
 
+    "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
     "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
 
     "lucide-vue-next": ["lucide-vue-next@1.0.0", "", { "peerDependencies": { "vue": ">=3.0.1" } }, "sha512-V6SPvx1IHTj/UY+FrIYWV5faISsPSb8BnWSFDxAtezWKvWc9ZZ40PDrdu1/Qb5vg4lHWr1hs1BAMGVGm6V1Xdg=="],
@@ -1332,7 +1367,21 @@
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
+    "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
+
+    "mdast-util-mdx-expression": ["mdast-util-mdx-expression@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ=="],
+
+    "mdast-util-mdx-jsx": ["mdast-util-mdx-jsx@3.2.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "parse-entities": "^4.0.0", "stringify-entities": "^4.0.0", "unist-util-stringify-position": "^4.0.0", "vfile-message": "^4.0.0" } }, "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q=="],
+
+    "mdast-util-mdxjs-esm": ["mdast-util-mdxjs-esm@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg=="],
+
+    "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
+
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
+
+    "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
 
     "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
 
@@ -1344,11 +1393,43 @@
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
+    "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
+
+    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
+
+    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
+
+    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
+
     "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
+
+    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
+
+    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
+
+    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
+
+    "micromark-util-decode-string": ["micromark-util-decode-string@2.0.1", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ=="],
 
     "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
 
+    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
+
+    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
+
+    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
+
     "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
 
     "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
 
@@ -1422,6 +1503,8 @@
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
+    "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
+
     "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
     "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
@@ -1484,6 +1567,8 @@
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
+    "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
+
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
@@ -1501,6 +1586,10 @@
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
 
     "reka-ui": ["reka-ui@2.10.1", "", { "dependencies": { "@floating-ui/dom": "^1.6.13", "@floating-ui/vue": "^1.1.6", "@internationalized/date": "^3.5.0", "@internationalized/number": "^3.5.0", "@tanstack/vue-virtual": "^3.12.0", "@vueuse/core": "^14.1.0", "@vueuse/shared": "^14.1.0", "aria-hidden": "^1.2.4", "defu": "^6.1.5", "ohash": "^2.0.11" }, "peerDependencies": { "vue": ">= 3.4.0" } }, "sha512-drcOQ4rQtDYAcGCsyQBqQg8QQ+H3B+zDaMJU0h8KPEPMa7g9BHu3zcOi4OB39XJSWizceFoNO0Z9tctSGLOXqg=="],
+
+    "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
+
+    "remark-rehype": ["remark-rehype@11.1.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
@@ -1614,6 +1703,10 @@
 
     "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
 
+    "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
+
+    "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
+
     "superjson": ["superjson@2.2.6", "", { "dependencies": { "copy-anything": "^4" } }, "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA=="],
 
     "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
@@ -1654,6 +1747,8 @@
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
+    "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
+
     "ts-morph": ["ts-morph@26.0.0", "", { "dependencies": { "@ts-morph/common": "~0.27.0", "code-block-writer": "^13.0.3" } }, "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug=="],
 
     "tsconfig-paths": ["tsconfig-paths@4.2.0", "", { "dependencies": { "json5": "^2.2.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg=="],
@@ -1677,6 +1772,8 @@
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
     "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
+
+    "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 
     "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
 
@@ -1883,6 +1980,8 @@
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
+
+    "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 

--- a/crates/oore-contract/src/lib.rs
+++ b/crates/oore-contract/src/lib.rs
@@ -989,6 +989,8 @@ pub struct Build {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub branch: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub changelog: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub source_build_id: Option<String>,
     #[schema(value_type = Object)]
     pub config_snapshot: serde_json::Value,
@@ -1047,11 +1049,21 @@ pub struct CreateBuildRequest {
     pub commit_sha: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trigger_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub changelog: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct CreateBuildResponse {
     pub build: Build,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct BuildChangelogPreviewResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_commit: Option<String>,
+    pub target_commit: String,
+    pub markdown: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]

--- a/crates/oored/migrations/033_build_changelog.sql
+++ b/crates/oored/migrations/033_build_changelog.sql
@@ -1,0 +1,1 @@
+ALTER TABLE builds ADD COLUMN changelog TEXT;

--- a/crates/oored/src/artifacts.rs
+++ b/crates/oored/src/artifacts.rs
@@ -461,6 +461,40 @@ pub async fn list_artifacts(
     Ok(Json(ListArtifactsResponse { artifacts }))
 }
 
+/// `GET /v1/projects/{project_id}/artifacts` — list available artifacts for a project.
+pub async fn list_project_artifacts(
+    State(state): State<Arc<AppState>>,
+    auth: AuthUser,
+    Path(project_id): Path<String>,
+) -> ApiResult<ListArtifactsResponse> {
+    let pool = {
+        let store = state.store.lock().await;
+        store.pool().clone()
+    };
+    require_project_artifact_read(&pool, &auth, &project_id).await?;
+
+    let rows = sqlx::query(
+        "SELECT a.* FROM artifacts a \
+         JOIN builds b ON b.id = a.build_id \
+         WHERE b.project_id = ?1 AND a.state = 'available' \
+         ORDER BY a.created_at DESC",
+    )
+    .bind(&project_id)
+    .fetch_all(&pool)
+    .await
+    .map_err(|e| {
+        error!(error = %e, "failed to list project artifacts");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to list project artifacts",
+        )
+    })?;
+
+    let artifacts = rows.iter().map(row_to_artifact).collect();
+    Ok(Json(ListArtifactsResponse { artifacts }))
+}
+
 /// `POST /v1/artifacts/{artifact_id}/download-link` — generate a download link.
 pub async fn generate_download_link(
     State(state): State<Arc<AppState>>,

--- a/crates/oored/src/bin/openapi_export.rs
+++ b/crates/oored/src/bin/openapi_export.rs
@@ -124,6 +124,7 @@ use utoipa::OpenApi;
         paths::register_pipeline_ios_device,
         // ── Builds ──
         paths::create_build,
+        paths::preview_build_changelog,
         paths::list_builds,
         paths::get_build,
         paths::cancel_build,
@@ -155,6 +156,7 @@ use utoipa::OpenApi;
         paths::complete_artifact,
         paths::abort_artifact,
         paths::list_artifacts,
+        paths::list_project_artifacts,
         paths::generate_download_link,
         paths::create_artifact_install_link,
         paths::get_ios_install_manifest,
@@ -308,6 +310,7 @@ use utoipa::OpenApi;
         oore_contract::BuildEvent,
         oore_contract::CreateBuildRequest,
         oore_contract::CreateBuildResponse,
+        oore_contract::BuildChangelogPreviewResponse,
         oore_contract::BuildDetailResponse,
         oore_contract::ListBuildsResponse,
         oore_contract::CancelBuildResponse,
@@ -1576,6 +1579,23 @@ mod paths {
     )]
     pub(super) async fn create_build() {}
 
+    /// Preview a Markdown changelog for a manual build.
+    #[utoipa::path(get, path = "/v1/projects/{project_id}/builds/changelog-preview", tag = "Builds",
+        params(
+            ("project_id" = String, Path, description = "Project ID"),
+            ("pipeline_id" = String, Query, description = "Pipeline ID"),
+            ("branch" = Option<String>, Query, description = "Target branch"),
+            ("commit_sha" = Option<String>, Query, description = "Target commit"),
+        ),
+        security(("bearer_auth" = [])),
+        responses(
+            (status = 200, description = "Generated changelog draft", body = BuildChangelogPreviewResponse),
+            (status = 400, description = "Invalid revision", body = ApiError),
+            (status = 404, description = "Project or pipeline not found", body = ApiError),
+        )
+    )]
+    pub(super) async fn preview_build_changelog() {}
+
     /// List builds
     ///
     /// Returns builds, optionally filtered by project, pipeline, or status.
@@ -1886,6 +1906,16 @@ mod paths {
         )
     )]
     pub(super) async fn list_artifacts() {}
+
+    /// List available artifacts across a project
+    #[utoipa::path(get, path = "/v1/projects/{project_id}/artifacts", tag = "Artifacts",
+        params(("project_id" = String, Path, description = "Project ID")),
+        security(("bearer_auth" = [])),
+        responses(
+            (status = 200, description = "Project artifact list", body = ListArtifactsResponse),
+        )
+    )]
+    pub(super) async fn list_project_artifacts() {}
 
     /// Generate download link
     ///

--- a/crates/oored/src/builds.rs
+++ b/crates/oored/src/builds.rs
@@ -4,9 +4,10 @@ use axum::Json;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use oore_contract::{
-    ApiError, Build, BuildContext, BuildDetailResponse, BuildEvent, BuildPlatform, BuildStatus,
-    CancelBuildResponse, ConcurrencyPolicy, CreateBuildRequest, CreateBuildResponse,
-    ListBuildsResponse, PipelineExecutionConfig, RerunBuildResponse, TriggerConfig,
+    ApiError, Build, BuildChangelogPreviewResponse, BuildContext, BuildDetailResponse, BuildEvent,
+    BuildPlatform, BuildStatus, CancelBuildResponse, ConcurrencyPolicy, CreateBuildRequest,
+    CreateBuildResponse, ListBuildsResponse, PipelineExecutionConfig, RerunBuildResponse,
+    TriggerConfig,
 };
 use serde::Deserialize;
 use sqlx::Row;
@@ -54,6 +55,7 @@ fn row_to_build(row: &sqlx::sqlite::SqliteRow) -> Build {
         trigger_ref: row.get("trigger_ref"),
         commit_sha: row.get("commit_sha"),
         branch: row.get("branch"),
+        changelog: row.get("changelog"),
         source_build_id: row.get("source_build_id"),
         config_snapshot,
         runner_id: row.get("runner_id"),
@@ -375,6 +377,7 @@ struct BuildInsertBinds<'a> {
     trigger_ref: Option<&'a str>,
     commit_sha: Option<&'a str>,
     branch: Option<&'a str>,
+    changelog: Option<&'a str>,
     config_snapshot: &'a str,
     webhook_id: Option<&'a str>,
     now: i64,
@@ -390,10 +393,10 @@ async fn execute_build_insert(
     sqlx::query(
         "INSERT INTO builds (id, project_id, pipeline_id, build_number, status, \
          trigger_type, trigger_actor, trigger_event, trigger_ref, commit_sha, branch, \
-         config_snapshot, webhook_id, source_build_id, queued_at, created_at, updated_at) \
+         changelog, config_snapshot, webhook_id, source_build_id, queued_at, created_at, updated_at) \
          VALUES (?1, ?2, ?3, \
                  (SELECT COALESCE(MAX(build_number), 0) + 1 FROM builds WHERE project_id = ?2), \
-                 'queued', ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?13, ?13)",
+                 'queued', ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?14, ?14)",
     )
     .bind(b.build_id)
     .bind(b.project_id)
@@ -404,6 +407,7 @@ async fn execute_build_insert(
     .bind(b.trigger_ref)
     .bind(b.commit_sha)
     .bind(b.branch)
+    .bind(b.changelog)
     .bind(b.config_snapshot)
     .bind(b.webhook_id)
     .bind(b.source_build_id)
@@ -423,6 +427,56 @@ pub struct ListBuildsQuery {
     pub branch: Option<String>,
     pub limit: Option<i64>,
     pub offset: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BuildChangelogPreviewQuery {
+    pub pipeline_id: String,
+    pub branch: Option<String>,
+    pub commit_sha: Option<String>,
+}
+
+fn escape_markdown_inline(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('*', "\\*")
+        .replace('_', "\\_")
+        .replace('[', "\\[")
+        .replace(']', "\\]")
+        .replace('<', "\\<")
+        .replace('>', "\\>")
+}
+
+fn changelog_markdown(commits: Vec<crate::integrations::CommitSummary>) -> String {
+    let mut markdown = String::new();
+    let total = commits.len();
+    for (index, commit) in commits.into_iter().enumerate() {
+        let title = commit
+            .title
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        let author = commit
+            .author
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        if title.is_empty() {
+            continue;
+        }
+        let line = format!(
+            "- {} — {}\n",
+            escape_markdown_inline(&title),
+            escape_markdown_inline(&author)
+        );
+        if markdown.len() + line.len() > 3_900 {
+            let remaining = total.saturating_sub(index);
+            markdown.push_str(&format!("- …and {remaining} more changes\n"));
+            break;
+        }
+        markdown.push_str(&line);
+    }
+    markdown.trim_end().to_string()
 }
 
 // ── Concurrency policy ──────────────────────────────────────────
@@ -485,6 +539,123 @@ async fn apply_cancel_previous(
 
 // ── Handlers ────────────────────────────────────────────────────
 
+/// `GET /v1/projects/{project_id}/builds/changelog-preview` — draft release notes.
+pub async fn preview_build_changelog(
+    State(state): State<Arc<AppState>>,
+    auth: AuthUser,
+    Path(project_id): Path<String>,
+    Query(params): Query<BuildChangelogPreviewQuery>,
+) -> ApiResult<BuildChangelogPreviewResponse> {
+    let pool = {
+        let store = state.store.lock().await;
+        store.pool().clone()
+    };
+    let effective = resolve_effective_project_role(
+        &pool,
+        &auth.0.user_id,
+        &auth.0.role,
+        &project_id,
+        &auth.0.auth_source,
+    )
+    .await?;
+    require_project_permission(&effective, ProjectPermission::TriggerBuild)?;
+
+    let project = sqlx::query("SELECT repository_id, default_branch FROM projects WHERE id = ?1")
+        .bind(&project_id)
+        .fetch_optional(&pool)
+        .await
+        .map_err(|e| {
+            error!(error = %e, "failed to fetch project for changelog preview");
+            api_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "store_error",
+                "Failed to fetch project",
+            )
+        })?
+        .ok_or_else(|| api_err(StatusCode::NOT_FOUND, "not_found", "Project not found"))?;
+    let repository_id: Option<String> = project.get("repository_id");
+    let repository_id = repository_id.ok_or_else(|| {
+        api_err(
+            StatusCode::CONFLICT,
+            "source_not_configured",
+            "Project is not linked to a source repository",
+        )
+    })?;
+    let pipeline_exists: bool =
+        sqlx::query_scalar("SELECT COUNT(*) > 0 FROM pipelines WHERE id = ?1 AND project_id = ?2")
+            .bind(&params.pipeline_id)
+            .bind(&project_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap_or(false);
+    if !pipeline_exists {
+        return Err(api_err(
+            StatusCode::NOT_FOUND,
+            "not_found",
+            "Pipeline not found in this project",
+        ));
+    }
+
+    let commit_sha = normalize_optional(params.commit_sha);
+    let branch = normalize_optional(params.branch)
+        .or_else(|| normalize_optional(project.get::<Option<String>, _>("default_branch")));
+    let target_commit = match commit_sha {
+        Some(commit_sha) => commit_sha,
+        None => {
+            crate::integrations::resolve_branch_commit(
+                &pool,
+                &state.encryption_key,
+                &repository_id,
+                branch.as_deref().ok_or_else(|| {
+                    api_err(
+                        StatusCode::BAD_REQUEST,
+                        "invalid_input",
+                        "Provide branch or commit_sha",
+                    )
+                })?,
+            )
+            .await?
+        }
+    };
+    let base_commit: Option<String> = sqlx::query_scalar(
+        "SELECT commit_sha FROM builds \
+         WHERE project_id = ?1 AND pipeline_id = ?2 AND status = 'succeeded' \
+           AND commit_sha IS NOT NULL \
+         ORDER BY build_number DESC LIMIT 1",
+    )
+    .bind(&project_id)
+    .bind(&params.pipeline_id)
+    .fetch_optional(&pool)
+    .await
+    .map_err(|e| {
+        error!(error = %e, "failed to fetch previous build revision");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to fetch previous build revision",
+        )
+    })?;
+    let markdown = match base_commit.as_deref() {
+        Some(base) if base != target_commit => changelog_markdown(
+            crate::integrations::compare_commits(
+                &pool,
+                &state.encryption_key,
+                &repository_id,
+                base,
+                &target_commit,
+            )
+            .await?,
+        ),
+        _ => String::new(),
+    };
+
+    Ok(Json(BuildChangelogPreviewResponse {
+        base_commit,
+        target_commit,
+        markdown,
+    }))
+}
+
 /// `POST /v1/projects/{project_id}/builds` — create a new build (manual/API trigger).
 pub async fn create_build(
     State(state): State<Arc<AppState>>,
@@ -510,6 +681,14 @@ pub async fn create_build(
     let requested_branch = normalize_optional(req.branch);
     let mut commit_sha = normalize_optional(req.commit_sha);
     let trigger_ref = normalize_optional(req.trigger_ref);
+    let changelog = normalize_optional(req.changelog);
+    if changelog.as_ref().is_some_and(|value| value.len() > 4_000) {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "invalid_input",
+            "Changelog must be 4,000 characters or fewer",
+        ));
+    }
 
     // Verify project exists and has source linkage.
     let project_row =
@@ -677,6 +856,7 @@ pub async fn create_build(
             trigger_ref: trigger_ref.as_deref(),
             commit_sha: commit_sha.as_deref(),
             branch: branch.as_deref(),
+            changelog: changelog.as_deref(),
             config_snapshot: &snapshot_str,
             webhook_id: None,
             now,
@@ -741,6 +921,7 @@ pub async fn create_build(
         trigger_ref,
         commit_sha,
         branch,
+        changelog,
         source_build_id: None,
         config_snapshot,
         runner_id: None,
@@ -991,7 +1172,7 @@ pub async fn rerun_build(
     // Fetch source build
     let source_row = sqlx::query(
         "SELECT id, project_id, pipeline_id, build_number, status, \
-         trigger_ref, commit_sha, branch, config_snapshot \
+         trigger_ref, commit_sha, branch, changelog, config_snapshot \
          FROM builds WHERE id = ?1",
     )
     .bind(&build_id)
@@ -1056,6 +1237,7 @@ pub async fn rerun_build(
     let branch: Option<String> = source_row.get("branch");
     let commit_sha: Option<String> = source_row.get("commit_sha");
     let trigger_ref: Option<String> = source_row.get("trigger_ref");
+    let changelog: Option<String> = source_row.get("changelog");
 
     let now = now_unix();
     let new_build_id = Uuid::new_v4().to_string();
@@ -1072,6 +1254,7 @@ pub async fn rerun_build(
             trigger_ref: trigger_ref.as_deref(),
             commit_sha: commit_sha.as_deref(),
             branch: branch.as_deref(),
+            changelog: changelog.as_deref(),
             config_snapshot: &config_snapshot_str,
             webhook_id: None,
             now,
@@ -1144,6 +1327,7 @@ pub async fn rerun_build(
         trigger_ref,
         commit_sha,
         branch,
+        changelog,
         source_build_id: Some(build_id),
         config_snapshot,
         runner_id: None,
@@ -1332,6 +1516,7 @@ pub async fn trigger_build_from_webhook(
                     trigger_ref: branch,
                     commit_sha,
                     branch,
+                    changelog: None,
                     config_snapshot: &snapshot_str,
                     webhook_id: Some(webhook_id),
                     now,
@@ -1380,6 +1565,7 @@ pub async fn trigger_build_from_webhook(
                 trigger_ref: branch.map(String::from),
                 commit_sha: commit_sha.map(String::from),
                 branch: branch.map(String::from),
+                changelog: None,
                 source_build_id: None,
                 config_snapshot,
                 runner_id: None,

--- a/crates/oored/src/integrations/github.rs
+++ b/crates/oored/src/integrations/github.rs
@@ -1124,6 +1124,115 @@ pub(crate) async fn resolve_branch_commit(
         })
 }
 
+pub(crate) async fn compare_commits(
+    pool: &sqlx::SqlitePool,
+    encryption_key: &[u8],
+    integration_id: &str,
+    installation_id: &str,
+    full_name: &str,
+    base: &str,
+    head: &str,
+) -> Result<Vec<super::CommitSummary>, (StatusCode, Json<ApiError>)> {
+    #[derive(Deserialize)]
+    struct CompareResponse {
+        commits: Vec<CompareCommit>,
+    }
+    #[derive(Deserialize)]
+    struct CompareCommit {
+        author: Option<GitHubUser>,
+        commit: GitCommit,
+    }
+    #[derive(Deserialize)]
+    struct GitHubUser {
+        login: String,
+    }
+    #[derive(Deserialize)]
+    struct GitCommit {
+        author: GitAuthor,
+        message: String,
+    }
+    #[derive(Deserialize)]
+    struct GitAuthor {
+        name: String,
+    }
+
+    let client = build_http_client().map_err(|e| {
+        error!(error = %e, "failed to build GitHub client");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "http_client_error",
+            "Failed to create GitHub client",
+        )
+    })?;
+    let token = load_installation_access_token(
+        &client,
+        pool,
+        encryption_key,
+        integration_id,
+        installation_id,
+    )
+    .await?;
+    let response = client
+        .get(format!(
+            "https://api.github.com/repos/{full_name}/compare/{}...{}",
+            urlencoding::encode(base),
+            urlencoding::encode(head)
+        ))
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Accept", "application/vnd.github+json")
+        .header("User-Agent", "oore-ci")
+        .send()
+        .await
+        .map_err(|e| {
+            error!(error = %e, "failed to compare GitHub commits");
+            api_err(
+                StatusCode::BAD_GATEWAY,
+                "github_api_error",
+                "Failed to compare repository revisions",
+            )
+        })?;
+    if !response.status().is_success() {
+        return Err(api_err(
+            StatusCode::BAD_GATEWAY,
+            "github_api_error",
+            format!(
+                "GitHub returned {} while comparing revisions",
+                response.status()
+            ),
+        ));
+    }
+    response
+        .json::<CompareResponse>()
+        .await
+        .map(|response| {
+            response
+                .commits
+                .into_iter()
+                .map(|commit| super::CommitSummary {
+                    title: commit
+                        .commit
+                        .message
+                        .lines()
+                        .next()
+                        .unwrap_or_default()
+                        .to_string(),
+                    author: commit
+                        .author
+                        .map(|author| author.login)
+                        .unwrap_or(commit.commit.author.name),
+                })
+                .collect()
+        })
+        .map_err(|e| {
+            error!(error = %e, "failed to parse GitHub comparison");
+            api_err(
+                StatusCode::BAD_GATEWAY,
+                "github_parse_error",
+                "Failed to read repository comparison",
+            )
+        })
+}
+
 /// Core sync logic — fetches installations and repos from GitHub, upserts them,
 /// and removes stale records that are no longer present on GitHub.
 ///

--- a/crates/oored/src/integrations/gitlab.rs
+++ b/crates/oored/src/integrations/gitlab.rs
@@ -31,6 +31,40 @@ type ApiResult<T> = Result<Json<T>, (StatusCode, Json<ApiError>)>;
 const STATE_MAX_AGE_SECS: i64 = 600; // 10 minutes
 const MAX_AVATAR_BYTES: usize = 2 * 1024 * 1024;
 
+fn avatar_content_type(declared: Option<&str>, body: &[u8]) -> Option<&'static str> {
+    match declared.map(str::trim) {
+        Some("image/png") => Some("image/png"),
+        Some("image/jpeg" | "image/jpg") => Some("image/jpeg"),
+        Some("image/gif") => Some("image/gif"),
+        Some("image/webp") => Some("image/webp"),
+        Some("image/avif") => Some("image/avif"),
+        Some("image/svg+xml") => Some("image/svg+xml"),
+        Some("application/octet-stream" | "binary/octet-stream") | None => {
+            sniff_avatar_content_type(body)
+        }
+        _ => None,
+    }
+}
+
+fn sniff_avatar_content_type(body: &[u8]) -> Option<&'static str> {
+    if body.starts_with(b"\x89PNG\r\n\x1a\n") {
+        Some("image/png")
+    } else if body.starts_with(b"\xff\xd8\xff") {
+        Some("image/jpeg")
+    } else if body.starts_with(b"GIF87a") || body.starts_with(b"GIF89a") {
+        Some("image/gif")
+    } else if body.len() >= 12 && body.starts_with(b"RIFF") && &body[8..12] == b"WEBP" {
+        Some("image/webp")
+    } else if body.len() >= 12
+        && &body[4..8] == b"ftyp"
+        && matches!(&body[8..12], b"avif" | b"avis")
+    {
+        Some("image/avif")
+    } else {
+        None
+    }
+}
+
 fn build_http_client() -> Result<reqwest::Client, reqwest::Error> {
     reqwest::Client::builder()
         .timeout(Duration::from_secs(15))
@@ -169,31 +203,13 @@ pub(crate) async fn fetch_repository_avatar(
         ));
     }
 
-    let content_type = response
+    let declared_content_type = response
         .headers()
         .get(reqwest::header::CONTENT_TYPE)
         .and_then(|value| value.to_str().ok())
         .and_then(|value| value.split(';').next())
         .map(str::trim)
-        .filter(|value| {
-            matches!(
-                *value,
-                "image/png"
-                    | "image/jpeg"
-                    | "image/gif"
-                    | "image/webp"
-                    | "image/avif"
-                    | "image/svg+xml"
-            )
-        })
-        .ok_or_else(|| {
-            api_err(
-                StatusCode::BAD_GATEWAY,
-                "gitlab_avatar_invalid",
-                "GitLab returned an unsupported repository avatar",
-            )
-        })?
-        .to_string();
+        .map(str::to_string);
 
     let mut body = Vec::new();
     while let Some(chunk) = response.chunk().await.map_err(|e| {
@@ -213,6 +229,16 @@ pub(crate) async fn fetch_repository_avatar(
         }
         body.extend_from_slice(&chunk);
     }
+
+    let content_type = avatar_content_type(declared_content_type.as_deref(), &body)
+        .ok_or_else(|| {
+            api_err(
+                StatusCode::BAD_GATEWAY,
+                "gitlab_avatar_invalid",
+                "GitLab returned an unsupported repository avatar",
+            )
+        })?
+        .to_string();
 
     Ok((content_type, body))
 }
@@ -288,6 +314,88 @@ pub(crate) async fn resolve_branch_commit(
                 StatusCode::BAD_GATEWAY,
                 "gitlab_parse_error",
                 "Failed to parse GitLab commit response",
+            )
+        })
+}
+
+pub(crate) async fn compare_commits(
+    pool: &sqlx::SqlitePool,
+    encryption_key: &[u8],
+    integration_id: &str,
+    target: (&str, &str, &str),
+    base: &str,
+    head: &str,
+) -> Result<Vec<super::CommitSummary>, (StatusCode, Json<ApiError>)> {
+    #[derive(Deserialize)]
+    struct CompareResponse {
+        commits: Vec<CompareCommit>,
+    }
+    #[derive(Deserialize)]
+    struct CompareCommit {
+        author_name: String,
+        title: String,
+    }
+
+    let (host_url, auth_mode, repository_external_id) = target;
+    let token = access_token(pool, encryption_key, integration_id).await?;
+    let client = build_http_client().map_err(|e| {
+        error!(error = %e, "failed to build GitLab client");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "http_client_error",
+            "Failed to create GitLab client",
+        )
+    })?;
+    let mut request = client
+        .get(format!(
+            "{}/api/v4/projects/{}/repository/compare",
+            host_url.trim_end_matches('/'),
+            urlencoding::encode(repository_external_id)
+        ))
+        .query(&[("from", base), ("to", head), ("straight", "true")])
+        .header("User-Agent", "oore-ci");
+    request = if auth_mode == "oauth_app" {
+        request.header("Authorization", format!("Bearer {token}"))
+    } else {
+        request.header("PRIVATE-TOKEN", token)
+    };
+    let response = request.send().await.map_err(|e| {
+        error!(error = %e, "failed to compare GitLab commits");
+        api_err(
+            StatusCode::BAD_GATEWAY,
+            "gitlab_api_error",
+            "Failed to compare repository revisions",
+        )
+    })?;
+    if !response.status().is_success() {
+        return Err(api_err(
+            StatusCode::BAD_GATEWAY,
+            "gitlab_api_error",
+            format!(
+                "GitLab returned {} while comparing revisions",
+                response.status()
+            ),
+        ));
+    }
+    response
+        .json::<CompareResponse>()
+        .await
+        .map(|response| {
+            response
+                .commits
+                .into_iter()
+                .map(|commit| super::CommitSummary {
+                    title: commit.title,
+                    author: commit.author_name,
+                })
+                .collect()
+        })
+        .map_err(|e| {
+            error!(error = %e, "failed to parse GitLab comparison");
+            api_err(
+                StatusCode::BAD_GATEWAY,
+                "gitlab_parse_error",
+                "Failed to read repository comparison",
             )
         })
 }
@@ -1777,17 +1885,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn repository_avatar_uses_gitlab_credentials() {
+    async fn repository_avatar_uses_gitlab_credentials_and_sniffs_generic_content_type() {
+        let avatar = b"\x89PNG\r\n\x1a\navatar".to_vec();
         let app = axum::Router::new().route(
             "/api/v4/projects/42/avatar",
-            get(|headers: HeaderMap| async move {
-                assert_eq!(
-                    headers
-                        .get("PRIVATE-TOKEN")
-                        .and_then(|value| value.to_str().ok()),
-                    Some("gitlab-token")
-                );
-                ([("content-type", "image/png")], vec![1_u8, 2, 3])
+            get(move |headers: HeaderMap| {
+                let avatar = avatar.clone();
+                async move {
+                    assert_eq!(
+                        headers
+                            .get("PRIVATE-TOKEN")
+                            .and_then(|value| value.to_str().ok()),
+                        Some("gitlab-token")
+                    );
+                    ([("content-type", "application/octet-stream")], avatar)
+                }
             }),
         );
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -1827,7 +1939,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(content_type, "image/png");
-        assert_eq!(body, vec![1, 2, 3]);
+        assert_eq!(body, b"\x89PNG\r\n\x1a\navatar");
         server.abort();
     }
 

--- a/crates/oored/src/integrations/local_git.rs
+++ b/crates/oored/src/integrations/local_git.rs
@@ -156,6 +156,61 @@ pub(crate) async fn resolve_branch_commit(
     })?
 }
 
+pub(crate) async fn compare_commits(
+    repo_path: &str,
+    base: &str,
+    head: &str,
+) -> Result<Vec<super::CommitSummary>, (StatusCode, Json<ApiError>)> {
+    let repo_path = repo_path.to_string();
+    let range = format!("{base}..{head}");
+    tokio::task::spawn_blocking(move || {
+        let output = Command::new("git")
+            .args([
+                "-C",
+                repo_path.as_str(),
+                "log",
+                "--reverse",
+                "--format=%s%x1f%an%x1e",
+                &range,
+            ])
+            .output()
+            .map_err(|e| {
+                error!(error = %e, "failed to compare local git commits");
+                api_err(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "git_error",
+                    "Failed to compare repository revisions",
+                )
+            })?;
+        if !output.status.success() {
+            return Err(api_err(
+                StatusCode::BAD_REQUEST,
+                "invalid_ref",
+                "The previous or target commit is unavailable",
+            ));
+        }
+        Ok(String::from_utf8_lossy(&output.stdout)
+            .split('\x1e')
+            .filter_map(|record| {
+                let (title, author) = record.trim().split_once('\x1f')?;
+                Some(super::CommitSummary {
+                    title: title.to_string(),
+                    author: author.to_string(),
+                })
+            })
+            .collect())
+    })
+    .await
+    .map_err(|e| {
+        error!(error = %e, "local git comparison task failed");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "git_error",
+            "Failed to compare repository revisions",
+        )
+    })?
+}
+
 struct LocalGitRepoInspection {
     canonical_str: String,
     default_branch: Option<String>,

--- a/crates/oored/src/integrations/mod.rs
+++ b/crates/oored/src/integrations/mod.rs
@@ -80,6 +80,11 @@ use crate::util::api_err;
 
 type ApiResult<T> = Result<Json<T>, (StatusCode, Json<ApiError>)>;
 
+pub(crate) struct CommitSummary {
+    pub title: String,
+    pub author: String,
+}
+
 pub(crate) async fn require_remote_mode(
     pool: &sqlx::SqlitePool,
 ) -> Result<(), (StatusCode, Json<ApiError>)> {
@@ -188,6 +193,94 @@ pub(crate) async fn resolve_branch_commit(
             StatusCode::CONFLICT,
             "unsupported_provider",
             "The linked source provider cannot resolve branch revisions",
+        )),
+    }
+}
+
+pub(crate) async fn compare_commits(
+    pool: &sqlx::SqlitePool,
+    encryption_key: &[u8],
+    repository_id: &str,
+    base: &str,
+    head: &str,
+) -> Result<Vec<CommitSummary>, (StatusCode, Json<ApiError>)> {
+    let row = sqlx::query(
+        "SELECT i.id AS integration_id, i.provider, i.host_url, i.auth_mode, \
+                inst.external_id AS installation_external_id, r.external_id AS repository_external_id, \
+                r.full_name, r.html_url \
+         FROM integration_repositories r \
+         JOIN integration_installations inst ON inst.id = r.installation_id \
+         JOIN integrations i ON i.id = inst.integration_id \
+         WHERE r.id = ?1 AND i.status = 'active'",
+    )
+    .bind(repository_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| {
+        error!(error = %e, repository_id = %repository_id, "failed to load source comparison target");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to load the linked repository",
+        )
+    })?
+    .ok_or_else(|| {
+        api_err(
+            StatusCode::CONFLICT,
+            "source_unresolvable",
+            "The linked source is unavailable; reconnect it before triggering a build",
+        )
+    })?;
+
+    let provider: String = row.get("provider");
+    let integration_id: String = row.get("integration_id");
+    match provider.as_str() {
+        "local_git" => {
+            let path: Option<String> = row.get("html_url");
+            local_git::compare_commits(
+                path.as_deref().ok_or_else(|| {
+                    api_err(
+                        StatusCode::CONFLICT,
+                        "source_unresolvable",
+                        "The linked local repository path is missing",
+                    )
+                })?,
+                base,
+                head,
+            )
+            .await
+        }
+        "github" => {
+            github::compare_commits(
+                pool,
+                encryption_key,
+                &integration_id,
+                &row.get::<String, _>("installation_external_id"),
+                &row.get::<String, _>("full_name"),
+                base,
+                head,
+            )
+            .await
+        }
+        "gitlab" => {
+            gitlab::compare_commits(
+                pool,
+                encryption_key,
+                &integration_id,
+                (
+                    &row.get::<String, _>("host_url"),
+                    &row.get::<String, _>("auth_mode"),
+                    &row.get::<String, _>("repository_external_id"),
+                ),
+                base,
+                head,
+            )
+            .await
+        }
+        _ => Err(api_err(
+            StatusCode::CONFLICT,
+            "unsupported_provider",
+            "The linked source provider cannot compare revisions",
         )),
     }
 }

--- a/crates/oored/src/lib.rs
+++ b/crates/oored/src/lib.rs
@@ -2397,6 +2397,10 @@ async fn build_router_inner(
             "/v1/projects/{project_id}/builds",
             post(builds::create_build),
         )
+        .route(
+            "/v1/projects/{project_id}/builds/changelog-preview",
+            get(builds::preview_build_changelog),
+        )
         .route("/v1/builds", get(builds::list_builds))
         .route("/v1/builds/{build_id}", get(builds::get_build))
         .route("/v1/builds/{build_id}/cancel", post(builds::cancel_build))
@@ -2475,6 +2479,10 @@ async fn build_router_inner(
         .route(
             "/v1/builds/{build_id}/artifacts",
             get(artifacts::list_artifacts),
+        )
+        .route(
+            "/v1/projects/{project_id}/artifacts",
+            get(artifacts::list_project_artifacts),
         )
         .route(
             "/v1/artifacts/{artifact_id}/download-link",

--- a/crates/oored/tests/build_reproducibility_integration.rs
+++ b/crates/oored/tests/build_reproducibility_integration.rs
@@ -142,6 +142,22 @@ async fn post_json(
     (status, body_json(response.into_body()).await)
 }
 
+async fn get_json(app: &axum::Router, token: &str, uri: &str) -> (StatusCode, serde_json::Value) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(uri)
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    (status, body_json(response.into_body()).await)
+}
+
 #[tokio::test]
 async fn branch_builds_are_pinned_and_reruns_keep_the_original_commit() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -202,6 +218,52 @@ async fn branch_builds_are_pinned_and_reruns_keep_the_original_commit() {
 }
 
 #[tokio::test]
+async fn changelog_preview_compares_with_the_previous_successful_build() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let repo = tmp.path().join("repo");
+    fs::create_dir(&repo).unwrap();
+    git(&repo, &["init", "--quiet"]);
+    git(&repo, &["config", "user.name", "Oore Tests"]);
+    git(&repo, &["config", "user.email", "tests@oore.build"]);
+    git(&repo, &["checkout", "-q", "-b", "main"]);
+    let first_sha = commit(&repo, "first\n", "Initial app");
+
+    let db_path = tmp.path().join("oore.db");
+    let app = create_test_app(&db_path).await;
+    let pool = connect_pool(&db_path).await;
+    let user_id = seed_test_user(&pool).await;
+    let token = session_token(&pool, &user_id).await;
+    let (project_id, pipeline_id) = seed_local_project(&pool, &user_id, &repo).await;
+    let (status, first) = post_json(
+        &app,
+        &token,
+        &format!("/v1/projects/{project_id}/builds"),
+        serde_json::json!({ "pipeline_id": pipeline_id }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    sqlx::query("UPDATE builds SET status = 'succeeded' WHERE id = ?1")
+        .bind(first["build"]["id"].as_str().unwrap())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let second_sha = commit(&repo, "second\n", "Improve checkout");
+    let (status, preview) = get_json(
+        &app,
+        &token,
+        &format!(
+            "/v1/projects/{project_id}/builds/changelog-preview?pipeline_id={pipeline_id}&branch=main"
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(preview["base_commit"], first_sha);
+    assert_eq!(preview["target_commit"], second_sha);
+    assert_eq!(preview["markdown"], "- Improve checkout — Oore Tests");
+}
+
+#[tokio::test]
 async fn manual_platform_selection_is_validated_snapshotted_and_kept_on_rerun() {
     let tmp = tempfile::TempDir::new().unwrap();
     let repo = tmp.path().join("repo");
@@ -242,11 +304,28 @@ async fn manual_platform_selection_is_validated_snapshotted_and_kept_on_rerun() 
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert_eq!(invalid["code"], "invalid_input");
 
+    let (status, invalid) = post_json(
+        &app,
+        &token,
+        &format!("/v1/projects/{project_id}/builds"),
+        serde_json::json!({
+            "pipeline_id": pipeline_id,
+            "changelog": "x".repeat(4_001)
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(invalid["code"], "invalid_input");
+
     let (status, first) = post_json(
         &app,
         &token,
         &format!("/v1/projects/{project_id}/builds"),
-        serde_json::json!({ "pipeline_id": pipeline_id, "platforms": ["ios"] }),
+        serde_json::json!({
+            "pipeline_id": pipeline_id,
+            "platforms": ["ios"],
+            "changelog": "Test the new checkout flow"
+        }),
     )
     .await;
     assert_eq!(status, StatusCode::OK);
@@ -254,6 +333,7 @@ async fn manual_platform_selection_is_validated_snapshotted_and_kept_on_rerun() 
         first["build"]["config_snapshot"]["selected_platforms"],
         serde_json::json!(["ios"])
     );
+    assert_eq!(first["build"]["changelog"], "Test the new checkout flow");
 
     let first_build_id = first["build"]["id"].as_str().unwrap();
     sqlx::query("UPDATE builds SET status = 'succeeded' WHERE id = ?1")
@@ -273,4 +353,5 @@ async fn manual_platform_selection_is_validated_snapshotted_and_kept_on_rerun() 
         rerun["build"]["config_snapshot"]["selected_platforms"],
         serde_json::json!(["ios"])
     );
+    assert_eq!(rerun["build"]["changelog"], "Test the new checkout flow");
 }

--- a/crates/oored/tests/logs_artifacts_integration.rs
+++ b/crates/oored/tests/logs_artifacts_integration.rs
@@ -911,7 +911,7 @@ async fn test_create_artifact_checksum_dedup() {
 
 #[tokio::test]
 async fn test_list_artifacts() {
-    let (app, _pool, session_token, runner_id, runner_token, build_id) = full_scaffold().await;
+    let (app, pool, session_token, runner_id, runner_token, build_id) = full_scaffold().await;
 
     // Create two artifacts
     for (name, art_type) in [("app.apk", "apk"), ("app.ipa", "ipa")] {
@@ -964,6 +964,25 @@ async fn test_list_artifacts() {
     assert_eq!(artifacts.len(), 2);
     assert_eq!(artifacts[0]["name"].as_str().unwrap(), "app.apk");
     assert_eq!(artifacts[1]["name"].as_str().unwrap(), "app.ipa");
+
+    let project_id: String = sqlx::query_scalar("SELECT project_id FROM builds WHERE id = ?1")
+        .bind(&build_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let req = Request::builder()
+        .uri(format!("/v1/projects/{project_id}/artifacts"))
+        .method("GET")
+        .header(
+            http::header::AUTHORIZATION,
+            format!("Bearer {session_token}"),
+        )
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_json(resp.into_body()).await;
+    assert_eq!(json["artifacts"].as_array().unwrap().len(), 2);
 }
 
 #[tokio::test]

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -19,12 +19,18 @@ Rules:
   - QA users now land on a build-first surface with build-only navigation and a truthful no-project-access state, keeping project, source, pipeline, and instance administration out of their default experience while preserving artifact install/download access for assigned projects.
   - Owners can start an audited 10-minute QA preview from Users without changing stored roles. The frontend isolates the preview in a clearly labeled instance session and restores the untouched owner session when preview ends or expires.
   - Build detail actions now follow the same permission boundary as the build list: QA Viewers can inspect logs and install or download artifacts, but do not see re-run or cancel controls that the backend would reject.
+  - QA Viewers now use a phone-first app-testing home without the CI sidebar, build table, filters, commits, triggers, or logs. App tabs group every installable platform produced by the same build into one compact `x.y.z+n` version row and paginate retained versions in place. Active builds use the same version language, while technical build links without an install target return to this home.
+  - Manual builds prefill an optional Markdown changelog from commit titles and authors since the previous successful build of the same pipeline. The draft remains editable or clearable, pins the run to the compared target commit, is preserved by re-runs, appears as a stripped-down summary beside the version, and renders safely in full on the install page.
+  - Each version is one tappable row with a quiet chevron instead of separate platform or Install buttons, even when its build produced both Android and iOS artifacts. Oore automatically chooses the current phone's matching artifact, preserves a shared link's intended artifact as the fallback, and otherwise prefers the directly usable APK on desktop.
+  - Phone install pages identify the app with its repository avatar and name, use typography and spacing instead of decorative section dividers, and keep a safe-area-aware bottom dock with a compact Back action and one primary Install or Download APK action. IPA downloads and duplicate artifact download actions are absent from the QA flow; larger layouts retain inline navigation and actions.
+  - The frontend loads retained QA version history through a project-scoped artifact listing guarded by `ReadArtifacts`; it derives a missing artifact version from the newest known app version and the build number instead of exposing filenames or CI-only labels.
   - Linear feature doc: https://linear.app/oorebuild/document/feature-ad-hoc-app-installation-18011ca32086
   - Linear RBAC ADR: https://linear.app/oorebuild/document/adr-0002-rbac-implementation-strategy-28554f736e4a
 
 - **Authenticated private GitLab repository avatars**:
   - Private GitLab repository avatars now load through a bearer-authenticated Oore endpoint instead of depending on each browser's GitLab cookies. GitHub avatars continue using their public URLs, while missing or unavailable images retain the existing initials fallback.
   - The backend applies the stored GitLab credential through GitLab's project/group avatar APIs, restricts requests to the configured GitLab origin, disables redirects, validates image types, and enforces a 2 MiB response limit.
+  - GitLab avatar responses with a generic binary or missing content type are accepted only when their bytes match a supported raster-image signature. Oore normalizes the resulting MIME type and continues rejecting arbitrary binary responses.
   - Linear feature doc: https://linear.app/oorebuild/document/authenticated-gitlab-repository-avatars-3eab35144db0
 
 - **Ad-hoc Android and iOS app installation**:


### PR DESCRIPTION
## What changed

- adds a phone-first QA app portal with project tabs, version history, app identity, and device-aware installation
- groups Android and iOS artifacts from the same build behind one tappable version row
- generates editable Markdown changelog drafts from commits since the previous successful pipeline build, including author attribution
- adds project-scoped artifact history and preserves changelogs on reruns
- fixes private GitLab avatar MIME detection for generic binary responses

## Why

QA users need a focused app-distribution experience rather than the developer CI interface, including direct ad-hoc iOS installation and APK delivery.

## Validation

- `make validate` passed through docs, lint, 161 web tests, docs/release-index tests, Rust workspace tests, Clippy, and production builds
- focused changelog/reproducibility integration tests passed
- React Doctor was not run because executing unpinned `@latest` third-party code outside the sandbox was blocked
- bundle budget is an explicitly accepted release exception: 241.40 KiB JS vs 240.00 KiB; broader bundle work is deferred
