### PR TITLE
perf(web): defer shell interaction bundles

### DIFF
--- a/apps/web/src/components/InstanceSwitcher.tsx
+++ b/apps/web/src/components/InstanceSwitcher.tsx
@@ -1,44 +1,29 @@
 import { Suspense, lazy, useState } from 'react'
 import { HugeiconsIcon } from '@hugeicons/react'
-import {
-  Add01Icon,
-  ArrowUpDownIcon,
-  Delete02Icon,
-  PencilEdit02Icon,
-  Tick02Icon,
-} from '@hugeicons/core-free-icons'
-import type { Instance } from '@/lib/types'
+import { ArrowUpDownIcon } from '@hugeicons/core-free-icons'
+
 import { getInstanceIcon } from '@/lib/instance-icons'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
 import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  useSidebar,
 } from '@/components/ui/sidebar'
 import { useActiveInstance, useInstanceStore } from '@/stores/instance-store'
 
-const AddInstanceDialog = lazy(() => import('@/components/AddInstanceDialog'))
-const EditInstanceDialog = lazy(() => import('@/components/EditInstanceDialog'))
+const loadInstanceSwitcherMenu = () =>
+  import('@/components/instance-switcher-menu')
+const InstanceSwitcherMenu = lazy(loadInstanceSwitcherMenu)
 
-export default function InstanceSwitcher() {
-  const { isMobile } = useSidebar()
+function InstanceButton({
+  onClick,
+  onFocus,
+  onMouseEnter,
+}: {
+  onClick: () => void
+  onFocus: () => void
+  onMouseEnter: () => void
+}) {
   const instance = useActiveInstance()
-  const instances = useInstanceStore((s) => s.instances)
-  const setActiveInstance = useInstanceStore((s) => s.setActiveInstance)
-  const removeInstance = useInstanceStore((s) => s.removeInstance)
-  const [showAddDialog, setShowAddDialog] = useState(false)
-  const [editingInstance, setEditingInstance] = useState<Instance | null>(null)
-
-  const instanceList = Object.values(instances)
-
-  if (!instance && instanceList.length === 0) return null
 
   const hostname = instance
     ? (() => {
@@ -51,127 +36,60 @@ export default function InstanceSwitcher() {
     : ''
 
   return (
-    <>
-      <SidebarMenu>
-        <SidebarMenuItem>
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              render={
-                <SidebarMenuButton
-                  size="lg"
-                  className="data-open:bg-sidebar-accent data-open:text-sidebar-accent-foreground"
-                />
-              }
-            >
-              <div className="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center">
-                <HugeiconsIcon
-                  icon={getInstanceIcon(instance?.icon)}
-                  size={16}
-                />
-              </div>
-              <div className="grid flex-1 text-left text-sm leading-tight">
-                <span className="truncate font-medium">
-                  {instance?.label ?? 'No instance'}
-                </span>
-                <span className="truncate text-xs text-muted-foreground">
-                  {hostname}
-                </span>
-              </div>
-              <HugeiconsIcon
-                icon={ArrowUpDownIcon}
-                className="ml-auto"
-                size={16}
-              />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              className="min-w-56"
-              align="start"
-              side={isMobile ? 'bottom' : 'right'}
-              sideOffset={4}
-            >
-              {instanceList.map((inst) => (
-                <DropdownMenuItem
-                  key={inst.id}
-                  onClick={() => setActiveInstance(inst.id)}
-                  className="group gap-2 p-2"
-                >
-                  <div className="flex size-6 items-center justify-center border">
-                    <HugeiconsIcon
-                      icon={getInstanceIcon(inst.icon)}
-                      size={14}
-                    />
-                  </div>
-                  <span className="truncate flex-1">{inst.label}</span>
-                  {!inst.qaPreviewSourceId ? (
-                    <button
-                      type="button"
-                      className="ml-auto text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        requestAnimationFrame(() => setEditingInstance(inst))
-                      }}
-                      title={`Edit ${inst.label}`}
-                      aria-label={`Edit ${inst.label}`}
-                    >
-                      <HugeiconsIcon icon={PencilEdit02Icon} size={14} />
-                    </button>
-                  ) : null}
-                  {inst.id === instance?.id ? (
-                    <HugeiconsIcon
-                      icon={Tick02Icon}
-                      size={14}
-                      className="text-primary"
-                    />
-                  ) : null}
-                </DropdownMenuItem>
-              ))}
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                className="gap-2 p-2"
-                onClick={() => {
-                  requestAnimationFrame(() => setShowAddDialog(true))
-                }}
-              >
-                <div className="flex size-6 items-center justify-center border bg-background">
-                  <HugeiconsIcon icon={Add01Icon} size={14} />
-                </div>
-                Add instance
-              </DropdownMenuItem>
-              {instance ? (
-                <DropdownMenuItem
-                  className="gap-2 p-2 text-destructive focus:text-destructive"
-                  onClick={() => removeInstance(instance.id)}
-                >
-                  <div className="flex size-6 items-center justify-center border">
-                    <HugeiconsIcon icon={Delete02Icon} size={14} />
-                  </div>
-                  Remove {instance.label}
-                </DropdownMenuItem>
-              ) : null}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </SidebarMenuItem>
-      </SidebarMenu>
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <SidebarMenuButton
+          size="lg"
+          className="data-open:bg-sidebar-accent data-open:text-sidebar-accent-foreground"
+          aria-haspopup="menu"
+          onClick={onClick}
+          onFocus={onFocus}
+          onMouseEnter={onMouseEnter}
+        >
+          <div className="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center">
+            <HugeiconsIcon icon={getInstanceIcon(instance?.icon)} size={16} />
+          </div>
+          <div className="grid flex-1 text-left text-sm leading-tight">
+            <span className="truncate font-medium">
+              {instance?.label ?? 'No instance'}
+            </span>
+            <span className="truncate text-xs text-muted-foreground">
+              {hostname}
+            </span>
+          </div>
+          <HugeiconsIcon icon={ArrowUpDownIcon} className="ml-auto" size={16} />
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  )
+}
 
-      {showAddDialog && (
-        <Suspense>
-          <AddInstanceDialog
-            open={showAddDialog}
-            onOpenChange={setShowAddDialog}
-          />
-        </Suspense>
-      )}
-      {editingInstance !== null && (
-        <Suspense>
-          <EditInstanceDialog
-            instance={editingInstance}
-            open
-            onOpenChange={(open) => {
-              if (!open) setEditingInstance(null)
-            }}
-          />
-        </Suspense>
-      )}
-    </>
+export default function InstanceSwitcher() {
+  const instance = useActiveInstance()
+  const instances = useInstanceStore((state) => state.instances)
+  const [menuRequested, setMenuRequested] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
+
+  if (!instance && Object.keys(instances).length === 0) return null
+
+  function openMenu() {
+    setMenuOpen(true)
+    setMenuRequested(true)
+  }
+
+  const button = (
+    <InstanceButton
+      onClick={openMenu}
+      onFocus={() => void loadInstanceSwitcherMenu()}
+      onMouseEnter={() => void loadInstanceSwitcherMenu()}
+    />
+  )
+
+  if (!menuRequested) return button
+
+  return (
+    <Suspense fallback={button}>
+      <InstanceSwitcherMenu open={menuOpen} onOpenChange={setMenuOpen} />
+    </Suspense>
   )
 }

--- a/apps/web/src/components/instance-switcher-menu.tsx
+++ b/apps/web/src/components/instance-switcher-menu.tsx
@@ -1,0 +1,183 @@
+import { Suspense, lazy, useState } from 'react'
+import { HugeiconsIcon } from '@hugeicons/react'
+import {
+  Add01Icon,
+  ArrowUpDownIcon,
+  Delete02Icon,
+  PencilEdit02Icon,
+  Tick02Icon,
+} from '@hugeicons/core-free-icons'
+
+import type { Instance } from '@/lib/types'
+import { getInstanceIcon } from '@/lib/instance-icons'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  useSidebar,
+} from '@/components/ui/sidebar'
+import { useActiveInstance, useInstanceStore } from '@/stores/instance-store'
+
+const AddInstanceDialog = lazy(() => import('@/components/AddInstanceDialog'))
+const EditInstanceDialog = lazy(() => import('@/components/EditInstanceDialog'))
+
+export default function InstanceSwitcherMenu({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const { isMobile } = useSidebar()
+  const instance = useActiveInstance()
+  const instances = useInstanceStore((state) => state.instances)
+  const setActiveInstance = useInstanceStore((state) => state.setActiveInstance)
+  const removeInstance = useInstanceStore((state) => state.removeInstance)
+  const [showAddDialog, setShowAddDialog] = useState(false)
+  const [editingInstance, setEditingInstance] = useState<Instance | null>(null)
+
+  const instanceList = Object.values(instances)
+  const hostname = instance
+    ? (() => {
+        try {
+          return new URL(instance.url).hostname
+        } catch {
+          return instance.url || 'local'
+        }
+      })()
+    : ''
+
+  return (
+    <>
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <DropdownMenu open={open} onOpenChange={onOpenChange}>
+            <DropdownMenuTrigger
+              render={
+                <SidebarMenuButton
+                  size="lg"
+                  className="data-open:bg-sidebar-accent data-open:text-sidebar-accent-foreground"
+                />
+              }
+            >
+              <div className="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center">
+                <HugeiconsIcon
+                  icon={getInstanceIcon(instance?.icon)}
+                  size={16}
+                />
+              </div>
+              <div className="grid flex-1 text-left text-sm leading-tight">
+                <span className="truncate font-medium">
+                  {instance?.label ?? 'No instance'}
+                </span>
+                <span className="truncate text-xs text-muted-foreground">
+                  {hostname}
+                </span>
+              </div>
+              <HugeiconsIcon
+                icon={ArrowUpDownIcon}
+                className="ml-auto"
+                size={16}
+              />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              className="min-w-56"
+              align="start"
+              side={isMobile ? 'bottom' : 'right'}
+              sideOffset={4}
+            >
+              {instanceList.map((candidate) => (
+                <DropdownMenuItem
+                  key={candidate.id}
+                  onClick={() => setActiveInstance(candidate.id)}
+                  className="group gap-2 p-2"
+                >
+                  <div className="flex size-6 items-center justify-center border">
+                    <HugeiconsIcon
+                      icon={getInstanceIcon(candidate.icon)}
+                      size={14}
+                    />
+                  </div>
+                  <span className="truncate flex-1">{candidate.label}</span>
+                  {!candidate.qaPreviewSourceId ? (
+                    <button
+                      type="button"
+                      className="ml-auto text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        requestAnimationFrame(() =>
+                          setEditingInstance(candidate),
+                        )
+                      }}
+                      title={`Edit ${candidate.label}`}
+                      aria-label={`Edit ${candidate.label}`}
+                    >
+                      <HugeiconsIcon icon={PencilEdit02Icon} size={14} />
+                    </button>
+                  ) : null}
+                  {candidate.id === instance?.id ? (
+                    <HugeiconsIcon
+                      icon={Tick02Icon}
+                      size={14}
+                      className="text-primary"
+                    />
+                  ) : null}
+                </DropdownMenuItem>
+              ))}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                className="gap-2 p-2"
+                onClick={() => {
+                  requestAnimationFrame(() => setShowAddDialog(true))
+                }}
+              >
+                <div className="flex size-6 items-center justify-center border bg-background">
+                  <HugeiconsIcon icon={Add01Icon} size={14} />
+                </div>
+                Add instance
+              </DropdownMenuItem>
+              {instance ? (
+                <DropdownMenuItem
+                  className="gap-2 p-2 text-destructive focus:text-destructive"
+                  onClick={() => removeInstance(instance.id)}
+                >
+                  <div className="flex size-6 items-center justify-center border">
+                    <HugeiconsIcon icon={Delete02Icon} size={14} />
+                  </div>
+                  Remove {instance.label}
+                </DropdownMenuItem>
+              ) : null}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </SidebarMenuItem>
+      </SidebarMenu>
+
+      {showAddDialog ? (
+        <Suspense>
+          <AddInstanceDialog
+            open={showAddDialog}
+            onOpenChange={setShowAddDialog}
+          />
+        </Suspense>
+      ) : null}
+      {editingInstance !== null ? (
+        <Suspense>
+          <EditInstanceDialog
+            instance={editingInstance}
+            open
+            onOpenChange={(dialogOpen) => {
+              if (!dialogOpen) setEditingInstance(null)
+            }}
+          />
+        </Suspense>
+      ) : null}
+    </>
+  )
+}

--- a/apps/web/src/components/instance-switcher.test.tsx
+++ b/apps/web/src/components/instance-switcher.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import InstanceSwitcher from '@/components/InstanceSwitcher'
+import { SidebarProvider } from '@/components/ui/sidebar'
+import { useInstanceStore } from '@/stores/instance-store'
+
+vi.stubGlobal(
+  'matchMedia',
+  vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }),
+)
+
+describe('InstanceSwitcher', () => {
+  beforeEach(() => {
+    useInstanceStore.setState({
+      activeInstanceId: 'local',
+      instances: {
+        local: {
+          id: 'local',
+          label: 'Local Oore',
+          url: 'http://127.0.0.1:8787',
+          addedAt: 1,
+        },
+      },
+    })
+  })
+
+  afterEach(() => {
+    useInstanceStore.setState({ activeInstanceId: null, instances: {} })
+  })
+
+  it('preloads without replacing focus and opens the full menu on click', async () => {
+    render(
+      <SidebarProvider>
+        <InstanceSwitcher />
+      </SidebarProvider>,
+    )
+
+    const trigger = screen.getByRole('button', { name: /Local Oore/i })
+    trigger.focus()
+
+    await waitFor(() => expect(document.activeElement).toBe(trigger))
+
+    fireEvent.click(trigger)
+
+    expect(await screen.findByRole('menu')).toBeTruthy()
+    expect(screen.getByText('Add instance')).toBeTruthy()
+  })
+})

--- a/apps/web/src/components/nav-user-menu.tsx
+++ b/apps/web/src/components/nav-user-menu.tsx
@@ -1,0 +1,167 @@
+import { HugeiconsIcon } from '@hugeicons/react'
+import {
+  ArrowUp01Icon,
+  BookOpen01Icon,
+  Logout03Icon,
+  Moon02Icon,
+  SmartPhone01Icon,
+  Sun03Icon,
+} from '@hugeicons/core-free-icons'
+import { useTheme } from 'next-themes'
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  useSidebar,
+} from '@/components/ui/sidebar'
+import { useAuthStore } from '@/stores/auth-store'
+import { useLogout } from '@/hooks/use-auth'
+
+function getInitials(email: string): string {
+  const parts = email.split('@')[0].split(/[._-]/)
+  return (
+    parts
+      .slice(0, 2)
+      .map((part) => (part.length > 0 ? part[0].toUpperCase() : ''))
+      .join('') || email[0].toUpperCase()
+  )
+}
+
+export default function NavUserMenu({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const { isMobile } = useSidebar()
+  const authUser = useAuthStore((state) => state.user)
+  const logoutMutation = useLogout()
+  const { theme, setTheme } = useTheme()
+
+  if (!authUser) return null
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <DropdownMenu open={open} onOpenChange={onOpenChange}>
+          <DropdownMenuTrigger
+            render={
+              <SidebarMenuButton
+                size="lg"
+                className="data-open:bg-sidebar-accent data-open:text-sidebar-accent-foreground"
+              />
+            }
+          >
+            <Avatar className="size-8">
+              {authUser.avatar_url ? (
+                <AvatarImage src={authUser.avatar_url} alt={authUser.email} />
+              ) : null}
+              <AvatarFallback className="text-xs">
+                {getInitials(authUser.email)}
+              </AvatarFallback>
+            </Avatar>
+            <div className="grid flex-1 text-left text-sm leading-tight">
+              <span className="truncate font-medium">{authUser.email}</span>
+              <span className="truncate text-xs text-muted-foreground capitalize">
+                {authUser.role.replace('_', ' ')}
+              </span>
+            </div>
+            <HugeiconsIcon icon={ArrowUp01Icon} className="ml-auto size-4" />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            className="min-w-56"
+            side={isMobile ? 'bottom' : 'right'}
+            align="end"
+            sideOffset={4}
+          >
+            <DropdownMenuGroup>
+              <DropdownMenuLabel className="font-normal p-0">
+                <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+                  <Avatar className="size-8">
+                    {authUser.avatar_url ? (
+                      <AvatarImage
+                        src={authUser.avatar_url}
+                        alt={authUser.email}
+                      />
+                    ) : null}
+                    <AvatarFallback className="text-xs">
+                      {getInitials(authUser.email)}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div className="grid flex-1 text-left text-sm leading-tight">
+                    <span className="truncate font-medium">
+                      {authUser.email}
+                    </span>
+                    <span className="truncate text-xs text-muted-foreground capitalize">
+                      {authUser.role.replace('_', ' ')}
+                    </span>
+                  </div>
+                </div>
+              </DropdownMenuLabel>
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuGroup>
+              <DropdownMenuLabel className="text-xs text-muted-foreground">
+                Theme
+              </DropdownMenuLabel>
+              <DropdownMenuItem onClick={() => setTheme('light')}>
+                <HugeiconsIcon icon={Sun03Icon} size={16} />
+                Light
+                {theme === 'light' ? (
+                  <span className="ml-auto text-xs text-primary">Active</span>
+                ) : null}
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setTheme('dark')}>
+                <HugeiconsIcon icon={Moon02Icon} size={16} />
+                Dark
+                {theme === 'dark' ? (
+                  <span className="ml-auto text-xs text-primary">Active</span>
+                ) : null}
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setTheme('system')}>
+                <HugeiconsIcon icon={SmartPhone01Icon} size={16} />
+                System
+                {theme === 'system' ? (
+                  <span className="ml-auto text-xs text-primary">Active</span>
+                ) : null}
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              render={
+                <a
+                  href="https://docs.oore.build"
+                  aria-label="Open Oore documentation"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                />
+              }
+            >
+              <HugeiconsIcon icon={BookOpen01Icon} size={16} />
+              Documentation
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() => logoutMutation.mutate()}
+              disabled={logoutMutation.isPending}
+            >
+              <HugeiconsIcon icon={Logout03Icon} size={16} />
+              Sign out
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  )
+}

--- a/apps/web/src/components/nav-user.tsx
+++ b/apps/web/src/components/nav-user.tsx
@@ -1,160 +1,97 @@
+import { Suspense, lazy, useState } from 'react'
 import { HugeiconsIcon } from '@hugeicons/react'
-import {
-  ArrowUp01Icon,
-  BookOpen01Icon,
-  Logout03Icon,
-  Moon02Icon,
-  SmartPhone01Icon,
-  Sun03Icon,
-} from '@hugeicons/core-free-icons'
-import { useTheme } from 'next-themes'
+import { ArrowUp01Icon } from '@hugeicons/core-free-icons'
+
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
 import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  useSidebar,
 } from '@/components/ui/sidebar'
 import { useAuthStore } from '@/stores/auth-store'
-import { useLogout } from '@/hooks/use-auth'
+
+const loadNavUserMenu = () => import('@/components/nav-user-menu')
+const NavUserMenu = lazy(loadNavUserMenu)
 
 function getInitials(email: string): string {
   const parts = email.split('@')[0].split(/[._-]/)
   return (
     parts
       .slice(0, 2)
-      .map((s) => (s.length > 0 ? s[0].toUpperCase() : ''))
+      .map((part) => (part.length > 0 ? part[0].toUpperCase() : ''))
       .join('') || email[0].toUpperCase()
   )
 }
 
-export default function NavUser() {
-  const { isMobile } = useSidebar()
-  const authUser = useAuthStore((s) => s.user)
-  const logoutMutation = useLogout()
-  const { theme, setTheme } = useTheme()
-
+function UserButton({
+  onClick,
+  onFocus,
+  onMouseEnter,
+}: {
+  onClick: () => void
+  onFocus: () => void
+  onMouseEnter: () => void
+}) {
+  const authUser = useAuthStore((state) => state.user)
   if (!authUser) return null
 
   return (
     <SidebarMenu>
       <SidebarMenuItem>
-        <DropdownMenu>
-          <DropdownMenuTrigger
-            render={
-              <SidebarMenuButton
-                size="lg"
-                className="data-open:bg-sidebar-accent data-open:text-sidebar-accent-foreground"
-              />
-            }
-          >
-            <Avatar className="size-8">
-              {authUser.avatar_url ? (
-                <AvatarImage src={authUser.avatar_url} alt={authUser.email} />
-              ) : null}
-              <AvatarFallback className="text-xs">
-                {getInitials(authUser.email)}
-              </AvatarFallback>
-            </Avatar>
-            <div className="grid flex-1 text-left text-sm leading-tight">
-              <span className="truncate font-medium">{authUser.email}</span>
-              <span className="truncate text-xs text-muted-foreground capitalize">
-                {authUser.role.replace('_', ' ')}
-              </span>
-            </div>
-            <HugeiconsIcon icon={ArrowUp01Icon} className="ml-auto size-4" />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            className="min-w-56"
-            side={isMobile ? 'bottom' : 'right'}
-            align="end"
-            sideOffset={4}
-          >
-            <DropdownMenuGroup>
-              <DropdownMenuLabel className="font-normal p-0">
-                <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
-                  <Avatar className="size-8">
-                    {authUser.avatar_url ? (
-                      <AvatarImage
-                        src={authUser.avatar_url}
-                        alt={authUser.email}
-                      />
-                    ) : null}
-                    <AvatarFallback className="text-xs">
-                      {getInitials(authUser.email)}
-                    </AvatarFallback>
-                  </Avatar>
-                  <div className="grid flex-1 text-left text-sm leading-tight">
-                    <span className="truncate font-medium">
-                      {authUser.email}
-                    </span>
-                    <span className="truncate text-xs text-muted-foreground capitalize">
-                      {authUser.role.replace('_', ' ')}
-                    </span>
-                  </div>
-                </div>
-              </DropdownMenuLabel>
-            </DropdownMenuGroup>
-            <DropdownMenuSeparator />
-            <DropdownMenuGroup>
-              <DropdownMenuLabel className="text-xs text-muted-foreground">
-                Theme
-              </DropdownMenuLabel>
-              <DropdownMenuItem onClick={() => setTheme('light')}>
-                <HugeiconsIcon icon={Sun03Icon} size={16} />
-                Light
-                {theme === 'light' ? (
-                  <span className="ml-auto text-xs text-primary">Active</span>
-                ) : null}
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setTheme('dark')}>
-                <HugeiconsIcon icon={Moon02Icon} size={16} />
-                Dark
-                {theme === 'dark' ? (
-                  <span className="ml-auto text-xs text-primary">Active</span>
-                ) : null}
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setTheme('system')}>
-                <HugeiconsIcon icon={SmartPhone01Icon} size={16} />
-                System
-                {theme === 'system' ? (
-                  <span className="ml-auto text-xs text-primary">Active</span>
-                ) : null}
-              </DropdownMenuItem>
-            </DropdownMenuGroup>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              render={
-                <a
-                  href="https://docs.oore.build"
-                  aria-label="Open Oore documentation"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                />
-              }
-            >
-              <HugeiconsIcon icon={BookOpen01Icon} size={16} />
-              Documentation
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => logoutMutation.mutate()}
-              disabled={logoutMutation.isPending}
-            >
-              <HugeiconsIcon icon={Logout03Icon} size={16} />
-              Sign out
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <SidebarMenuButton
+          size="lg"
+          className="data-open:bg-sidebar-accent data-open:text-sidebar-accent-foreground"
+          aria-haspopup="menu"
+          onClick={onClick}
+          onFocus={onFocus}
+          onMouseEnter={onMouseEnter}
+        >
+          <Avatar className="size-8">
+            {authUser.avatar_url ? (
+              <AvatarImage src={authUser.avatar_url} alt={authUser.email} />
+            ) : null}
+            <AvatarFallback className="text-xs">
+              {getInitials(authUser.email)}
+            </AvatarFallback>
+          </Avatar>
+          <div className="grid flex-1 text-left text-sm leading-tight">
+            <span className="truncate font-medium">{authUser.email}</span>
+            <span className="truncate text-xs text-muted-foreground capitalize">
+              {authUser.role.replace('_', ' ')}
+            </span>
+          </div>
+          <HugeiconsIcon icon={ArrowUp01Icon} className="ml-auto size-4" />
+        </SidebarMenuButton>
       </SidebarMenuItem>
     </SidebarMenu>
+  )
+}
+
+export default function NavUser() {
+  const authUser = useAuthStore((state) => state.user)
+  const [menuRequested, setMenuRequested] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
+
+  if (!authUser) return null
+
+  function openMenu() {
+    setMenuOpen(true)
+    setMenuRequested(true)
+  }
+
+  const button = (
+    <UserButton
+      onClick={openMenu}
+      onFocus={() => void loadNavUserMenu()}
+      onMouseEnter={() => void loadNavUserMenu()}
+    />
+  )
+
+  if (!menuRequested) return button
+
+  return (
+    <Suspense fallback={button}>
+      <NavUserMenu open={menuOpen} onOpenChange={setMenuOpen} />
+    </Suspense>
   )
 }

--- a/apps/web/src/components/ui/sidebar-menu-tooltip.tsx
+++ b/apps/web/src/components/ui/sidebar-menu-tooltip.tsx
@@ -1,0 +1,24 @@
+import type { ReactElement } from 'react'
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+
+export default function SidebarMenuTooltip({
+  children,
+  label,
+}: {
+  children: ReactElement
+  label: string
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger render={children} />
+      <TooltipContent side="right" align="center">
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/apps/web/src/components/ui/sidebar-mobile.tsx
+++ b/apps/web/src/components/ui/sidebar-mobile.tsx
@@ -1,0 +1,45 @@
+import type { ComponentProps, ReactNode } from 'react'
+
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+
+export default function SidebarMobile({
+  open,
+  onOpenChange,
+  children,
+  side,
+  dir,
+  className,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  children: ReactNode
+  side: 'left' | 'right'
+  dir?: ComponentProps<'div'>['dir']
+  className?: string
+}) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        dir={dir}
+        data-sidebar="sidebar"
+        data-slot="sidebar"
+        data-mobile="true"
+        className={`w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden ${className ?? ''}`}
+        style={{ '--sidebar-width': '18rem' } as React.CSSProperties}
+        side={side}
+      >
+        <SheetHeader className="sr-only">
+          <SheetTitle>Sidebar</SheetTitle>
+          <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+        </SheetHeader>
+        <div className="flex h-full w-full flex-col">{children}</div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -12,24 +12,17 @@ import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from '@/components/ui/sheet'
 import { Skeleton } from '@/components/ui/skeleton'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
+
+const loadSidebarMobile = () => import('@/components/ui/sidebar-mobile')
+const SidebarMobile = React.lazy(loadSidebarMobile)
+const SidebarMenuTooltip = React.lazy(
+  () => import('@/components/ui/sidebar-menu-tooltip'),
+)
 
 const SIDEBAR_COOKIE_NAME = 'sidebar_state'
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
 const SIDEBAR_WIDTH = '16rem'
-const SIDEBAR_WIDTH_MOBILE = '18rem'
 const SIDEBAR_WIDTH_ICON = '3rem'
 const SIDEBAR_KEYBOARD_SHORTCUT = 'b'
 
@@ -178,28 +171,20 @@ function Sidebar({
   }
 
   if (isMobile) {
+    if (!openMobile) return null
+
     return (
-      <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
-        <SheetContent
-          dir={dir}
-          data-sidebar="sidebar"
-          data-slot="sidebar"
-          data-mobile="true"
-          className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
-          style={
-            {
-              '--sidebar-width': SIDEBAR_WIDTH_MOBILE,
-            } as React.CSSProperties
-          }
+      <React.Suspense fallback={null}>
+        <SidebarMobile
+          open={openMobile}
+          onOpenChange={setOpenMobile}
           side={side}
+          dir={dir}
+          className={className}
         >
-          <SheetHeader className="sr-only">
-            <SheetTitle>Sidebar</SheetTitle>
-            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
-          </SheetHeader>
-          <div className="flex h-full w-full flex-col">{children}</div>
-        </SheetContent>
-      </Sheet>
+          {children}
+        </SidebarMobile>
+      </React.Suspense>
     )
   }
 
@@ -252,9 +237,11 @@ function Sidebar({
 function SidebarTrigger({
   className,
   onClick,
+  onFocus,
+  onMouseEnter,
   ...props
 }: React.ComponentProps<typeof Button>) {
-  const { toggleSidebar } = useSidebar()
+  const { isMobile, toggleSidebar } = useSidebar()
 
   return (
     <Button
@@ -266,6 +253,14 @@ function SidebarTrigger({
       onClick={(event) => {
         onClick?.(event)
         toggleSidebar()
+      }}
+      onFocus={(event) => {
+        onFocus?.(event)
+        if (isMobile) void loadSidebarMobile()
+      }}
+      onMouseEnter={(event) => {
+        onMouseEnter?.(event)
+        if (isMobile) void loadSidebarMobile()
       }}
       {...props}
     >
@@ -505,7 +500,7 @@ function SidebarMenuButton({
 }: useRender.ComponentProps<'button'> &
   React.ComponentProps<'button'> & {
     isActive?: boolean
-    tooltip?: string | React.ComponentProps<typeof TooltipContent>
+    tooltip?: string
   } & VariantProps<typeof sidebarMenuButtonVariants>) {
   const { isMobile, state } = useSidebar()
   const comp = useRender({
@@ -516,7 +511,7 @@ function SidebarMenuButton({
       },
       props,
     ),
-    render: !tooltip ? render : <TooltipTrigger render={render} />,
+    render,
     state: {
       slot: 'sidebar-menu-button',
       sidebar: 'menu-button',
@@ -529,22 +524,12 @@ function SidebarMenuButton({
     return comp
   }
 
-  if (typeof tooltip === 'string') {
-    tooltip = {
-      children: tooltip,
-    }
-  }
+  if (state !== 'collapsed' || isMobile) return comp
 
   return (
-    <Tooltip>
-      {comp}
-      <TooltipContent
-        side="right"
-        align="center"
-        hidden={state !== 'collapsed' || isMobile}
-        {...tooltip}
-      />
-    </Tooltip>
+    <React.Suspense fallback={comp}>
+      <SidebarMenuTooltip label={tooltip}>{comp}</SidebarMenuTooltip>
+    </React.Suspense>
   )
 }
 

--- a/apps/web/tools/check-bundle-budget.js
+++ b/apps/web/tools/check-bundle-budget.js
@@ -7,23 +7,25 @@ const manifest = JSON.parse(
   readFileSync(resolve(distDir, '.vite/manifest.json'), 'utf8'),
 )
 
-function initialAssets() {
-  const entry = Object.values(manifest).find((chunk) => chunk.isEntry)
-  if (!entry) throw new Error('Vite manifest has no entry chunk')
+const entryKey = Object.entries(manifest).find(([, chunk]) => chunk.isEntry)?.[0]
+if (!entryKey) throw new Error('Vite manifest has no entry chunk')
 
+function assetsFor(entryKeys) {
   const js = new Set()
   const css = new Set()
   const seen = new Set()
 
-  function visit(chunk) {
+  function visit(key) {
+    const chunk = manifest[key]
+    if (!chunk) throw new Error(`Vite manifest has no chunk for ${key}`)
     if (seen.has(chunk.file)) return
     seen.add(chunk.file)
     js.add(chunk.file)
     for (const stylesheet of chunk.css ?? []) css.add(stylesheet)
-    for (const imported of chunk.imports ?? []) visit(manifest[imported])
+    for (const imported of chunk.imports ?? []) visit(imported)
   }
 
-  visit(entry)
+  for (const key of entryKeys) visit(key)
   return { js, css }
 }
 
@@ -35,11 +37,49 @@ function gzipKiB(assetPaths) {
   return bytes / 1024
 }
 
-const assets = initialAssets()
+const assets = assetsFor([entryKey])
 const jsKiB = gzipKiB(assets.js)
 const cssKiB = gzipKiB(assets.css)
-const jsBudgetKiB = Number(process.env.OORE_WEB_JS_BUDGET_KIB ?? 245)
+const jsBudgetKiB = Number(process.env.OORE_WEB_JS_BUDGET_KIB ?? 190)
 const cssBudgetKiB = Number(process.env.OORE_WEB_CSS_BUDGET_KIB ?? 22)
+
+const profiles = [
+  {
+    name: 'Mobile shell',
+    entries: ['src/components/ui/sidebar-mobile.tsx'],
+    budgetKiB: Number(process.env.OORE_WEB_MOBILE_SHELL_BUDGET_KIB ?? 195),
+  },
+  {
+    name: 'Admin shell interactions',
+    entries: [
+      'src/components/instance-switcher-menu.tsx',
+      'src/components/nav-user-menu.tsx',
+      'src/components/ui/sidebar-menu-tooltip.tsx',
+    ],
+    budgetKiB: Number(process.env.OORE_WEB_ADMIN_SHELL_BUDGET_KIB ?? 230),
+  },
+  {
+    name: 'Admin command palette',
+    entries: ['src/components/command-palette.tsx'],
+    budgetKiB: Number(process.env.OORE_WEB_COMMAND_PALETTE_BUDGET_KIB ?? 215),
+  },
+  {
+    name: 'Operator build detail',
+    entries: [
+      'src/routes/builds/$buildId.tsx?tsr-split=component',
+      'src/components/build-details/build-detail-page.tsx',
+    ],
+    budgetKiB: Number(process.env.OORE_WEB_BUILD_DETAIL_BUDGET_KIB ?? 275),
+  },
+  {
+    name: 'QA artifact install',
+    entries: [
+      'src/routes/builds/$buildId.tsx?tsr-split=component',
+      'src/components/build-details/artifact-install-page.tsx',
+    ],
+    budgetKiB: Number(process.env.OORE_WEB_QA_INSTALL_BUDGET_KIB ?? 215),
+  },
+]
 
 console.log(
   `Initial bundle: ${jsKiB.toFixed(2)} KiB JS / ${cssKiB.toFixed(2)} KiB CSS gzip`,
@@ -48,7 +88,18 @@ console.log(
   `Bundle budget:  ${jsBudgetKiB.toFixed(2)} KiB JS / ${cssBudgetKiB.toFixed(2)} KiB CSS gzip`,
 )
 
-if (jsKiB > jsBudgetKiB || cssKiB > cssBudgetKiB) {
-  console.error('Initial bundle exceeds its production budget.')
+let exceedsBudget = jsKiB > jsBudgetKiB || cssKiB > cssBudgetKiB
+
+for (const profile of profiles) {
+  const profileAssets = assetsFor([entryKey, ...profile.entries])
+  const profileJsKiB = gzipKiB(profileAssets.js)
+  console.log(
+    `${profile.name.padEnd(24)} ${profileJsKiB.toFixed(2)} KiB JS / ${profile.budgetKiB.toFixed(2)} KiB budget`,
+  )
+  exceedsBudget ||= profileJsKiB > profile.budgetKiB
+}
+
+if (exceedsBudget) {
+  console.error('Web bundle exceeds a production budget.')
   process.exitCode = 1
 }

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -18,6 +18,9 @@ Rules:
   - The production bundle check now follows every static import in Vite's manifest instead of counting only tags present in `index.html`, closing the gap that hid the form runtime from the previous budget.
   - Form-heavy setup and settings screens use explicit lazy route modules, while manual chunk rules no longer pull route-only Zod, React Hook Form, or Base UI code into startup. Initial JavaScript fell from 312.90 KiB to 216.44 KiB gzip (30.8%) with the existing interface and validation intact.
   - Command palette code and project fetching now wait for search intent, with hover/focus preloading for responsiveness. Build detail loads only the operator or artifact-install experience required by the active user.
+  - Sidebar mobile-drawer, collapsed-tooltip, instance-menu, and account-menu engines now load only for the matching viewport, sidebar state, or hover/focus/click intent. The visible shell and every interaction remain intact while initial JavaScript falls again from 216.44 KiB to 165.22 KiB gzip (23.7%), a cumulative 47.2% reduction from the audited baseline.
+  - The bundle gate now caps initial JavaScript at 190 KiB gzip and separately measures manifest-union payloads for the mobile shell, admin interactions, command palette, operator build detail, and QA artifact-install personas, preventing async code movement from hiding regressions.
+  - Google Sans Flex delivery remains unchanged because no field LCP or CLS evidence currently supports changing its preload priority; font experiments remain measurement-gated.
   - The self-hosted `oore-web` launcher now caches content-hashed assets immutably, revalidates HTML, and uses a short revalidation window for unhashed static files.
   - Linear feature doc: https://linear.app/oorebuild/document/web-performance-and-bundle-discipline-8aacaadaa620
 


### PR DESCRIPTION
## Summary
- defer mobile drawer, collapsed tooltip, instance menu, and account menu engines until matching state or user intent
- reduce initial JavaScript from 216.44 KiB to 165.22 KiB gzip while preserving the visible shell and interactions
- enforce initial, mobile, admin, command palette, operator, and QA manifest-union budgets
- add focus-preservation and lazy-menu regression coverage
- update the Linear performance feature doc, V1 roadmap, and repo change ledger

## Validation
- make validate
- React Doctor 0.7.8: no findings in this milestone's changed React files
- initial JS: 165.22 / 190 KiB gzip
- CSS: 20.78 / 22 KiB gzip
- mobile shell: 186.44 / 195 KiB
- admin interactions: 220.04 / 230 KiB
- command palette: 205.11 / 215 KiB
- operator build detail: 265.29 / 275 KiB
- QA artifact install: 208.42 / 215 KiB

Linear: https://linear.app/oorebuild/document/web-performance-and-bundle-discipline-8aacaadaa620