### PR TITLE
fix(ci): support Rust 1.97 clippy

### DIFF
--- a/crates/oored/src/artifact_tokens.rs
+++ b/crates/oored/src/artifact_tokens.rs
@@ -234,7 +234,7 @@ pub async fn create_scoped_token_handler(
     // Build the download URL
     let public_url = state.public_url.read().await.clone();
     let base = public_url.as_deref().unwrap_or("http://127.0.0.1:8787");
-    let download_url = format!("{}/install/artifact/{}", base.trim_end_matches('/'), &token);
+    let download_url = format!("{}/install/artifact/{}", base.trim_end_matches('/'), token);
 
     // Audit log
     let details = serde_json::json!({

--- a/crates/oored/src/lib.rs
+++ b/crates/oored/src/lib.rs
@@ -1549,7 +1549,7 @@ async fn setup_oidc_verify(
         // Convention: code format is "test-code" and we use known test values
         (
             "admin@example.com".to_string(),
-            format!("test-subject-{}", &req.code),
+            format!("test-subject-{}", req.code),
         )
     } else {
         // Real OIDC token exchange

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -14,6 +14,10 @@ Rules:
 
 ## 2026-07-17
 
+- **Rust 1.97 release-gate compatibility**:
+  - Removed two redundant formatting borrows newly rejected by Rust 1.97 Clippy so strict alpha validation remains green without changing runtime behavior.
+  - Release channels doc: https://linear.app/oorebuild/document/release-channels-alpha-beta-stable-via-woodpecker-github-releases-993db297927a
+
 - **Host-authorized local recovery for Ready Remote instances (R086-001)**:
   - Ready Remote local recovery no longer treats a TCP loopback peer or forwarding headers as authentication authority. The public local-login route requires and atomically consumes a short-lived, single-use capability bound to one active account.
   - `oored` exposes capability minting only through an effective-user-owned Unix management socket under a `0700` directory with a `0600` socket. Ownership, exact modes, symlinks, active paths, and stale sockets fail closed; raw capabilities are held only in a URL fragment and submitted once in a POST body.


### PR DESCRIPTION
Rust 1.97 introduced useless-borrows-in-formatting warnings that made the post-merge alpha validation fail despite the identical PR tree passing on Rust 1.96. This removes the two redundant formatting borrows with no runtime behavior change and records the compatibility fix in the change ledger.

Validated locally:
- make validate
- actionlint .github/workflows/autotag.yml .github/workflows/release.yml
- make release-smoke
- cargo clippy --workspace --all-targets --all-features -- -D warnings