### PR TITLE
fix(runner): repair managed Android update lifecycle

### DIFF
--- a/apps/web/tools/oore-web.js
+++ b/apps/web/tools/oore-web.js
@@ -125,8 +125,8 @@ Usage:
   oore-web update [--channel stable|beta|alpha] [--repo owner/name] [--check] [--force]
 
 Options:
-  --channel   Release channel. Defaults to installed CHANNEL, then current VERSION.
-  --repo      GitHub repo. Defaults to installed GITHUB_REPO, then ${DEFAULT_GITHUB_REPO}.
+  --channel   Release channel. Defaults to the installed frontend channel, then current version.
+  --repo      GitHub repo. Defaults to the installed frontend repository, then ${DEFAULT_GITHUB_REPO}.
   --check     Only print whether an update is available.
   --force     Reinstall the latest release even if already current.
   --help      Show this help text
@@ -717,18 +717,32 @@ function replaceDirectory(src, dst) {
 }
 
 function readInstalledVersion(installRoot) {
-  return readTrimmedFile(path.join(installRoot, 'VERSION'))
+  return (
+    readTrimmedFile(path.join(installRoot, 'WEB_VERSION')) ||
+    readTrimmedFile(path.join(installRoot, 'VERSION'))
+  )
 }
 
-function readInstalledMetadata() {
-  const installRoot = resolveInstallRoot()
+function readInstalledChannel(installRoot) {
+  return (
+    readTrimmedFile(path.join(installRoot, 'WEB_CHANNEL')) ||
+    readTrimmedFile(path.join(installRoot, 'CHANNEL'))
+  )
+}
+
+function readInstalledRepo(installRoot) {
+  return normalizeGitHubRepo(
+    readTrimmedFile(path.join(installRoot, 'WEB_GITHUB_REPO')) ||
+      readTrimmedFile(path.join(installRoot, 'GITHUB_REPO')) ||
+      DEFAULT_GITHUB_REPO,
+  )
+}
+
+export function readInstalledMetadata(installRoot = resolveInstallRoot()) {
   return {
     version: readInstalledVersion(installRoot) || 'unknown',
-    channel: readTrimmedFile(path.join(installRoot, 'CHANNEL')),
-    github_repo: normalizeGitHubRepo(
-      readTrimmedFile(path.join(installRoot, 'GITHUB_REPO')) ||
-        DEFAULT_GITHUB_REPO,
-    ),
+    channel: readInstalledChannel(installRoot),
+    github_repo: readInstalledRepo(installRoot),
   }
 }
 
@@ -953,9 +967,9 @@ export function installUpdateCandidate({
   fs.mkdirSync(binDir, { recursive: true })
   replaceFile(extractedBinary, path.join(binDir, 'oore-web'))
   replaceDirectory(extractedDist, path.join(installRoot, 'web-dist'))
-  fs.copyFileSync(extractedVersion, path.join(installRoot, 'VERSION'))
-  fs.writeFileSync(path.join(installRoot, 'CHANNEL'), `${channel}\n`)
-  fs.writeFileSync(path.join(installRoot, 'GITHUB_REPO'), `${repo}\n`)
+  fs.copyFileSync(extractedVersion, path.join(installRoot, 'WEB_VERSION'))
+  fs.writeFileSync(path.join(installRoot, 'WEB_CHANNEL'), `${channel}\n`)
+  fs.writeFileSync(path.join(installRoot, 'WEB_GITHUB_REPO'), `${repo}\n`)
   if (fileExists(extractedLicense)) {
     fs.copyFileSync(extractedLicense, path.join(installRoot, 'LICENSE'))
   }
@@ -963,17 +977,13 @@ export function installUpdateCandidate({
 
 async function runUpdate(config, activeConfig = null) {
   const installRoot = resolveInstallRoot()
-  const currentRaw = readInstalledVersion(installRoot) || '0.0.0'
+  const installed = readInstalledMetadata(installRoot)
+  const currentRaw =
+    installed.version === 'unknown' ? '0.0.0' : installed.version
   const current = parseVersion(currentRaw)
-  const repo = normalizeGitHubRepo(
-    config.repo ||
-      readTrimmedFile(path.join(installRoot, 'GITHUB_REPO')) ||
-      DEFAULT_GITHUB_REPO,
-  )
+  const repo = normalizeGitHubRepo(config.repo || installed.github_repo)
   const channel = parseChannel(
-    config.channel ||
-      readTrimmedFile(path.join(installRoot, 'CHANNEL')) ||
-      inferChannelFromVersion(current),
+    config.channel || installed.channel || inferChannelFromVersion(current),
   )
 
   const release = await fetchReleaseManifest(channel, repo)

--- a/apps/web/tools/oore-web.test.js
+++ b/apps/web/tools/oore-web.test.js
@@ -15,6 +15,7 @@ import {
   parseBackendUrl,
   parseListen,
   parseServeArgs,
+  readInstalledMetadata,
   spaCacheControl,
   spaResponseHeaders,
 } from './oore-web.js'
@@ -266,6 +267,93 @@ describe('oore-web launcher security policy', () => {
       ])
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('updates frontend metadata without advancing backend and runner metadata', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oore-web-test-'))
+    const installRoot = path.join(tempDir, 'install')
+    const extractRoot = path.join(tempDir, 'extract')
+    const extractedBinary = path.join(extractRoot, 'bin', 'oore-web')
+    const extractedDist = path.join(extractRoot, 'web-dist')
+    const extractedVersion = path.join(extractRoot, 'VERSION')
+    try {
+      fs.mkdirSync(path.dirname(extractedBinary), { recursive: true })
+      fs.mkdirSync(extractedDist, { recursive: true })
+      fs.mkdirSync(installRoot, { recursive: true })
+      fs.writeFileSync(path.join(installRoot, 'VERSION'), '1.0.0\n')
+      fs.writeFileSync(path.join(installRoot, 'CHANNEL'), 'stable\n')
+      fs.writeFileSync(
+        path.join(installRoot, 'GITHUB_REPO'),
+        'backend/repository\n',
+      )
+      fs.writeFileSync(extractedBinary, '#!/bin/sh\nexit 0\n', {
+        mode: 0o755,
+      })
+      fs.writeFileSync(path.join(extractedDist, 'index.html'), 'candidate')
+      fs.writeFileSync(extractedVersion, '2.0.0\n')
+
+      installUpdateCandidate({
+        installRoot,
+        extractedBinary,
+        extractedDist,
+        extractedVersion,
+        extractedLicense: path.join(extractRoot, 'LICENSE'),
+        channel: 'alpha',
+        repo: 'oore-ci/oore.build',
+      })
+
+      expect(fs.readFileSync(path.join(installRoot, 'VERSION'), 'utf8')).toBe(
+        '1.0.0\n',
+      )
+      expect(fs.readFileSync(path.join(installRoot, 'CHANNEL'), 'utf8')).toBe(
+        'stable\n',
+      )
+      expect(
+        fs.readFileSync(path.join(installRoot, 'GITHUB_REPO'), 'utf8'),
+      ).toBe('backend/repository\n')
+      expect(
+        fs.readFileSync(path.join(installRoot, 'WEB_VERSION'), 'utf8'),
+      ).toBe('2.0.0\n')
+      expect(
+        fs.readFileSync(path.join(installRoot, 'WEB_CHANNEL'), 'utf8'),
+      ).toBe('alpha\n')
+      expect(
+        fs.readFileSync(path.join(installRoot, 'WEB_GITHUB_REPO'), 'utf8'),
+      ).toBe('oore-ci/oore.build\n')
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('prefers frontend metadata while retaining legacy install compatibility', () => {
+    const installRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'oore-web-test-'))
+    try {
+      fs.writeFileSync(path.join(installRoot, 'VERSION'), '1.0.0\n')
+      fs.writeFileSync(path.join(installRoot, 'CHANNEL'), 'stable\n')
+      fs.writeFileSync(
+        path.join(installRoot, 'GITHUB_REPO'),
+        'legacy/repository\n',
+      )
+      expect(readInstalledMetadata(installRoot)).toEqual({
+        version: '1.0.0',
+        channel: 'stable',
+        github_repo: 'legacy/repository',
+      })
+
+      fs.writeFileSync(path.join(installRoot, 'WEB_VERSION'), '2.0.0\n')
+      fs.writeFileSync(path.join(installRoot, 'WEB_CHANNEL'), 'alpha\n')
+      fs.writeFileSync(
+        path.join(installRoot, 'WEB_GITHUB_REPO'),
+        'frontend/repository\n',
+      )
+      expect(readInstalledMetadata(installRoot)).toEqual({
+        version: '2.0.0',
+        channel: 'alpha',
+        github_repo: 'frontend/repository',
+      })
+    } finally {
+      fs.rmSync(installRoot, { recursive: true, force: true })
     }
   })
 })

--- a/crates/oore-runner/src/lib.rs
+++ b/crates/oore-runner/src/lib.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::fs::{self, OpenOptions};
 use std::io::{ErrorKind, Read, Write};
 use std::net::IpAddr;
@@ -188,20 +189,50 @@ fn repository_shell_command(
     script: &str,
     workspace: &Path,
     runner_workspace_root: &Path,
+    protected_host_paths: &[PathBuf],
 ) -> anyhow::Result<tokio::process::Command> {
     #[cfg(target_os = "macos")]
     let mut command = {
-        let runner_workspace_root = fs::canonicalize(runner_workspace_root)
+        let runner_workspace_root_path = fs::canonicalize(runner_workspace_root)
             .context("failed to resolve runner workspace root")?;
-        let workspace = fs::canonicalize(workspace).context("failed to resolve build workspace")?;
+        let workspace_path =
+            fs::canonicalize(workspace).context("failed to resolve build workspace")?;
         anyhow::ensure!(
-            workspace.parent() == Some(runner_workspace_root.as_path()),
+            workspace_path.parent() == Some(runner_workspace_root_path.as_path()),
             "build workspace is outside the runner workspace root"
         );
-        let runner_workspace_root = runner_workspace_root
+        let mut protected_host_write_denials = String::new();
+        for protected_path in protected_host_paths {
+            let protected_path = fs::canonicalize(protected_path).with_context(|| {
+                format!(
+                    "failed to resolve protected host toolchain path {}",
+                    protected_path.display()
+                )
+            })?;
+            anyhow::ensure!(
+                protected_path.is_absolute()
+                    && !protected_path.starts_with(&workspace_path)
+                    && !workspace_path.starts_with(&protected_path),
+                "protected host toolchain path {} is not outside the repository workspace",
+                protected_path.display()
+            );
+            let protected_path = protected_path
+                .to_str()
+                .context("protected host toolchain path is not valid UTF-8")?;
+            anyhow::ensure!(
+                !protected_path.chars().any(char::is_control),
+                "protected host toolchain path contains control characters"
+            );
+            let protected_path = protected_path.replace('\\', "\\\\").replace('"', "\\\"");
+            protected_host_write_denials.push_str(&format!(
+                "(deny file-write* (literal \"{protected_path}\"))\n\
+                 (deny file-write* (subpath \"{protected_path}\"))\n"
+            ));
+        }
+        let runner_workspace_root = runner_workspace_root_path
             .to_str()
             .context("runner workspace root path is not valid UTF-8")?;
-        let workspace = workspace
+        let workspace = workspace_path
             .to_str()
             .context("build workspace path is not valid UTF-8")?;
         anyhow::ensure!(
@@ -221,6 +252,7 @@ fn repository_shell_command(
 (deny file* (subpath "{runner_workspace_root}"))
 (allow file* (subpath "{workspace}"))
 (allow file-read-metadata (literal "{runner_workspace_root}"))
+{protected_host_write_denials}
 (deny process-info*)
 (allow process-info-pidinfo (target self))
 (deny mach-task-name)
@@ -477,7 +509,42 @@ fn android_artifact_extension(command: &str) -> Option<&'static str> {
     }
 }
 
-fn find_apksigner() -> PathBuf {
+#[derive(Debug, Clone)]
+struct AndroidSigningToolchain {
+    apksigner: PathBuf,
+    jarsigner: PathBuf,
+    zip: PathBuf,
+    java_home: Option<PathBuf>,
+    protected_host_paths: Vec<PathBuf>,
+}
+
+#[derive(Debug)]
+struct ResolvedAndroidJava {
+    home: PathBuf,
+    jarsigner: PathBuf,
+    protected_host_paths: Vec<PathBuf>,
+}
+
+fn push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
+    if !paths.contains(&path) {
+        paths.push(path);
+    }
+}
+
+fn canonical_file(path: &Path) -> Option<PathBuf> {
+    if !path.is_file() {
+        return None;
+    }
+    fs::canonicalize(path).ok()
+}
+
+fn fixed_system_executable(name: &str) -> Option<PathBuf> {
+    ["/usr/bin", "/bin", "/usr/sbin", "/sbin"]
+        .into_iter()
+        .find_map(|root| canonical_file(&Path::new(root).join(name)))
+}
+
+fn find_apksigner() -> (PathBuf, Vec<PathBuf>) {
     let mut roots = ["ANDROID_HOME", "ANDROID_SDK_ROOT"]
         .into_iter()
         .filter_map(|key| std::env::var_os(key).map(PathBuf::from))
@@ -497,30 +564,194 @@ fn find_apksigner() -> PathBuf {
             .filter(|path| path.is_file())
             .collect::<Vec<_>>();
         candidates.sort();
-        if let Some(path) = candidates.pop() {
-            return path;
+        while let Some(path) = candidates.pop() {
+            let Some(apksigner) = canonical_file(&path) else {
+                continue;
+            };
+            let mut protected_host_paths = Vec::new();
+            if let Ok(root) = fs::canonicalize(&root) {
+                push_unique_path(&mut protected_host_paths, root);
+            }
+            if let Some(version_root) = apksigner.parent() {
+                push_unique_path(&mut protected_host_paths, version_root.to_path_buf());
+            }
+            return (apksigner, protected_host_paths);
         }
     }
-    PathBuf::from("apksigner")
+    (
+        fixed_system_executable("apksigner").unwrap_or_else(|| PathBuf::from("apksigner")),
+        Vec::new(),
+    )
+}
+
+fn resolve_android_signing_java(
+    home: &Path,
+    protection_root: Option<&Path>,
+) -> Option<ResolvedAndroidJava> {
+    let home = fs::canonicalize(home).ok()?;
+    let java = canonical_file(&home.join("bin/java"))?;
+    let jarsigner = canonical_file(&home.join("bin/jarsigner"))?;
+    let mut protected_host_paths = Vec::new();
+    if let Some(protection_root) = protection_root
+        && let Ok(protection_root) = fs::canonicalize(protection_root)
+    {
+        push_unique_path(&mut protected_host_paths, protection_root);
+    }
+    push_unique_path(&mut protected_host_paths, home.clone());
+    for executable in [&java, &jarsigner] {
+        if let Some(parent) = executable.parent() {
+            push_unique_path(&mut protected_host_paths, parent.to_path_buf());
+        }
+    }
+    Some(ResolvedAndroidJava {
+        home,
+        jarsigner,
+        protected_host_paths,
+    })
+}
+
+fn find_android_signing_java() -> Option<ResolvedAndroidJava> {
+    if let Some(path) = std::env::var_os("JAVA_HOME").map(PathBuf::from)
+        && let Some(java) = resolve_android_signing_java(&path, Some(&path))
+    {
+        return Some(java);
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let mut application_roots = Vec::new();
+        if let Some(home) = std::env::var_os("HOME") {
+            application_roots.push(PathBuf::from(home).join("Applications"));
+        }
+        application_roots.push(PathBuf::from("/Applications"));
+        for root in application_roots {
+            for app in ["Android Studio.app", "Android Studio Preview.app"] {
+                let app_root = root.join(app);
+                let home = app_root.join("Contents/jbr/Contents/Home");
+                if let Some(java) = resolve_android_signing_java(&home, Some(&app_root)) {
+                    return Some(java);
+                }
+            }
+        }
+
+        if let Ok(output) = Command::new("/usr/libexec/java_home").output()
+            && output.status.success()
+        {
+            let home = PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
+            let bundle_root = home.parent().and_then(Path::parent);
+            if let Some(java) = resolve_android_signing_java(&home, bundle_root) {
+                return Some(java);
+            }
+        }
+    }
+
+    None
+}
+
+impl AndroidSigningToolchain {
+    fn discover() -> Self {
+        let (apksigner, mut protected_host_paths) = find_apksigner();
+        let java = find_android_signing_java();
+        let (java_home, jarsigner) = if let Some(java) = java {
+            for path in java.protected_host_paths {
+                push_unique_path(&mut protected_host_paths, path);
+            }
+            (Some(java.home), java.jarsigner)
+        } else {
+            (
+                None,
+                fixed_system_executable("jarsigner").unwrap_or_else(|| PathBuf::from("jarsigner")),
+            )
+        };
+        Self {
+            apksigner,
+            jarsigner,
+            zip: fixed_system_executable("zip").unwrap_or_else(|| PathBuf::from("zip")),
+            java_home,
+            protected_host_paths,
+        }
+    }
+
+    fn system_path() -> anyhow::Result<OsString> {
+        std::env::join_paths(
+            ["/usr/bin", "/bin", "/usr/sbin", "/sbin"]
+                .into_iter()
+                .map(PathBuf::from),
+        )
+        .context("invalid fixed system PATH")
+    }
+
+    fn signer_path(&self) -> anyhow::Result<OsString> {
+        let mut paths = Vec::new();
+        if let Some(java_home) = &self.java_home {
+            paths.push(java_home.join("bin"));
+        }
+        paths.extend(
+            ["/usr/bin", "/bin", "/usr/sbin", "/sbin"]
+                .into_iter()
+                .map(PathBuf::from),
+        );
+        std::env::join_paths(paths).context("invalid fixed Android signer PATH")
+    }
 }
 
 fn run_android_signer_command(
+    toolchain: &AndroidSigningToolchain,
     program: &Path,
     args: &[String],
     inputs: &AndroidSigningInputs,
     action: &str,
 ) -> anyhow::Result<()> {
-    let output = Command::new(program)
+    let mut command = Command::new(program);
+    command
         .args(args)
         .env(ANDROID_SIGNER_STORE_PASSWORD_ENV, &inputs.keystore_password)
         .env(ANDROID_SIGNER_KEY_PASSWORD_ENV, &inputs.key_password)
-        .output()
-        .map_err(|error| {
-            anyhow::anyhow!("failed to {action} with {}: {error}", program.display())
-        })?;
+        .env("PATH", toolchain.signer_path()?);
+    if let Some(java_home) = &toolchain.java_home {
+        command.env("JAVA_HOME", java_home);
+    } else {
+        command.env_remove("JAVA_HOME");
+    }
+    let output = command.output().map_err(|error| {
+        anyhow::anyhow!("failed to {action} with {}: {error}", program.display())
+    })?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         anyhow::bail!("failed to {action}: {stderr}");
+    }
+    Ok(())
+}
+
+fn strip_android_bundle_signatures(
+    toolchain: &AndroidSigningToolchain,
+    artifact: &Path,
+) -> anyhow::Result<()> {
+    let output = Command::new(&toolchain.zip)
+        .args([
+            "-d",
+            artifact.to_str().unwrap_or_default(),
+            "META-INF/*.SF",
+            "META-INF/*.RSA",
+            "META-INF/*.DSA",
+            "META-INF/*.EC",
+            "META-INF/MANIFEST.MF",
+        ])
+        .env("PATH", AndroidSigningToolchain::system_path()?)
+        .env_remove(ANDROID_SIGNER_STORE_PASSWORD_ENV)
+        .env_remove(ANDROID_SIGNER_KEY_PASSWORD_ENV)
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to strip existing AAB signatures with {}",
+                toolchain.zip.display()
+            )
+        })?;
+    if !output.status.success() && output.status.code() != Some(12) {
+        anyhow::bail!(
+            "failed to strip existing AAB signatures: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
     }
     Ok(())
 }
@@ -555,6 +786,7 @@ fn sign_android_artifacts(
     signing_workspace: &Path,
     command: &str,
     inputs: &AndroidSigningInputs,
+    toolchain: &AndroidSigningToolchain,
 ) -> anyhow::Result<Vec<PathBuf>> {
     let extension = android_artifact_extension(command)
         .ok_or_else(|| anyhow::anyhow!("unsupported Android signing command"))?;
@@ -568,9 +800,9 @@ fn sign_android_artifacts(
     for (index, artifact) in artifacts.iter().enumerate() {
         let signed_artifact = signing_dir.join(format!("signed-{index}.{extension}"));
         if extension == "apk" {
-            let apksigner = find_apksigner();
             run_android_signer_command(
-                &apksigner,
+                toolchain,
+                &toolchain.apksigner,
                 &[
                     "sign".to_string(),
                     "--ks".to_string(),
@@ -589,7 +821,8 @@ fn sign_android_artifacts(
                 "sign Android APK",
             )?;
             run_android_signer_command(
-                &apksigner,
+                toolchain,
+                &toolchain.apksigner,
                 &[
                     "verify".to_string(),
                     "--verbose".to_string(),
@@ -601,26 +834,10 @@ fn sign_android_artifacts(
             )?;
         } else {
             fs::copy(artifact, &signed_artifact)?;
-            let strip = Command::new("zip")
-                .args([
-                    "-d",
-                    signed_artifact.to_str().unwrap_or_default(),
-                    "META-INF/*.SF",
-                    "META-INF/*.RSA",
-                    "META-INF/*.DSA",
-                    "META-INF/*.EC",
-                    "META-INF/MANIFEST.MF",
-                ])
-                .output()
-                .context("failed to strip existing AAB signatures")?;
-            if !strip.status.success() && strip.status.code() != Some(12) {
-                anyhow::bail!(
-                    "failed to strip existing AAB signatures: {}",
-                    String::from_utf8_lossy(&strip.stderr).trim()
-                );
-            }
+            strip_android_bundle_signatures(toolchain, &signed_artifact)?;
             run_android_signer_command(
-                Path::new("jarsigner"),
+                toolchain,
+                &toolchain.jarsigner,
                 &[
                     "-keystore".to_string(),
                     keystore_path.display().to_string(),
@@ -635,7 +852,8 @@ fn sign_android_artifacts(
                 "sign Android App Bundle",
             )?;
             run_android_signer_command(
-                Path::new("jarsigner"),
+                toolchain,
+                &toolchain.jarsigner,
                 &[
                     "-verify".to_string(),
                     "-strict".to_string(),
@@ -3000,6 +3218,8 @@ async fn execute_build(
     daemon_url: &str,
     config: &RunnerConfig,
 ) -> (Vec<StepResult>, anyhow::Result<()>) {
+    // Pin signer executables before any repository-controlled checkout or build stage runs.
+    let android_signing_toolchain = AndroidSigningToolchain::discover();
     let runner_workspace_root = match prepare_runner_workspace_root() {
         Ok(root) => root,
         Err(error) => return (vec![], Err(error)),
@@ -3090,6 +3310,7 @@ async fn execute_build(
         &checkout.shell_script,
         &workspace,
         &runner_workspace_root,
+        &android_signing_toolchain.protected_host_paths,
     ) {
         Ok(command) => command,
         Err(error) => return (steps, Err(error)),
@@ -3404,6 +3625,7 @@ async fn execute_build(
                 &normalized_command,
                 &workspace,
                 &runner_workspace_root,
+                &android_signing_toolchain.protected_host_paths,
             ) {
                 Ok(command) => command,
                 Err(error) => return (steps, Err(error)),
@@ -3526,8 +3748,13 @@ Install required tooling (for example Flutter/FVM) or override build commands. C
                             ),
                         )
                         .await;
-                        let signing_result =
-                            sign_android_artifacts(&workspace, &signing_workspace, command, inputs);
+                        let signing_result = sign_android_artifacts(
+                            &workspace,
+                            &signing_workspace,
+                            command,
+                            inputs,
+                            &android_signing_toolchain,
+                        );
                         let signing_finished = now_unix();
                         let signing_succeeded = signing_result.is_ok();
                         steps.push(StepResult {
@@ -5140,6 +5367,7 @@ mod tests {
             "/usr/bin/git init --quiet",
             &repository_workspace,
             &runner_workspace_root,
+            &[],
         )
         .expect("build contained repository command")
         .output()
@@ -5154,6 +5382,73 @@ mod tests {
             String::from_utf8_lossy(&output.stderr),
         );
         assert!(repository_workspace.join(".git").is_dir());
+        cleanup_workspace(&parent);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn repository_command_cannot_mutate_android_signing_toolchain() {
+        let parent = temp_workspace();
+        let runner_workspace_root = create_private_workspace_in(&parent, "protected-runner")
+            .expect("create protected runner root");
+        let repository_workspace =
+            create_private_workspace_in(&runner_workspace_root, "repository")
+                .expect("create repository workspace");
+        let sdk_root = parent.join("host-android-sdk");
+        let java_home = parent.join("host-jdk");
+        let apksigner = sdk_root.join("build-tools/36.1.0/apksigner");
+        let java = java_home.join("bin/java");
+        let jarsigner = java_home.join("bin/jarsigner");
+        for path in [&apksigner, &java, &jarsigner] {
+            fs::create_dir_all(path.parent().expect("tool parent"))
+                .expect("create synthetic tool parent");
+            fs::write(path, b"TRUSTED_TOOL").expect("write synthetic trusted tool");
+        }
+
+        let allowed_write = repository_workspace.join("allowed-write");
+        let protected_host_paths = vec![
+            fs::canonicalize(&sdk_root).expect("resolve synthetic SDK root"),
+            fs::canonicalize(&java_home).expect("resolve synthetic JDK root"),
+        ];
+        let mut command = repository_shell_command(
+            r#"printf 'REPOSITORY_CONTROLLED' > "$OORE_TEST_APKSIGNER"
+printf 'REPOSITORY_CONTROLLED' > "$OORE_TEST_JAVA"
+printf 'REPOSITORY_CONTROLLED' > "$OORE_TEST_JARSIGNER"
+printf 'ALLOWED' > "$OORE_TEST_ALLOWED_WRITE""#,
+            &repository_workspace,
+            &runner_workspace_root,
+            &protected_host_paths,
+        )
+        .expect("build contained repository command");
+        command
+            .env("OORE_TEST_APKSIGNER", &apksigner)
+            .env("OORE_TEST_JAVA", &java)
+            .env("OORE_TEST_JARSIGNER", &jarsigner)
+            .env("OORE_TEST_ALLOWED_WRITE", &allowed_write);
+        let output = command
+            .output()
+            .await
+            .expect("run repository toolchain mutation attempt");
+        assert!(
+            output.status.success(),
+            "mutation probe failed: status={:?}, stdout={}, stderr={}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        assert_eq!(
+            fs::read(&apksigner).expect("read apksigner"),
+            b"TRUSTED_TOOL"
+        );
+        assert_eq!(fs::read(&java).expect("read java"), b"TRUSTED_TOOL");
+        assert_eq!(
+            fs::read(&jarsigner).expect("read jarsigner"),
+            b"TRUSTED_TOOL"
+        );
+        assert_eq!(
+            fs::read(&allowed_write).expect("read allowed write"),
+            b"ALLOWED"
+        );
         cleanup_workspace(&parent);
     }
 
@@ -5248,6 +5543,7 @@ mod tests {
             "\"$OORE_ESCAPE_HELPER\" --exact tests::repository_descendant_escape_helper >/dev/null 2>&1 &",
             &repository_workspace,
             &runner_workspace_root,
+            &[],
         )
         .expect("build contained repository command");
         repository_command
@@ -5348,8 +5644,14 @@ mod tests {
         let Ok(result_path) = std::env::var("OORE_APKSIGNER_LOOKUP_RESULT") else {
             return;
         };
-        fs::write(result_path, find_apksigner().display().to_string())
-            .expect("write resolved apksigner path");
+        fs::write(
+            result_path,
+            AndroidSigningToolchain::discover()
+                .apksigner
+                .display()
+                .to_string(),
+        )
+        .expect("write resolved apksigner path");
     }
 
     #[cfg(target_os = "macos")]
@@ -5380,7 +5682,232 @@ mod tests {
         );
         assert_eq!(
             PathBuf::from(fs::read_to_string(&result_path).expect("read resolved apksigner")),
-            apksigner
+            fs::canonicalize(&apksigner).expect("resolve expected apksigner")
+        );
+        cleanup_workspace(&workspace);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn android_signer_runtime_helper() {
+        let Ok(result_path) = std::env::var("OORE_ANDROID_SIGNER_RUNTIME_RESULT") else {
+            return;
+        };
+        let inputs = AndroidSigningInputs {
+            keystore_bytes: Vec::new(),
+            keystore_password: "unused-store-password".to_string(),
+            key_alias: "unused-alias".to_string(),
+            key_password: "unused-key-password".to_string(),
+        };
+        let result = (|| {
+            let toolchain = AndroidSigningToolchain::discover();
+            run_android_signer_command(
+                &toolchain,
+                &toolchain.apksigner,
+                &["version".to_string()],
+                &inputs,
+                "query Android APK signer version",
+            )?;
+            run_android_signer_command(
+                &toolchain,
+                &toolchain.jarsigner,
+                &["-version".to_string()],
+                &inputs,
+                "query Android App Bundle signer version",
+            )
+        })();
+        fs::write(
+            result_path,
+            result
+                .as_ref()
+                .map(|_| "ok".to_string())
+                .unwrap_or_else(|error| format!("{error:#}")),
+        )
+        .expect("write signer runtime result");
+        result.expect("Android signing tools should execute");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn android_aab_signer_runtime_helper() {
+        let Some(workspace) = std::env::var_os("OORE_AAB_SIGNER_WORKSPACE") else {
+            return;
+        };
+        let signing_workspace = PathBuf::from(
+            std::env::var_os("OORE_AAB_SIGNING_WORKSPACE")
+                .expect("AAB signing workspace is configured"),
+        );
+        let jarsigner = PathBuf::from(
+            std::env::var_os("OORE_AAB_JARSIGNER").expect("AAB jarsigner is configured"),
+        );
+        let result_path = PathBuf::from(
+            std::env::var_os("OORE_AAB_SIGNER_RESULT").expect("AAB result path is configured"),
+        );
+        let toolchain = AndroidSigningToolchain {
+            apksigner: PathBuf::from("/usr/bin/true"),
+            jarsigner,
+            zip: fixed_system_executable("zip").expect("system zip is installed"),
+            java_home: None,
+            protected_host_paths: Vec::new(),
+        };
+        let inputs = AndroidSigningInputs {
+            keystore_bytes: b"synthetic-keystore".to_vec(),
+            keystore_password: "store-password".to_string(),
+            key_alias: "upload".to_string(),
+            key_password: "key-password".to_string(),
+        };
+        let result = sign_android_artifacts(
+            Path::new(&workspace),
+            &signing_workspace,
+            "flutter build appbundle --release",
+            &inputs,
+            &toolchain,
+        );
+        fs::write(
+            result_path,
+            result
+                .as_ref()
+                .map(|_| "ok".to_string())
+                .unwrap_or_else(|error| format!("{error:#}")),
+        )
+        .expect("write AAB signer result");
+        result.expect("AAB signing should use pinned host tools");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn android_aab_signing_ignores_repository_controlled_zip_on_path() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = temp_workspace();
+        let workspace = root.join("repository");
+        let signing_workspace = root.join("signing");
+        let artifact = workspace.join("build/app/outputs/bundle/release/app-release.aab");
+        let payload = workspace.join("payload.txt");
+        let hostile_bin = root.join("hostile-bin");
+        let hostile_zip = hostile_bin.join("zip");
+        let hostile_marker = root.join("hostile-zip-ran");
+        let jarsigner = root.join("pinned-jarsigner");
+        let result_path = root.join("aab-signer-result");
+        fs::create_dir_all(artifact.parent().expect("artifact parent"))
+            .expect("create artifact output directory");
+        fs::create_dir_all(&signing_workspace).expect("create signing workspace");
+        fs::create_dir_all(&hostile_bin).expect("create hostile PATH directory");
+        fs::write(&payload, b"bundle payload").expect("write bundle payload");
+        let zip = fixed_system_executable("zip").expect("system zip is installed");
+        let archive = Command::new(&zip)
+            .current_dir(&workspace)
+            .args([
+                "-q",
+                artifact.to_str().expect("artifact path is UTF-8"),
+                payload.file_name().unwrap().to_str().unwrap(),
+            ])
+            .status()
+            .expect("create synthetic AAB");
+        assert!(archive.success(), "failed to create synthetic AAB");
+        fs::write(
+            &hostile_zip,
+            "#!/bin/sh\nprintf 'ran' > \"$OORE_HOSTILE_ZIP_MARKER\"\nexit 99\n",
+        )
+        .expect("write hostile zip shim");
+        fs::write(&jarsigner, "#!/bin/sh\nexit 0\n").expect("write pinned jarsigner");
+        for executable in [&hostile_zip, &jarsigner] {
+            fs::set_permissions(executable, fs::Permissions::from_mode(0o755))
+                .expect("make synthetic tool executable");
+        }
+
+        let output = Command::new(std::env::current_exe().expect("resolve test binary"))
+            .args(["--exact", "tests::android_aab_signer_runtime_helper"])
+            .env("PATH", format!("{}:/usr/bin:/bin", hostile_bin.display()))
+            .env("OORE_HOSTILE_ZIP_MARKER", &hostile_marker)
+            .env("OORE_AAB_SIGNER_WORKSPACE", &workspace)
+            .env("OORE_AAB_SIGNING_WORKSPACE", &signing_workspace)
+            .env("OORE_AAB_JARSIGNER", &jarsigner)
+            .env("OORE_AAB_SIGNER_RESULT", &result_path)
+            .output()
+            .expect("run isolated AAB signer");
+        assert!(
+            output.status.success(),
+            "AAB signer failed: {}\n{}",
+            fs::read_to_string(&result_path).unwrap_or_default(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            fs::read_to_string(&result_path).expect("read AAB signer result"),
+            "ok"
+        );
+        assert!(
+            !hostile_marker.exists(),
+            "repository-controlled zip shim executed"
+        );
+        cleanup_workspace(&root);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn android_signer_executes_with_default_macos_toolchain_under_launchd_environment() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let workspace = temp_workspace();
+        let home = workspace.join("home");
+        let result_path = workspace.join("signer-runtime-result");
+        let apksigner = home.join("Library/Android/sdk/build-tools/36.1.0/apksigner");
+        let java_home = home.join("Applications/Android Studio.app/Contents/jbr/Contents/Home");
+        let blocked_bin = workspace.join("blocked-bin");
+        let java = java_home.join("bin/java");
+        let jarsigner = java_home.join("bin/jarsigner");
+        let blocked_java = blocked_bin.join("java");
+        let blocked_jarsigner = blocked_bin.join("jarsigner");
+        let blocked_dirname = blocked_bin.join("dirname");
+        for (path, contents) in [
+            (
+                &apksigner,
+                "#!/bin/sh\ndirname \"$0\" >/dev/null || exit 1\nexec java \"$@\"\n",
+            ),
+            (&java, "#!/bin/sh\nexit 0\n"),
+            (
+                &jarsigner,
+                "#!/bin/sh\ndirname \"$0\" >/dev/null || exit 1\nexit 0\n",
+            ),
+            (
+                &blocked_java,
+                "#!/bin/sh\necho 'Unable to locate a Java Runtime.' >&2\nexit 1\n",
+            ),
+            (
+                &blocked_jarsigner,
+                "#!/bin/sh\necho 'Unable to locate a Java Runtime.' >&2\nexit 1\n",
+            ),
+            (&blocked_dirname, "#!/bin/sh\nexit 1\n"),
+        ] {
+            fs::create_dir_all(path.parent().expect("tool parent"))
+                .expect("create synthetic tool parent");
+            fs::write(path, contents).expect("write synthetic tool");
+            fs::set_permissions(path, fs::Permissions::from_mode(0o755))
+                .expect("make synthetic tool executable");
+        }
+
+        let output = Command::new(std::env::current_exe().expect("resolve test binary"))
+            .args(["--exact", "tests::android_signer_runtime_helper"])
+            .env_remove("ANDROID_HOME")
+            .env_remove("ANDROID_SDK_ROOT")
+            .env_remove("JAVA_HOME")
+            .env_remove("JDK_HOME")
+            .env_remove("STUDIO_JDK")
+            .env("HOME", &home)
+            .env("PATH", format!("{}:/usr/bin:/bin", blocked_bin.display()))
+            .env("OORE_ANDROID_SIGNER_RUNTIME_RESULT", &result_path)
+            .output()
+            .expect("run isolated Android signer runtime check");
+
+        assert!(
+            output.status.success(),
+            "signer runtime failed: {}\n{}",
+            fs::read_to_string(&result_path).unwrap_or_default(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            fs::read_to_string(&result_path).expect("read signer runtime result"),
+            "ok"
         );
         cleanup_workspace(&workspace);
     }

--- a/crates/oore/src/main.rs
+++ b/crates/oore/src/main.rs
@@ -2783,11 +2783,11 @@ fn handle_config_get(args: ConfigGetArgs) -> anyhow::Result<()> {
     }
 }
 
-fn command_output(cmd: &str, args: &[&str]) -> Option<std::process::Output> {
+fn command_output(cmd: impl AsRef<std::ffi::OsStr>, args: &[&str]) -> Option<std::process::Output> {
     std::process::Command::new(cmd).args(args).output().ok()
 }
 
-fn command_version(cmd: &str, args: &[&str]) -> Option<String> {
+fn command_version(cmd: impl AsRef<std::ffi::OsStr>, args: &[&str]) -> Option<String> {
     command_output(cmd, args)
         .and_then(|out| {
             if out.status.success() {
@@ -2823,13 +2823,94 @@ fn doctor_has_platform(args: &DoctorArgs, platform: DoctorPlatform) -> bool {
 }
 
 fn android_sdk_root() -> Option<PathBuf> {
-    ["ANDROID_HOME", "ANDROID_SDK_ROOT"]
+    let mut roots = ["ANDROID_HOME", "ANDROID_SDK_ROOT"]
         .into_iter()
-        .find_map(|key| {
-            std::env::var_os(key)
-                .map(PathBuf::from)
-                .filter(|path| path.is_dir())
-        })
+        .filter_map(|key| std::env::var_os(key).map(PathBuf::from))
+        .collect::<Vec<_>>();
+    #[cfg(target_os = "macos")]
+    if let Some(home) = std::env::var_os("HOME") {
+        roots.push(PathBuf::from(home).join("Library/Android/sdk"));
+    }
+    roots
+        .into_iter()
+        .find(|path| path.join("platform-tools/adb").is_file())
+}
+
+fn valid_android_signing_java_home(path: &Path) -> bool {
+    path.join("bin/java").is_file() && path.join("bin/jarsigner").is_file()
+}
+
+fn android_signing_java_home() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("JAVA_HOME").map(PathBuf::from)
+        && valid_android_signing_java_home(&path)
+    {
+        return Some(path);
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let mut application_roots = Vec::new();
+        if let Some(home) = std::env::var_os("HOME") {
+            application_roots.push(PathBuf::from(home).join("Applications"));
+        }
+        application_roots.push(PathBuf::from("/Applications"));
+        for root in application_roots {
+            for app in ["Android Studio.app", "Android Studio Preview.app"] {
+                let path = root.join(app).join("Contents/jbr/Contents/Home");
+                if valid_android_signing_java_home(&path) {
+                    return Some(path);
+                }
+            }
+        }
+
+        if let Ok(output) = std::process::Command::new("/usr/libexec/java_home").output()
+            && output.status.success()
+        {
+            let path = PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
+            if valid_android_signing_java_home(&path) {
+                return Some(path);
+            }
+        }
+    }
+
+    None
+}
+
+fn add_android_checks(checks: &mut Vec<DoctorCheckResult>) {
+    let java = android_signing_java_home()
+        .map(|home| home.join("bin/java"))
+        .unwrap_or_else(|| PathBuf::from("java"));
+    if let Some(version) = command_version(&java, &["-version"]) {
+        let detail = if java.is_absolute() {
+            format!("{version} ({})", java.display())
+        } else {
+            version
+        };
+        checks.push(doctor_check("java", "ok", Some(detail), None));
+    } else {
+        checks.push(doctor_check(
+            "java",
+            "missing",
+            None,
+            Some("install Android Studio or a supported JDK and set JAVA_HOME"),
+        ));
+    }
+
+    if let Some(sdk_root) = android_sdk_root() {
+        checks.push(doctor_check(
+            "android_sdk",
+            "ok",
+            Some(sdk_root.display().to_string()),
+            None,
+        ));
+    } else {
+        checks.push(doctor_check(
+            "android_sdk",
+            "missing",
+            None,
+            Some("install Android Studio or set ANDROID_HOME to an SDK with Platform-Tools"),
+        ));
+    }
 }
 
 fn add_xcode_checks(checks: &mut Vec<DoctorCheckResult>) {
@@ -2934,42 +3015,7 @@ fn run_doctor_checks(args: DoctorArgs) -> anyhow::Result<()> {
     }
 
     if doctor_has_platform(&args, DoctorPlatform::Android) {
-        if let Some(version) = command_version("java", &["-version"]) {
-            checks.push(doctor_check("java", "ok", Some(version), None));
-        } else {
-            checks.push(doctor_check(
-                "java",
-                "missing",
-                None,
-                Some("install a supported JDK and set JAVA_HOME"),
-            ));
-        }
-
-        if let Some(sdk_root) = android_sdk_root() {
-            let adb = sdk_root.join("platform-tools/adb");
-            if adb.is_file() {
-                checks.push(doctor_check(
-                    "android_sdk",
-                    "ok",
-                    Some(sdk_root.display().to_string()),
-                    None,
-                ));
-            } else {
-                checks.push(doctor_check(
-                    "android_sdk",
-                    "missing",
-                    Some(sdk_root.display().to_string()),
-                    Some("install Android SDK Platform-Tools in this SDK"),
-                ));
-            }
-        } else {
-            checks.push(doctor_check(
-                "android_sdk",
-                "missing",
-                None,
-                Some("install Android Studio, then set ANDROID_HOME to its SDK directory"),
-            ));
-        }
+        add_android_checks(&mut checks);
     } else {
         checks.push(doctor_check(
             "android",
@@ -3749,6 +3795,38 @@ const DAEMON_SERVICE_LABEL: &str = "build.oore.oored";
 const WEB_SERVICE_LABEL: &str = "build.oore.oore-web";
 const RUNNER_SERVICE_LABEL: &str = "build.oore.oore-runner";
 
+fn managed_runner_update_service_from_program_arguments(
+    install_root: &Path,
+    runner_is_managed: bool,
+    program_arguments: &[String],
+) -> Option<&'static str> {
+    if !runner_is_managed {
+        return None;
+    }
+    let configured = fs::canonicalize(Path::new(program_arguments.first()?)).ok()?;
+    let installed = fs::canonicalize(install_root.join("bin/oore")).ok()?;
+    (configured == installed).then_some(RUNNER_SERVICE_LABEL)
+}
+
+fn managed_runner_update_service(
+    install_root: &Path,
+    runner_is_managed: bool,
+) -> anyhow::Result<Option<&'static str>> {
+    if !runner_is_managed {
+        return Ok(None);
+    }
+    let (plist, _) = managed_service_plist(RUNNER_SERVICE_LABEL)?;
+    if !plist.is_file() {
+        return Ok(None);
+    }
+    let program_arguments = plist_program_arguments(&plist)?;
+    Ok(managed_runner_update_service_from_program_arguments(
+        install_root,
+        true,
+        &program_arguments,
+    ))
+}
+
 fn launchd_xml_escape(value: &str) -> String {
     value
         .replace('&', "&amp;")
@@ -4172,8 +4250,11 @@ fn copy_release_snapshot(install_root: &Path, snapshot: &Path) -> anyhow::Result
         "bin/oored",
         "bin/oore-web",
         "VERSION",
+        "WEB_VERSION",
         "CHANNEL",
+        "WEB_CHANNEL",
         "GITHUB_REPO",
+        "WEB_GITHUB_REPO",
         "LICENSE",
     ] {
         let source = install_root.join(relative);
@@ -4249,8 +4330,11 @@ fn restore_release_snapshot(install_root: &Path, snapshot: &Path) -> anyhow::Res
         "bin/oored",
         "bin/oore-web",
         "VERSION",
+        "WEB_VERSION",
         "CHANNEL",
+        "WEB_CHANNEL",
         "GITHUB_REPO",
+        "WEB_GITHUB_REPO",
         "LICENSE",
     ] {
         let source = snapshot.join(relative);
@@ -4290,7 +4374,13 @@ fn install_staged_release(
     }
     let web = stage.join("web-dist");
     if web.is_dir() {
+        let version = stage.join("VERSION");
+        if version.is_file() {
+            atomic_replace_file(&version, &install_root.join("WEB_VERSION"), false)?;
+        }
         atomic_replace_directory(&web, &install_root.join("web-dist"))?;
+        fs::write(install_root.join("WEB_CHANNEL"), channel.as_str())?;
+        fs::write(install_root.join("WEB_GITHUB_REPO"), repo)?;
     }
     let license = stage.join("LICENSE");
     if license.is_file() {
@@ -4309,6 +4399,128 @@ where
     tokio::task::spawn_blocking(operation)
         .await
         .context("blocking update step failed")?
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ReleaseActivation {
+    Installed,
+    Restored,
+}
+
+struct UpdateServicePlan {
+    defer_daemon_restart: bool,
+    daemon_is_managed: bool,
+    unmanaged_daemon_listen: Option<String>,
+    daemon_should_be_running: bool,
+    daemon_ready_url: String,
+    runner_service: Option<&'static str>,
+    web_is_managed: bool,
+    web_was_running: bool,
+    web_ready_url: Option<String>,
+}
+
+trait UpdateServiceControl {
+    fn restart_managed_service(&mut self, label: &str) -> anyhow::Result<()>;
+
+    async fn restart_unmanaged_daemon(&mut self, listen: &str) -> anyhow::Result<()>;
+
+    async fn wait_for_endpoint(&mut self, url: &str, name: &str) -> anyhow::Result<()>;
+}
+
+struct LiveUpdateServiceControl<'a> {
+    install_root: &'a Path,
+    daemon_url: &'a str,
+    client: &'a reqwest::Client,
+}
+
+impl UpdateServiceControl for LiveUpdateServiceControl<'_> {
+    fn restart_managed_service(&mut self, label: &str) -> anyhow::Result<()> {
+        restart_launchd_service(label)
+    }
+
+    async fn restart_unmanaged_daemon(&mut self, listen: &str) -> anyhow::Result<()> {
+        restart_daemon(self.install_root, listen, self.daemon_url, self.client).await
+    }
+
+    async fn wait_for_endpoint(&mut self, url: &str, name: &str) -> anyhow::Result<()> {
+        wait_for_endpoint(self.client, url, name).await
+    }
+}
+
+impl UpdateServicePlan {
+    async fn activate<C: UpdateServiceControl>(
+        &self,
+        control: &mut C,
+        activation: ReleaseActivation,
+    ) -> anyhow::Result<()> {
+        if self.daemon_is_managed && !self.defer_daemon_restart {
+            control.restart_managed_service(DAEMON_SERVICE_LABEL)?;
+        } else if let Some(listen) = &self.unmanaged_daemon_listen {
+            control.restart_unmanaged_daemon(listen).await?;
+        }
+        if self.daemon_should_be_running && !self.defer_daemon_restart {
+            let name = if activation == ReleaseActivation::Restored {
+                "rollback oored"
+            } else {
+                "oored"
+            };
+            control
+                .wait_for_endpoint(&self.daemon_ready_url, name)
+                .await?;
+        }
+        if let Some(label) = self.runner_service {
+            control.restart_managed_service(label)?;
+        }
+        if self.web_is_managed {
+            control.restart_managed_service(WEB_SERVICE_LABEL)?;
+        } else if self.web_was_running && activation == ReleaseActivation::Installed {
+            anyhow::bail!(
+                "refusing to replace an unmanaged local web process; install it as the launchd service first"
+            );
+        }
+        if let Some(url) = &self.web_ready_url {
+            let name = if activation == ReleaseActivation::Restored {
+                "rollback oore-web"
+            } else {
+                "oore-web"
+            };
+            control.wait_for_endpoint(url, name).await?;
+        }
+        Ok(())
+    }
+}
+
+async fn install_release_with_rollback<C: UpdateServiceControl>(
+    staged_release: &Path,
+    install_root: &Path,
+    previous_release: &Path,
+    channel: ReleaseChannel,
+    repo: &str,
+    services: &UpdateServicePlan,
+    control: &mut C,
+) -> anyhow::Result<()> {
+    let update_result = async {
+        install_staged_release(staged_release, install_root, channel, repo)?;
+        services
+            .activate(control, ReleaseActivation::Installed)
+            .await
+    }
+    .await;
+    if let Err(error) = update_result {
+        eprintln!("Update failed; restoring the previous release...");
+        let rollback = async {
+            restore_release_snapshot(install_root, previous_release)?;
+            services
+                .activate(control, ReleaseActivation::Restored)
+                .await
+        }
+        .await;
+        if let Err(rollback_error) = rollback {
+            return Err(error.context(format!("rollback also failed: {rollback_error}")));
+        }
+        return Err(error);
+    }
+    Ok(())
 }
 
 async fn handle_update(args: UpdateArgs) -> anyhow::Result<()> {
@@ -4487,6 +4699,10 @@ async fn handle_update(args: UpdateArgs) -> anyhow::Result<()> {
     };
     let daemon_should_be_running = daemon_is_managed || daemon_was_running;
     let daemon_ready_url = endpoint_url(&daemon_url, "/readyz");
+    let runner_is_managed = launchd_service_loaded(RUNNER_SERVICE_LABEL);
+    let runner_update_service = managed_runner_update_service(&install_root, runner_is_managed)?;
+    let runner_is_system_managed =
+        runner_update_service.is_some() && managed_service_plist(RUNNER_SERVICE_LABEL)?.1;
 
     let web_is_managed = launchd_service_loaded(WEB_SERVICE_LABEL);
     let web_ready_url = web_is_managed
@@ -4506,6 +4722,7 @@ async fn handle_update(args: UpdateArgs) -> anyhow::Result<()> {
     let system_service_restart_required = (!defer_daemon_restart
         && daemon_is_managed
         && managed_service_plist(DAEMON_SERVICE_LABEL)?.1)
+        || runner_is_system_managed
         || (web_is_managed && managed_service_plist(WEB_SERVICE_LABEL)?.1);
     if system_service_restart_required {
         authorize_system_service_restart()?;
@@ -4518,53 +4735,32 @@ async fn handle_update(args: UpdateArgs) -> anyhow::Result<()> {
 
     // 10. Atomically install the staged release and only retain it if every
     // readiness check succeeds. On any failure, restore the prior release.
-    let update_result = async {
-        install_staged_release(&staged_release, &install_root, channel, &repo)?;
-        if daemon_is_managed && !defer_daemon_restart {
-            restart_launchd_service(DAEMON_SERVICE_LABEL)?;
-        } else if let Some(listen) = &unmanaged_daemon_listen {
-            restart_daemon(&install_root, listen, &daemon_url, &client).await?;
-        }
-        if daemon_should_be_running && !defer_daemon_restart {
-            wait_for_endpoint(&client, &daemon_ready_url, "oored").await?;
-        }
-        if web_is_managed {
-            restart_launchd_service(WEB_SERVICE_LABEL)?;
-        } else if web_was_running {
-            anyhow::bail!("refusing to replace an unmanaged local web process; install it as the launchd service first");
-        }
-        if let Some(url) = &web_ready_url {
-            wait_for_endpoint(&client, url, "oore-web").await?;
-        }
-        Ok::<(), anyhow::Error>(())
-    }
-    .await;
-    if let Err(error) = update_result {
-        eprintln!("Update failed; restoring the previous release...");
-        let rollback = async {
-            restore_release_snapshot(&install_root, &previous_release)?;
-            if daemon_is_managed && !defer_daemon_restart {
-                restart_launchd_service(DAEMON_SERVICE_LABEL)?;
-            } else if let Some(listen) = &unmanaged_daemon_listen {
-                restart_daemon(&install_root, listen, &daemon_url, &client).await?;
-            }
-            if daemon_should_be_running && !defer_daemon_restart {
-                wait_for_endpoint(&client, &daemon_ready_url, "rollback oored").await?;
-            }
-            if web_is_managed {
-                restart_launchd_service(WEB_SERVICE_LABEL)?;
-            }
-            if let Some(url) = &web_ready_url {
-                wait_for_endpoint(&client, url, "rollback oore-web").await?;
-            }
-            Ok::<(), anyhow::Error>(())
-        }
-        .await;
-        if let Err(rollback_error) = rollback {
-            return Err(error.context(format!("rollback also failed: {rollback_error}")));
-        }
-        return Err(error);
-    }
+    let services = UpdateServicePlan {
+        defer_daemon_restart,
+        daemon_is_managed,
+        unmanaged_daemon_listen,
+        daemon_should_be_running,
+        daemon_ready_url,
+        runner_service: runner_update_service,
+        web_is_managed,
+        web_was_running,
+        web_ready_url,
+    };
+    let mut control = LiveUpdateServiceControl {
+        install_root: &install_root,
+        daemon_url: &daemon_url,
+        client: &client,
+    };
+    install_release_with_rollback(
+        &staged_release,
+        &install_root,
+        &previous_release,
+        channel,
+        &repo,
+        &services,
+        &mut control,
+    )
+    .await?;
     println!("Updated to version {latest}.");
 
     // 12. Note about current process
@@ -4769,6 +4965,255 @@ mod tests {
     }
 
     #[test]
+    fn managed_runner_restart_requires_the_installed_oore_executable() {
+        let temp = tempfile::tempdir().unwrap();
+        let install = temp.path().join("install");
+        let managed_oore = install.join("bin/oore");
+        let managed_oore_alias = temp.path().join("managed-oore-alias");
+        let unrelated_oore = temp.path().join("other/oore");
+        fs::create_dir_all(managed_oore.parent().unwrap()).unwrap();
+        fs::create_dir_all(unrelated_oore.parent().unwrap()).unwrap();
+        fs::write(&managed_oore, "managed").unwrap();
+        fs::write(&unrelated_oore, "unrelated").unwrap();
+        std::os::unix::fs::symlink(&managed_oore, &managed_oore_alias).unwrap();
+
+        assert_eq!(
+            managed_runner_update_service_from_program_arguments(
+                &install,
+                true,
+                &[
+                    managed_oore_alias.display().to_string(),
+                    "runner".to_string(),
+                ],
+            ),
+            Some(RUNNER_SERVICE_LABEL)
+        );
+        assert_eq!(
+            managed_runner_update_service_from_program_arguments(
+                &install,
+                true,
+                &[unrelated_oore.display().to_string(), "runner".to_string()],
+            ),
+            None
+        );
+        assert_eq!(
+            managed_runner_update_service_from_program_arguments(
+                &install,
+                false,
+                &[managed_oore.display().to_string(), "runner".to_string()],
+            ),
+            None
+        );
+    }
+
+    struct RecordingUpdateServiceControl {
+        install_root: PathBuf,
+        restarts: Vec<(String, String)>,
+        fail_service_once: Option<&'static str>,
+    }
+
+    impl UpdateServiceControl for RecordingUpdateServiceControl {
+        fn restart_managed_service(&mut self, label: &str) -> anyhow::Result<()> {
+            let binary = fs::read_to_string(self.install_root.join("bin/oore"))?;
+            self.restarts.push((label.to_string(), binary));
+            if self.fail_service_once == Some(label) {
+                self.fail_service_once = None;
+                anyhow::bail!("injected {label} restart failure");
+            }
+            Ok(())
+        }
+
+        async fn restart_unmanaged_daemon(&mut self, _listen: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn wait_for_endpoint(&mut self, _url: &str, _name: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn deferred_daemon_update_plan(web_is_managed: bool) -> UpdateServicePlan {
+        UpdateServicePlan {
+            defer_daemon_restart: true,
+            daemon_is_managed: true,
+            unmanaged_daemon_listen: None,
+            daemon_should_be_running: true,
+            daemon_ready_url: "http://127.0.0.1:8787/readyz".to_string(),
+            runner_service: Some(RUNNER_SERVICE_LABEL),
+            web_is_managed,
+            web_was_running: false,
+            web_ready_url: None,
+        }
+    }
+
+    fn prepare_update_transaction() -> (tempfile::TempDir, PathBuf, PathBuf, PathBuf) {
+        let temp = tempfile::tempdir().unwrap();
+        let install = temp.path().join("install");
+        let stage = temp.path().join("stage");
+        let snapshot = temp.path().join("snapshot");
+        fs::create_dir_all(install.join("bin")).unwrap();
+        fs::create_dir_all(stage.join("bin")).unwrap();
+        fs::write(install.join("bin/oore"), "old-binary").unwrap();
+        fs::write(install.join("VERSION"), "1.0.0").unwrap();
+        fs::write(stage.join("bin/oore"), "new-binary").unwrap();
+        fs::write(stage.join("VERSION"), "2.0.0").unwrap();
+        copy_release_snapshot(&install, &snapshot).unwrap();
+        (temp, install, stage, snapshot)
+    }
+
+    #[test]
+    fn deferred_daemon_update_still_restarts_the_updated_runner() {
+        let (_temp, install, stage, snapshot) = prepare_update_transaction();
+        let mut control = RecordingUpdateServiceControl {
+            install_root: install.clone(),
+            restarts: Vec::new(),
+            fail_service_once: None,
+        };
+
+        tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(install_release_with_rollback(
+                &stage,
+                &install,
+                &snapshot,
+                ReleaseChannel::Stable,
+                "oorebuild/oore",
+                &deferred_daemon_update_plan(false),
+                &mut control,
+            ))
+            .unwrap();
+
+        assert_eq!(
+            control.restarts,
+            vec![(RUNNER_SERVICE_LABEL.to_string(), "new-binary".to_string())]
+        );
+    }
+
+    #[test]
+    fn failed_update_restarts_the_runner_after_restoring_the_old_binary() {
+        let (_temp, install, stage, snapshot) = prepare_update_transaction();
+        let mut control = RecordingUpdateServiceControl {
+            install_root: install.clone(),
+            restarts: Vec::new(),
+            fail_service_once: Some(WEB_SERVICE_LABEL),
+        };
+
+        let error = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(install_release_with_rollback(
+                &stage,
+                &install,
+                &snapshot,
+                ReleaseChannel::Stable,
+                "oorebuild/oore",
+                &deferred_daemon_update_plan(true),
+                &mut control,
+            ))
+            .unwrap_err();
+
+        assert!(error.to_string().contains("injected"));
+        assert_eq!(
+            control.restarts,
+            vec![
+                (RUNNER_SERVICE_LABEL.to_string(), "new-binary".to_string()),
+                (WEB_SERVICE_LABEL.to_string(), "new-binary".to_string()),
+                (RUNNER_SERVICE_LABEL.to_string(), "old-binary".to_string()),
+                (WEB_SERVICE_LABEL.to_string(), "old-binary".to_string()),
+            ]
+        );
+        assert_eq!(
+            fs::read_to_string(install.join("bin/oore")).unwrap(),
+            "old-binary"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn android_doctor_runtime_helper() {
+        let Some(expected_sdk) = std::env::var_os("OORE_DOCTOR_EXPECTED_SDK_ROOT") else {
+            return;
+        };
+        let expected_java_home =
+            PathBuf::from(std::env::var_os("OORE_DOCTOR_EXPECTED_JAVA_HOME").unwrap());
+        let mut checks = Vec::new();
+        add_android_checks(&mut checks);
+
+        let java = checks.iter().find(|check| check.name == "java").unwrap();
+        assert_eq!(java.status, "ok");
+        assert!(
+            java.detail
+                .as_deref()
+                .unwrap_or_default()
+                .contains(&expected_java_home.join("bin/java").display().to_string()),
+            "unexpected Java detail: {:?}",
+            java.detail
+        );
+        let sdk = checks
+            .iter()
+            .find(|check| check.name == "android_sdk")
+            .unwrap();
+        assert_eq!(sdk.status, "ok");
+        assert_eq!(sdk.detail.as_deref(), Path::new(&expected_sdk).to_str());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn android_doctor_supports_launchd_defaults_and_valid_explicit_overrides() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().join("home");
+        let default_sdk = home.join("Library/Android/sdk");
+        let default_java_home =
+            home.join("Applications/Android Studio.app/Contents/jbr/Contents/Home");
+        let explicit_sdk = temp.path().join("explicit-sdk");
+        let explicit_java_home = temp.path().join("explicit-jdk");
+
+        for sdk in [&default_sdk, &explicit_sdk] {
+            let adb = sdk.join("platform-tools/adb");
+            fs::create_dir_all(adb.parent().unwrap()).unwrap();
+            fs::write(adb, "synthetic adb").unwrap();
+        }
+        for java_home in [&default_java_home, &explicit_java_home] {
+            for (tool, contents) in [
+                ("java", "#!/bin/sh\necho 'synthetic Java 21' >&2\n"),
+                ("jarsigner", "#!/bin/sh\nexit 0\n"),
+            ] {
+                let path = java_home.join("bin").join(tool);
+                fs::create_dir_all(path.parent().unwrap()).unwrap();
+                fs::write(&path, contents).unwrap();
+                set_executable(&path).unwrap();
+            }
+        }
+
+        for (configured, expected_sdk, expected_java_home) in [
+            (false, &default_sdk, &default_java_home),
+            (true, &explicit_sdk, &explicit_java_home),
+        ] {
+            let mut command = std::process::Command::new(std::env::current_exe().unwrap());
+            command
+                .args(["--exact", "tests::android_doctor_runtime_helper"])
+                .env_remove("ANDROID_HOME")
+                .env_remove("ANDROID_SDK_ROOT")
+                .env_remove("JAVA_HOME")
+                .env("HOME", &home)
+                .env("PATH", "/usr/bin:/bin")
+                .env("OORE_DOCTOR_EXPECTED_SDK_ROOT", expected_sdk)
+                .env("OORE_DOCTOR_EXPECTED_JAVA_HOME", expected_java_home);
+            if configured {
+                command
+                    .env("ANDROID_HOME", &explicit_sdk)
+                    .env("JAVA_HOME", &explicit_java_home);
+            }
+            let output = command.output().unwrap();
+            assert!(
+                output.status.success(),
+                "isolated doctor helper failed:\n{}\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+
+    #[test]
     fn command_timeout_stops_stalled_service_commands() {
         let mut command = std::process::Command::new("sh");
         command.args(["-c", "sleep 1"]);
@@ -4832,6 +5277,18 @@ mod tests {
             fs::read_to_string(install.join("VERSION")).unwrap(),
             "2.0.0"
         );
+        assert_eq!(
+            fs::read_to_string(install.join("WEB_VERSION")).unwrap(),
+            "2.0.0"
+        );
+        assert_eq!(
+            fs::read_to_string(install.join("WEB_CHANNEL")).unwrap(),
+            "stable"
+        );
+        assert_eq!(
+            fs::read_to_string(install.join("WEB_GITHUB_REPO")).unwrap(),
+            "oorebuild/oore"
+        );
 
         restore_release_snapshot(&install, &snapshot).unwrap();
         assert_eq!(
@@ -4842,6 +5299,9 @@ mod tests {
             fs::read_to_string(install.join("VERSION")).unwrap(),
             "1.0.0"
         );
+        assert!(!install.join("WEB_VERSION").exists());
+        assert!(!install.join("WEB_CHANNEL").exists());
+        assert!(!install.join("WEB_GITHUB_REPO").exists());
         assert_eq!(
             fs::read_to_string(install.join("web-dist/index.html")).unwrap(),
             "old-web"

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -14,6 +14,12 @@ Rules:
 
 ## 2026-07-17
 
+- **Managed runner updates and Android JDK discovery**:
+  - Runner-owned Android signing now resolves and canonicalizes one host SDK/JDK toolchain before checkout from an explicit valid configuration, the standard macOS SDK location, Android Studio's bundled runtime, or the macOS Java registry. Repository stages cannot write the pinned SDK/JDK paths; AAB preprocessing pins the system `zip`; and signer children use only pinned executables plus fixed system paths, so APK `apksigner` and AAB `jarsigner` work under launchd without accepting repository-controlled helpers. `oore doctor --platform android` recognizes the same standard launchd-compatible topology.
+  - Full managed updates now restart only the loaded runner whose launchd executable matches the `oore` binary being replaced, including web-triggered deferred-daemon updates, and repeat that restart after rollback restores the old binary. Frontend-only updates use component-scoped version, channel, and repository metadata with legacy fallbacks, preventing them from making an old backend or runner appear current. Backend-only installer runs preserve any existing frontend binary, assets, and component metadata instead of leaving its managed service broken.
+  - Product Trust feature doc: https://linear.app/oorebuild/document/feature-product-trust-hardening-release-592dfc525e77
+  - Runtime updates feature doc: https://linear.app/oorebuild/document/feature-runtime-updates-from-the-web-ui-6b648f19a3f9
+
 - **macOS managed-runner Android signing tool discovery**:
   - Runner-owned Android signing now finds `apksigner` in the standard per-user macOS SDK directory when launchd does not provide `ANDROID_HOME` or `ANDROID_SDK_ROOT`. Explicit SDK variables still take precedence, repository-controlled paths remain excluded, and signer launch failures now name the unresolved program.
   - Product Trust feature doc: https://linear.app/oorebuild/document/feature-product-trust-hardening-release-592dfc525e77

--- a/scripts/install-acceptance.sh
+++ b/scripts/install-acceptance.sh
@@ -47,6 +47,67 @@ new_inode="$(ls -di "$atomic_dir/oored" | awk '{print $1}')"
 [[ "$(< "$atomic_dir/oored")" == "new" ]]
 rm -rf "$atomic_dir"
 
+metadata_dir="$(mktemp -d)"
+version_file="$metadata_dir/release-version"
+printf '2.0.0\n' > "$version_file"
+OORE_INSTALL_ROOT="$metadata_dir"
+RESOLVED_CHANNEL=alpha
+OORE_GITHUB_REPO=oore-ci/oore.build
+
+printf '1.0.0\n' > "$metadata_dir/VERSION"
+printf 'stable\n' > "$metadata_dir/CHANNEL"
+printf 'backend/repository\n' > "$metadata_dir/GITHUB_REPO"
+OORE_INSTALL_MODE=frontend
+install_release_metadata "$version_file"
+[[ "$(< "$metadata_dir/VERSION")" == "1.0.0" ]]
+[[ "$(< "$metadata_dir/CHANNEL")" == "stable" ]]
+[[ "$(< "$metadata_dir/GITHUB_REPO")" == "backend/repository" ]]
+[[ "$(< "$metadata_dir/WEB_VERSION")" == "2.0.0" ]]
+[[ "$(< "$metadata_dir/WEB_CHANNEL")" == "alpha" ]]
+[[ "$(< "$metadata_dir/WEB_GITHUB_REPO")" == "oore-ci/oore.build" ]]
+
+rm -rf "$metadata_dir"
+
+transition_dir="$(mktemp -d)"
+release_dir="$transition_dir/release"
+TMP_DIR="$transition_dir/download"
+OORE_INSTALL_ROOT="$transition_dir/install"
+BIN_DIR="$OORE_INSTALL_ROOT/bin"
+LOG_DIR="$OORE_INSTALL_ROOT/logs"
+WEB_BINARY="$BIN_DIR/oore-web"
+WEB_DIST_DIR="$OORE_INSTALL_ROOT/web-dist"
+mkdir -p "$release_dir/bin" "$TMP_DIR" "$BIN_DIR" "$WEB_DIST_DIR"
+printf 'new-oored\n' > "$release_dir/bin/oored"
+printf 'new-oore\n' > "$release_dir/bin/oore"
+chmod +x "$release_dir/bin/oored" "$release_dir/bin/oore"
+printf '2.0.0\n' > "$release_dir/VERSION"
+printf 'old-oore-web\n' > "$WEB_BINARY"
+chmod +x "$WEB_BINARY"
+printf 'old-web-dist\n' > "$WEB_DIST_DIR/index.html"
+printf '1.5.0\n' > "$OORE_INSTALL_ROOT/WEB_VERSION"
+printf 'beta\n' > "$OORE_INSTALL_ROOT/WEB_CHANNEL"
+printf 'frontend/repository\n' > "$OORE_INSTALL_ROOT/WEB_GITHUB_REPO"
+OORE_INSTALL_MODE=backend
+RELEASE_VERSION=2.0.0
+RELEASE_OS=darwin
+RELEASE_ARCH=arm64
+RESOLVED_CHANNEL=alpha
+OORE_GITHUB_REPO=oore-ci/oore.build
+tar -czf "$TMP_DIR/$(release_archive_name)" -C "$release_dir" .
+install_binaries
+[[ "$(< "$BIN_DIR/oored")" == "new-oored" ]]
+[[ "$(< "$BIN_DIR/oore")" == "new-oore" ]]
+[[ "$(< "$WEB_BINARY")" == "old-oore-web" ]]
+[[ "$(< "$WEB_DIST_DIR/index.html")" == "old-web-dist" ]]
+[[ "$(< "$OORE_INSTALL_ROOT/VERSION")" == "2.0.0" ]]
+[[ "$(< "$OORE_INSTALL_ROOT/CHANNEL")" == "alpha" ]]
+[[ "$(< "$OORE_INSTALL_ROOT/GITHUB_REPO")" == "oore-ci/oore.build" ]]
+[[ "$(< "$OORE_INSTALL_ROOT/WEB_VERSION")" == "1.5.0" ]]
+[[ "$(< "$OORE_INSTALL_ROOT/WEB_CHANNEL")" == "beta" ]]
+[[ "$(< "$OORE_INSTALL_ROOT/WEB_GITHUB_REPO")" == "frontend/repository" ]]
+[[ "$(< "$OORE_INSTALL_ROOT/INSTALL_MODE")" == "backend" ]]
+rm -rf "$transition_dir"
+
 sudo_call="$(mktemp)"
 oored_call="$(mktemp)"
 service_bin_dir="$(mktemp -d)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1448,6 +1448,24 @@ install_executable() {
   mv -f "$staged" "$destination"
 }
 
+install_release_metadata() {
+  local version_file="$1"
+  if is_daemon_install; then
+    cp "$version_file" "$OORE_INSTALL_ROOT/VERSION"
+    if [[ -n "${RESOLVED_CHANNEL:-}" ]]; then
+      printf '%s\n' "$RESOLVED_CHANNEL" > "$OORE_INSTALL_ROOT/CHANNEL"
+    fi
+    printf '%s\n' "$OORE_GITHUB_REPO" > "$OORE_INSTALL_ROOT/GITHUB_REPO"
+  fi
+  if is_web_install; then
+    cp "$version_file" "$OORE_INSTALL_ROOT/WEB_VERSION"
+    if [[ -n "${RESOLVED_CHANNEL:-}" ]]; then
+      printf '%s\n' "$RESOLVED_CHANNEL" > "$OORE_INSTALL_ROOT/WEB_CHANNEL"
+    fi
+    printf '%s\n' "$OORE_GITHUB_REPO" > "$OORE_INSTALL_ROOT/WEB_GITHUB_REPO"
+  fi
+}
+
 install_binaries() {
   local archive_name
   local extract_dir="$TMP_DIR/extract"
@@ -1475,17 +1493,10 @@ install_binaries() {
     install_executable "$extract_dir/bin/oore-web" "$WEB_BINARY"
     rm -rf "$WEB_DIST_DIR"
     cp -R "$extract_dir/web-dist" "$WEB_DIST_DIR"
-  else
-    rm -f "$WEB_BINARY"
-    rm -rf "$WEB_DIST_DIR"
   fi
 
-  cp "$extract_dir/VERSION" "$OORE_INSTALL_ROOT/VERSION"
+  install_release_metadata "$extract_dir/VERSION"
   printf '%s\n' "$OORE_INSTALL_MODE" > "$OORE_INSTALL_ROOT/INSTALL_MODE"
-  if [[ -n "${RESOLVED_CHANNEL:-}" ]]; then
-    printf '%s\n' "$RESOLVED_CHANNEL" > "$OORE_INSTALL_ROOT/CHANNEL"
-  fi
-  printf '%s\n' "$OORE_GITHUB_REPO" > "$OORE_INSTALL_ROOT/GITHUB_REPO"
   if [[ -f "$extract_dir/LICENSE" ]]; then
     cp "$extract_dir/LICENSE" "$OORE_INSTALL_ROOT/LICENSE"
   fi


### PR DESCRIPTION
## What changed

- Resolve and canonicalize the macOS Android SDK/JDK toolchain before repository checkout, prevent repository stages from changing the pinned tools, pin system `zip` for AAB preprocessing, and launch signers with deterministic paths.
- Teach Android doctor and runner-owned APK/AAB signing to use Android Studio's bundled JBR and the standard per-user Android SDK under a launchd-style environment.
- Restart only the matching managed runner after full backend updates and rollbacks, including web-triggered deferred-daemon updates.
- Keep frontend release metadata separate from backend/runner metadata, and preserve an existing frontend component during backend-only installer runs.

## Root cause

The managed runner LaunchAgent intentionally receives a minimal environment. Flutter could locate Android Studio's JBR for the build, but the SDK `apksigner` wrapper later executed bare `java`, which reached Apple's missing-runtime shim. Separately, atomically replacing the shared `oore` executable did not reload the already-running runner process, and frontend-only updates advanced metadata shared with the backend.

## Validation

- `make validate`
- `cargo test -p oore-runner` (72 passed, including real `/usr/bin/git`, signer isolation, toolchain write denial, and hostile-`PATH` AAB preprocessing)
- Real installed `apksigner` + `jarsigner` smoke with Java/SDK overrides removed and a launchd-like `PATH`
- `cargo test -p oore --bin oore` (16 passed)
- `bash scripts/install-acceptance.sh`
- `bun run docs:check`

## Rollout note

The alpha.5 updater predates runner restart support, so alpha.5 to this release needs one final runner kickstart after the UI update. Updates performed by this release and later restart the matching runner automatically.
