### PR TITLE
fix(runner): allow Apple Git in repository sandbox

### DIFF
--- a/crates/oore-runner/src/lib.rs
+++ b/crates/oore-runner/src/lib.rs
@@ -220,12 +220,15 @@ fn repository_shell_command(
 (allow default)
 (deny file* (subpath "{runner_workspace_root}"))
 (allow file* (subpath "{workspace}"))
+(allow file-read-metadata (literal "{runner_workspace_root}"))
 (deny process-info*)
+(allow process-info-pidinfo (target self))
 (deny mach-task-name)
 (deny signal)
 (allow signal (target same-sandbox))
 (deny job-creation)
 (deny appleevent-send)
+(deny process-exec (literal "/usr/bin/security"))
 (deny mach-lookup
   (global-name "com.apple.securityd")
   (global-name "com.apple.securityd.xpc")
@@ -5113,6 +5116,37 @@ mod tests {
         for key in MANAGED_ANDROID_SIGNING_ENV_KEYS {
             assert!(!environment.contains(&format!("{key}=")));
         }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn repository_shell_command_allows_apple_git_init() {
+        let parent = temp_workspace();
+        let runner_workspace_root = create_private_workspace_in(&parent, "protected-runner")
+            .expect("create protected runner root");
+        let repository_workspace =
+            create_private_workspace_in(&runner_workspace_root, "repository")
+                .expect("create repository workspace");
+
+        let output = repository_shell_command(
+            "/usr/bin/git init --quiet",
+            &repository_workspace,
+            &runner_workspace_root,
+        )
+        .expect("build contained repository command")
+        .output()
+        .await
+        .expect("run Apple Git through repository sandbox");
+
+        assert!(
+            output.status.success(),
+            "Apple Git init failed: status={:?}, stdout={}, stderr={}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        assert!(repository_workspace.join(".git").is_dir());
+        cleanup_workspace(&parent);
     }
 
     #[cfg(target_os = "macos")]

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -14,6 +14,12 @@ Rules:
 
 ## 2026-07-17
 
+- **macOS runner checkout sandbox compatibility**:
+  - Repository commands may query only their own PID metadata, allowing the Apple `/usr/bin/git` Xcode-select shim to initialize without restoring access to unrelated processes. The sandbox also permits metadata lookup of the runner workspace root required to resolve the repository working directory while continuing to deny sibling contents.
+  - The Keychain CLI is denied explicitly, and the detached-descendant regression continues to prove that repository code cannot inspect or signal a later runner-owned signer or reach its protected workspace.
+  - Product Trust feature doc: https://linear.app/oorebuild/document/feature-product-trust-hardening-release-592dfc525e77
+  - Runner sandbox ADR: https://linear.app/oorebuild/document/adr-0014-external-process-and-os-sandbox-boundary-for-v1-runners-69d1382f1539
+
 - **Safe frontend service installs and updates across protected transports**:
   - Frontend installer commands and generated systemd/launchd services now persist explicit browser-ingress and backend-hop transport assertions. Remote HTTP fails before service state changes when its assertion is missing, and backend URLs are validated before pairing exchanges any capability or durable proof.
   - Managed web UI updates preflight the candidate launcher against the active service configuration before replacing files, and release packaging exercises that contract on the compiled native launcher. Installer health checks require the launcher JSON response, while `oore-web status` reports an upstream HTML `503` by status instead of misdiagnosing it as malformed launcher JSON.


### PR DESCRIPTION
## What changed

- allow only self-targeted `process-info-pidinfo` in the repository Seatbelt profile
- allow literal metadata lookup of the runner workspace root so Apple Git can resolve its working directory without exposing sibling contents
- explicitly deny the Keychain CLI after restoring Apple shim startup
- add a macOS regression that runs real `/usr/bin/git init` through `repository_shell_command`
- record the fix in `docs/changes.md` and the Product Trust feature doc

## Root cause

The blanket `(deny process-info*)` caused the Apple `/usr/bin/git` Xcode-select shim to abort in `libxcrun` before Git initialized. Once that was narrowed, Git also required metadata-only access to the workspace root while resolving its current directory.

## Security

The detached repository descendant test remains unchanged and passes. It confirms repository commands cannot inspect or signal the separately launched signer, access its workspace or canary, or launch the Keychain CLI.

## Validation

- real macOS Seatbelt rule probes against Apple Git
- `cargo test -p oore-runner` — 65 passed
- strict runner Clippy
- `bun run docs:check`
- `make validate`
