### PR TITLE
fix(web): simplify source trust controls

### DIFF
--- a/apps/web/src/components/collection-search-input.test.tsx
+++ b/apps/web/src/components/collection-search-input.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { CollectionSearchInput } from './collection-search-input'
+
+describe('CollectionSearchInput', () => {
+  it('keeps focus when the URL-backed value catches up and resets in place', () => {
+    const { rerender } = render(
+      <CollectionSearchInput
+        ariaLabel="Search repositories"
+        initialValue=""
+        onSearch={vi.fn()}
+        placeholder="Search repositories"
+      />,
+    )
+    const input = screen.getByRole('searchbox')
+    input.focus()
+    expect(document.activeElement).toBe(input)
+    fireEvent.change(input, { target: { value: 'native' } })
+
+    rerender(
+      <CollectionSearchInput
+        ariaLabel="Search repositories"
+        initialValue="native"
+        onSearch={vi.fn()}
+        placeholder="Search repositories"
+      />,
+    )
+    expect(screen.getByRole('searchbox')).toBe(input)
+    expect(document.activeElement).toBe(input)
+
+    rerender(
+      <CollectionSearchInput
+        ariaLabel="Search repositories"
+        initialValue=""
+        onSearch={vi.fn()}
+        placeholder="Search repositories"
+      />,
+    )
+    expect((screen.getByRole('searchbox') as HTMLInputElement).value).toBe('')
+  })
+})

--- a/apps/web/src/components/collection-search-input.tsx
+++ b/apps/web/src/components/collection-search-input.tsx
@@ -20,7 +20,13 @@ export function CollectionSearchInput({
   placeholder: string
 }) {
   const [value, setValue] = useState(initialValue)
+  const [lastExternalValue, setLastExternalValue] = useState(initialValue)
   const debouncedSearch = useDebouncedCallback(onSearch, 300)
+
+  if (initialValue !== lastExternalValue) {
+    setLastExternalValue(initialValue)
+    setValue(initialValue)
+  }
 
   return (
     <div className={cn('relative w-full sm:max-w-sm', className)}>

--- a/apps/web/src/components/direct-runner-policy-banner-utils.ts
+++ b/apps/web/src/components/direct-runner-policy-banner-utils.ts
@@ -1,0 +1,20 @@
+export const DIRECT_RUNNER_TRUST_NOTICE_VERSION = 'direct-runner-protocol-4'
+
+export function directRunnerTrustNoticeKey(
+  instanceId: string,
+  userId: string,
+): string {
+  return `${DIRECT_RUNNER_TRUST_NOTICE_VERSION}:${instanceId}:${userId}`
+}
+
+export function shouldShowDirectRunnerTrustNotice(
+  role: string | undefined,
+  noticeKey: string | null,
+  acknowledgements: Record<string, true>,
+): boolean {
+  return (
+    (role === 'owner' || role === 'admin') &&
+    noticeKey !== null &&
+    !acknowledgements[noticeKey]
+  )
+}

--- a/apps/web/src/components/direct-runner-policy-banner.test.ts
+++ b/apps/web/src/components/direct-runner-policy-banner.test.ts
@@ -1,36 +1,46 @@
 import { describe, expect, it } from 'vitest'
 
-import { needsDirectRunnerPolicySetup } from './direct-runner-policy-banner'
+import {
+  DIRECT_RUNNER_TRUST_NOTICE_VERSION,
+  directRunnerTrustNoticeKey,
+  shouldShowDirectRunnerTrustNotice,
+} from './direct-runner-policy-banner-utils'
 
-describe('direct runner policy banner', () => {
-  it('stays visible until the instance and every known repository are approved', () => {
+describe('direct runner trust notice', () => {
+  it('keys acknowledgement by notice version, instance, and user', () => {
+    expect(directRunnerTrustNoticeKey('instance-1', 'user-1')).toBe(
+      `${DIRECT_RUNNER_TRUST_NOTICE_VERSION}:instance-1:user-1`,
+    )
+  })
+
+  it('shows once to owners and admins', () => {
+    const key = directRunnerTrustNoticeKey('instance-1', 'user-1')
+
+    expect(shouldShowDirectRunnerTrustNotice('owner', key, {})).toBe(true)
+    expect(shouldShowDirectRunnerTrustNotice('admin', key, {})).toBe(true)
     expect(
-      needsDirectRunnerPolicySetup({
-        instanceEnabled: false,
-        repositoriesKnown: true,
-        unapprovedRepositoryCount: 0,
-      }),
-    ).toBe(true)
-    expect(
-      needsDirectRunnerPolicySetup({
-        instanceEnabled: true,
-        repositoriesKnown: true,
-        unapprovedRepositoryCount: 1,
-      }),
-    ).toBe(true)
-    expect(
-      needsDirectRunnerPolicySetup({
-        instanceEnabled: true,
-        repositoriesKnown: false,
-        unapprovedRepositoryCount: 0,
-      }),
-    ).toBe(true)
-    expect(
-      needsDirectRunnerPolicySetup({
-        instanceEnabled: true,
-        repositoriesKnown: true,
-        unapprovedRepositoryCount: 0,
-      }),
+      shouldShowDirectRunnerTrustNotice('owner', key, { [key]: true }),
     ).toBe(false)
+  })
+
+  it('does not share acknowledgement across versions, instances, or users', () => {
+    const key = directRunnerTrustNoticeKey('instance-1', 'user-1')
+    const acknowledgements: Record<string, true> = {
+      'direct-runner-protocol-3:instance-1:user-1': true,
+      [directRunnerTrustNoticeKey('instance-2', 'user-1')]: true,
+      [directRunnerTrustNoticeKey('instance-1', 'user-2')]: true,
+    }
+
+    expect(
+      shouldShowDirectRunnerTrustNotice('owner', key, acknowledgements),
+    ).toBe(true)
+  })
+
+  it('never shows to roles that cannot configure runner policy', () => {
+    const key = directRunnerTrustNoticeKey('instance-1', 'user-1')
+
+    expect(shouldShowDirectRunnerTrustNotice('developer', key, {})).toBe(false)
+    expect(shouldShowDirectRunnerTrustNotice('viewer', key, {})).toBe(false)
+    expect(shouldShowDirectRunnerTrustNotice(undefined, key, {})).toBe(false)
   })
 })

--- a/apps/web/src/components/direct-runner-policy-banner.tsx
+++ b/apps/web/src/components/direct-runner-policy-banner.tsx
@@ -2,49 +2,40 @@ import { Link } from '@tanstack/react-router'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { Alert02Icon } from '@hugeicons/core-free-icons'
 
-import { useInstancePreferences } from '@/hooks/use-artifact-storage'
-import { useRunnerPolicyRepositories } from '@/hooks/use-source-repositories'
-import { useAuthStore } from '@/stores/auth-store'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
-
-export interface DirectRunnerPolicySummary {
-  instanceEnabled: boolean
-  repositoriesKnown: boolean
-  unapprovedRepositoryCount: number
-}
-
-export function needsDirectRunnerPolicySetup(
-  summary: DirectRunnerPolicySummary,
-): boolean {
-  return (
-    !summary.instanceEnabled ||
-    !summary.repositoriesKnown ||
-    summary.unapprovedRepositoryCount > 0
-  )
-}
+import { Button } from '@/components/ui/button'
+import { useAuthStore } from '@/stores/auth-store'
+import { useInstanceStore } from '@/stores/instance-store'
+import { useUiStore } from '@/stores/ui-store'
+import {
+  directRunnerTrustNoticeKey,
+  shouldShowDirectRunnerTrustNotice,
+} from './direct-runner-policy-banner-utils'
 
 export default function DirectRunnerPolicyBanner() {
-  const role = useAuthStore((state) => state.user?.role)
-  const canConfigure = role === 'owner' || role === 'admin'
-  const preferencesQuery = useInstancePreferences({ enabled: canConfigure })
-  const repositoriesQuery = useRunnerPolicyRepositories(canConfigure)
+  const user = useAuthStore((state) => state.user)
+  const activeInstanceId = useInstanceStore((state) => state.activeInstanceId)
+  const acknowledgements = useUiStore(
+    (state) => state.directRunnerTrustNoticeAcknowledgements,
+  )
+  const acknowledge = useUiStore(
+    (state) => state.acknowledgeDirectRunnerTrustNotice,
+  )
+  const noticeKey =
+    activeInstanceId && user
+      ? directRunnerTrustNoticeKey(activeInstanceId, user.user_id)
+      : null
 
-  if (!canConfigure) return null
-  if (preferencesQuery.isLoading || repositoriesQuery.isLoading) return null
-
-  const preferences = preferencesQuery.data?.preferences
-  const repositories = repositoriesQuery.data
-  const summary: DirectRunnerPolicySummary = {
-    instanceEnabled: preferences?.direct_macos_runner_enabled ?? false,
-    repositoriesKnown:
-      !preferencesQuery.isError && !repositoriesQuery.isError && !!repositories,
-    unapprovedRepositoryCount:
-      repositories?.filter(
-        (repository) => !repository.allow_direct_macos_runner,
-      ).length ?? 0,
+  if (
+    !shouldShowDirectRunnerTrustNotice(
+      user?.role,
+      noticeKey,
+      acknowledgements,
+    ) ||
+    noticeKey === null
+  ) {
+    return null
   }
-
-  if (!needsDirectRunnerPolicySetup(summary)) return null
 
   return (
     <Alert className="rounded-none border-x-0 border-t-0 border-warning/30 bg-warning/10 text-foreground">
@@ -54,25 +45,34 @@ export default function DirectRunnerPolicyBanner() {
         className="text-warning"
         aria-hidden
       />
-      <AlertTitle>Direct runner setup required</AlertTitle>
+      <AlertTitle>Direct runner access</AlertTitle>
       <AlertDescription className="flex flex-wrap items-center gap-x-3 gap-y-1">
         <span>
-          Build code now runs with the runner account&apos;s macOS permissions.
-          Enable the instance runner, then approve each trusted repository.
+          Build commands run with the runner account&apos;s macOS permissions.
+          Only repositories you allow can run; all others stay blocked.
         </span>
-        <span className="ml-auto flex items-center gap-3">
+        <span className="ml-auto flex flex-wrap items-center gap-3">
           <Link
             to="/settings/preferences"
             className="inline-flex min-h-11 items-center font-medium sm:min-h-0"
           >
-            Preferences
+            Runner settings
           </Link>
           <Link
             to="/settings/integrations"
             className="inline-flex min-h-11 items-center font-medium sm:min-h-0"
           >
-            Sources
+            Repository access
           </Link>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="min-h-11 sm:min-h-8"
+            onClick={() => acknowledge(noticeKey)}
+          >
+            Dismiss
+          </Button>
         </span>
       </AlertDescription>
     </Alert>

--- a/apps/web/src/hooks/use-integrations.ts
+++ b/apps/web/src/hooks/use-integrations.ts
@@ -113,9 +113,6 @@ export function useUpdateRepositoryRunnerPolicy(integrationId: string) {
         queryKey: [instance?.id ?? '__none__', 'all-repos-for-project'],
       })
       void queryClient.invalidateQueries({
-        queryKey: [instance?.id ?? '__none__', 'all-repos-for-runner-policy'],
-      })
-      void queryClient.invalidateQueries({
         queryKey: [instance?.id ?? '__none__', 'builds'],
       })
     },
@@ -147,9 +144,6 @@ export function useSyncInstallations() {
           'integration-repos',
           integrationId,
         ],
-      })
-      void queryClient.invalidateQueries({
-        queryKey: [instance?.id ?? '__none__', 'all-repos-for-runner-policy'],
       })
     },
   })

--- a/apps/web/src/hooks/use-source-repositories.test.ts
+++ b/apps/web/src/hooks/use-source-repositories.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import type { Integration, ListRepositoriesResponse } from '@/lib/types'
-import {
-  discoverSourceRepositories,
-  discoverSourceRepositoriesStrict,
-} from '@/hooks/use-source-repositories'
+import { discoverSourceRepositories } from '@/hooks/use-source-repositories'
 
 function integration(id: string): Integration {
   return {
@@ -87,17 +84,5 @@ describe('discoverSourceRepositories', () => {
     result.resolve(repositories('first'))
 
     await expect(discovered).rejects.toThrow('Cancelled source discovery')
-  })
-
-  it('fails closed when policy discovery cannot inspect every source', async () => {
-    await expect(
-      discoverSourceRepositoriesStrict(
-        [integration('first'), integration('second')],
-        (source) =>
-          source.id === 'second'
-            ? Promise.reject(new Error('Source unavailable'))
-            : Promise.resolve(repositories(source.id)),
-      ),
-    ).rejects.toThrow('Source unavailable')
   })
 })

--- a/apps/web/src/hooks/use-source-repositories.ts
+++ b/apps/web/src/hooks/use-source-repositories.ts
@@ -45,31 +45,6 @@ export async function discoverSourceRepositories(
   )
 }
 
-export async function discoverSourceRepositoriesStrict(
-  integrations: Array<Integration>,
-  listRepositories: (
-    integration: Integration,
-  ) => Promise<ListRepositoriesResponse>,
-  signal?: AbortSignal,
-): Promise<Array<SourceRepository>> {
-  signal?.throwIfAborted()
-  const results = await Promise.all(
-    integrations.map(async (integration) => {
-      signal?.throwIfAborted()
-      const response = await listRepositories(integration)
-      signal?.throwIfAborted()
-      return response.repositories.map((repository) => ({
-        ...repository,
-        integration_id: integration.id,
-        provider: integration.provider,
-        host_url: integration.host_url,
-      }))
-    }),
-  )
-  signal?.throwIfAborted()
-  return results.flat()
-}
-
 export function useSourceRepositories(enabled: boolean) {
   const instance = useActiveInstance()
   const token = useAuthStore((state) => state.token)
@@ -89,33 +64,6 @@ export function useSourceRepositories(enabled: boolean) {
         },
       )
       return discoverSourceRepositories(
-        integrations,
-        (integration) =>
-          listIntegrationRepos(baseUrl, token, integration.id, { signal }),
-        signal,
-      )
-    },
-    enabled: enabled && !!baseUrl && !!token,
-  })
-}
-
-export function useRunnerPolicyRepositories(enabled: boolean) {
-  const instance = useActiveInstance()
-  const token = useAuthStore((state) => state.token)
-  const baseUrl = resolveInstanceApiBaseUrl(instance)
-
-  return useQuery({
-    queryKey: [instance?.id ?? '__none__', 'all-repos-for-runner-policy'],
-    queryFn: async ({ signal }) => {
-      signal.throwIfAborted()
-      if (!baseUrl || !token) return []
-      const { integrations } = await listAllIntegrations(
-        baseUrl,
-        token,
-        undefined,
-        { signal },
-      )
-      return discoverSourceRepositoriesStrict(
         integrations,
         (integration) =>
           listIntegrationRepos(baseUrl, token, integration.id, { signal }),

--- a/apps/web/src/routes/settings/integrations/$integrationId.tsx
+++ b/apps/web/src/routes/settings/integrations/$integrationId.tsx
@@ -1,16 +1,11 @@
-import { createFileRoute, useNavigate, useSearch } from '@tanstack/react-router'
+import { useMemo, useState } from 'react'
+import { createFileRoute, useSearch } from '@tanstack/react-router'
 import { HugeiconsIcon } from '@hugeicons/react'
-import {
-  Copy01Icon,
-  Delete02Icon,
-  InformationCircleIcon,
-  LinkSquare02Icon,
-  Refresh01Icon,
-  Setting07Icon,
-} from '@hugeicons/core-free-icons'
+import { InformationCircleIcon } from '@hugeicons/core-free-icons'
+
 import { toast } from '@/lib/toast'
 import { useMountEffect } from '@/hooks/use-mount-effect'
-
+import { usePageClamp } from '@/hooks/use-page-clamp'
 import {
   getActiveInstanceOrRedirect,
   requireInstanceRoleOrRedirect,
@@ -39,30 +34,66 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import PageHeader from '@/components/page-header'
 import PageLayout from '@/components/page-layout'
 import { Skeleton } from '@/components/ui/skeleton'
-import { Table, TableBody, TableCell, TableRow } from '@/components/ui/table'
-import type { Integration } from '@/lib/types'
-import { IntegrationInventory } from './-integration-inventory'
-import { GitLabWebhookTokens } from './-gitlab-webhook-tokens'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import type { IntegrationRepository } from '@/lib/types'
+import {
+  IntegrationAccountsInventory,
+  IntegrationRepositoryInventory,
+} from './-integration-inventory'
+import {
+  filterIntegrationRepositories,
+  paginateIntegrationRepositories,
+} from './-integration-inventory-utils'
+import type { RepositoryRunnerFilter } from './-integration-inventory-utils'
+import { GitLabWebhookTokenDialogs } from './-gitlab-webhook-tokens'
+import { IntegrationConnectionDetails } from './-integration-connection-details'
+import { IntegrationHeaderActions } from './-integration-header-actions'
+
+type IntegrationDetailTab = 'repositories' | 'accounts' | 'connection'
+
+const EMPTY_REPOSITORIES: Array<IntegrationRepository> = []
+
+interface IntegrationDetailSearch {
+  gitlab?: string
+  installed?: string
+  page?: number
+  pageSize?: 20 | 50 | 100
+  q?: string
+  runner?: Exclude<RepositoryRunnerFilter, 'all'>
+  tab?: Exclude<IntegrationDetailTab, 'repositories'>
+}
+
+function parseSearch(search: Record<string, unknown>): IntegrationDetailSearch {
+  const page = Number(search.page)
+  const pageSize = Number(search.pageSize)
+  const q = typeof search.q === 'string' ? search.q.trim() : ''
+  const tab = search.tab
+  const runner = search.runner
+
+  return {
+    installed:
+      typeof search.installed === 'string' ? search.installed : undefined,
+    gitlab: typeof search.gitlab === 'string' ? search.gitlab : undefined,
+    q: q || undefined,
+    runner: runner === 'allowed' || runner === 'blocked' ? runner : undefined,
+    tab: tab === 'accounts' || tab === 'connection' ? tab : undefined,
+    page: Number.isInteger(page) && page > 1 ? page : undefined,
+    pageSize: pageSize === 50 || pageSize === 100 ? pageSize : undefined,
+  }
+}
 
 export const Route = createFileRoute('/settings/integrations/$integrationId')({
   staticData: {
     breadcrumbLabel: 'Details',
     breadcrumbParent: { label: 'Sources', to: '/settings/integrations' },
   },
-  validateSearch: (
-    search: Record<string, unknown>,
-  ): { installed?: string; gitlab?: string } => ({
-    installed: (search.installed as string) || undefined,
-    gitlab: (search.gitlab as string) || undefined,
-  }),
+  validateSearch: parseSearch,
   beforeLoad: () => {
     const instance = getActiveInstanceOrRedirect()
     requireInstanceRoleOrRedirect(instance.id, ['owner', 'admin', 'developer'])
@@ -70,247 +101,200 @@ export const Route = createFileRoute('/settings/integrations/$integrationId')({
   component: IntegrationDetailPage,
 })
 
-function humanizeAuthMode(mode: string): string {
-  const labels: Record<string, string> = {
-    github_app_manifest: 'GitHub App (Manifest)',
-    github_app: 'GitHub App',
-    oauth_app: 'OAuth App',
-    pat: 'Personal Access Token',
-    personal_token: 'Personal Access Token',
-  }
-  return (
-    labels[mode] ??
-    mode.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
-  )
-}
-
-function IntegrationConnectionDetails({
-  canWrite,
-  gitLabWebhookUrl,
-  integration,
-  lastWebhookAt,
-}: {
-  canWrite: boolean
-  gitLabWebhookUrl: string
-  integration: Integration
-  lastWebhookAt: number | undefined
-}) {
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
-          Connection details
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        <Table>
-          <TableBody>
-            <TableRow>
-              <TableCell className="w-56 text-muted-foreground">
-                Provider
-              </TableCell>
-              <TableCell>{integration.provider}</TableCell>
-            </TableRow>
-            <TableRow>
-              <TableCell className="text-muted-foreground">Host URL</TableCell>
-              <TableCell>{integration.host_url}</TableCell>
-            </TableRow>
-            <TableRow>
-              <TableCell className="text-muted-foreground">Auth mode</TableCell>
-              <TableCell>{humanizeAuthMode(integration.auth_mode)}</TableCell>
-            </TableRow>
-            {integration.provider === 'gitlab' && canWrite ? (
-              <>
-                <TableRow>
-                  <TableCell className="text-muted-foreground">
-                    Webhook URL
-                  </TableCell>
-                  <TableCell>
-                    <div className="flex items-center gap-2">
-                      <code className="font-mono text-xs">
-                        {gitLabWebhookUrl}
-                      </code>
-                      <Button
-                        variant="ghost"
-                        size="icon-sm"
-                        aria-label="Copy GitLab webhook URL"
-                        title="Copy GitLab webhook URL"
-                        onClick={() => {
-                          void navigator.clipboard
-                            .writeText(gitLabWebhookUrl)
-                            .then(
-                              () => toast.success('Webhook URL copied'),
-                              () => toast.error('Could not copy webhook URL'),
-                            )
-                        }}
-                      >
-                        <HugeiconsIcon icon={Copy01Icon} />
-                      </Button>
-                    </div>
-                  </TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell className="text-muted-foreground">
-                    Last webhook delivery
-                  </TableCell>
-                  <TableCell>
-                    {lastWebhookAt
-                      ? new Date(lastWebhookAt * 1000).toLocaleString()
-                      : 'Waiting for a test delivery'}
-                  </TableCell>
-                </TableRow>
-              </>
-            ) : null}
-            {integration.app_id ? (
-              <TableRow>
-                <TableCell className="text-muted-foreground">App ID</TableCell>
-                <TableCell className="font-mono text-xs">
-                  {integration.app_id}
-                </TableCell>
-              </TableRow>
-            ) : null}
-            <TableRow>
-              <TableCell className="text-muted-foreground">Created</TableCell>
-              <TableCell>
-                {new Date(integration.created_at * 1000).toLocaleString()}
-              </TableCell>
-            </TableRow>
-          </TableBody>
-        </Table>
-      </CardContent>
-    </Card>
-  )
-}
-
 function useIntegrationDetailPageState(canWrite: boolean) {
   const { integrationId } = Route.useParams()
   const search = useSearch({ from: '/settings/integrations/$integrationId' })
-  const navigate = useNavigate()
+  const navigate = Route.useNavigate()
 
-  const { data: detail, isLoading, error } = useIntegration(integrationId)
-  const { data: networkSettings } = useExternalAccessNetworkSettings({
+  const detailQuery = useIntegration(integrationId)
+  const installationsQuery = useInstallations(integrationId)
+  const repositoriesQuery = useIntegrationRepos(integrationId)
+  const networkSettingsQuery = useExternalAccessNetworkSettings({
     enabled: canWrite,
   })
-  const { data: installationsData } = useInstallations(integrationId)
-  const { data: reposData } = useIntegrationRepos(integrationId)
   const syncMutation = useSyncInstallations()
   const deleteMutation = useDeleteIntegration()
   const gitlabAuthorizeMutation = useGitLabAuthorize()
 
   const label =
-    detail?.integration.display_name ??
-    detail?.integration.provider ??
+    detailQuery.data?.integration.display_name ??
+    detailQuery.data?.integration.provider ??
     'Source Details'
+  const repositories =
+    repositoriesQuery.data?.repositories ?? EMPTY_REPOSITORIES
+  const runnerFilter: RepositoryRunnerFilter = search.runner ?? 'all'
+  const pageSize = search.pageSize ?? 20
+  const filteredRepositories = useMemo(
+    () => filterIntegrationRepositories(repositories, search.q, runnerFilter),
+    [repositories, runnerFilter, search.q],
+  )
+  const total = filteredRepositories.length
+  const requestedPage = search.page ?? 1
+  const page = Math.min(requestedPage, Math.max(1, Math.ceil(total / pageSize)))
+  const visibleRepositories = paginateIntegrationRepositories(
+    filteredRepositories,
+    page,
+    pageSize,
+  )
+
+  function updateSearch(updates: Partial<IntegrationDetailSearch>) {
+    void navigate({
+      search: (previous) => ({ ...previous, ...updates }),
+      replace: true,
+    })
+  }
+
+  usePageClamp(
+    requestedPage,
+    pageSize,
+    repositoriesQuery.isLoading ? undefined : total,
+    (nextPage) => {
+      updateSearch({ page: nextPage === 1 ? undefined : nextPage })
+    },
+  )
 
   useBreadcrumbLabel(
     '/settings/integrations/$integrationId',
-    detail?.integration.display_name ?? detail?.integration.provider,
+    detailQuery.data?.integration.display_name ??
+      detailQuery.data?.integration.provider,
   )
 
   useMountEffect(() => {
+    let handledCallback = false
     if (search.installed === 'true') {
       toast.success('GitHub App installed successfully')
-      window.history.replaceState(
-        {},
-        '',
-        `/settings/integrations/${integrationId}`,
-      )
+      handledCallback = true
     }
     if (search.gitlab === 'success') {
       toast.success('GitLab OAuth authorization completed')
-      window.history.replaceState(
-        {},
-        '',
-        `/settings/integrations/${integrationId}`,
-      )
+      handledCallback = true
+    }
+    if (handledCallback) {
+      updateSearch({ installed: undefined, gitlab: undefined })
     }
   })
 
   function handleSync() {
+    const provider = detailQuery.data?.integration.provider
     syncMutation.mutate(integrationId, {
       onSuccess: () => {
-        toast.success('Installations synced')
+        toast.success(
+          provider === 'gitlab'
+            ? 'GitLab projects synced'
+            : 'GitHub repositories synced',
+        )
       },
-      onError: (err) => {
-        toast.error(`Sync failed: ${err.message}`)
+      onError: (error) => {
+        toast.error(`Sync failed: ${error.message}`)
       },
     })
   }
 
   function handleDisconnect() {
     const name =
-      detail?.integration.display_name ??
-      detail?.integration.provider ??
+      detailQuery.data?.integration.display_name ??
+      detailQuery.data?.integration.provider ??
       'source'
     deleteMutation.mutate(integrationId, {
       onSuccess: () => {
         toast.success(`Disconnected source: ${name}`)
         void navigate({ to: '/settings/integrations' })
       },
-      onError: (err) => {
-        toast.error(`Failed to disconnect: ${err.message}`)
+      onError: (error) => {
+        toast.error(`Failed to disconnect: ${error.message}`)
       },
     })
   }
 
-  if (isLoading) {
+  if (detailQuery.isLoading) {
     return { status: 'loading' as const, label }
   }
 
-  if (error) {
-    return { status: 'error' as const, label, message: error.message }
+  if (detailQuery.error) {
+    return {
+      status: 'error' as const,
+      label,
+      message: detailQuery.error.message,
+    }
   }
 
-  if (!detail) return { status: 'missing' as const }
+  if (!detailQuery.data) return { status: 'missing' as const }
 
-  const { integration } = detail
-  const installations = installationsData?.installations ?? []
-  const repositories = reposData?.repositories ?? []
-  const providerLabel = integration.provider === 'gitlab' ? 'GitLab' : 'GitHub'
-  const sourceDescription =
+  const { integration } = detailQuery.data
+  const installations = installationsQuery.data?.installations ?? []
+  const providerLabel =
     integration.provider === 'gitlab'
-      ? `GitLab source at ${integration.host_url}. Authorize, then sync projects to make them available in Oore.`
-      : 'GitHub App installation and repository link state for this source connection.'
+      ? 'GitLab'
+      : integration.provider === 'github'
+        ? 'GitHub'
+        : 'Local Git'
   const installationsLabel =
-    integration.provider === 'gitlab' ? 'GitLab accounts' : 'Installations'
-  const repositoriesLabel =
-    integration.provider === 'gitlab' ? 'GitLab projects' : 'Repositories'
-  const syncLabel =
     integration.provider === 'gitlab'
-      ? 'Sync GitLab projects'
-      : 'Sync installations'
-  const { webhookUrl: gitLabWebhookUrl } = gitLabPublicEndpoints(
-    networkSettings?.settings.public_url,
-    window.location.origin,
-  )
+      ? 'GitLab accounts'
+      : integration.provider === 'github'
+        ? 'Installations'
+        : 'Local paths'
+  const accountsTabLabel =
+    integration.provider === 'local_git' ? 'Path' : 'Accounts'
+  const accountsEmptyDescription =
+    integration.provider === 'gitlab'
+      ? 'Authorize GitLab, then sync this source.'
+      : integration.provider === 'github'
+        ? 'Install the GitHub App, then sync this source.'
+        : 'This source has no linked local path.'
+  const syncLabel =
+    integration.provider === 'gitlab' ? 'Sync projects' : 'Sync repositories'
   const canSyncInstallations =
     integration.provider === 'github' || integration.provider === 'gitlab'
+  const gitLabWebhookUrl = networkSettingsQuery.data
+    ? gitLabPublicEndpoints(
+        networkSettingsQuery.data.settings.public_url,
+        window.location.origin,
+      ).webhookUrl
+    : null
 
   return {
     status: 'ready' as const,
+    allowedRepositoryCount: repositories.filter(
+      (repository) => repository.allow_direct_macos_runner,
+    ).length,
+    accountsTabLabel,
+    accountsEmptyDescription,
     canSyncInstallations,
     deleteMutation,
-    detail,
+    detail: detailQuery.data,
     gitLabWebhookUrl,
     gitlabAuthorizeMutation,
     handleDisconnect,
     handleSync,
     installations,
     installationsLabel,
+    installationsQuery,
     integration,
     integrationId,
     label,
+    networkSettingsQuery,
+    page,
+    pageSize,
     providerLabel,
     repositories,
-    repositoriesLabel,
-    sourceDescription,
+    repositoriesQuery,
+    runnerFilter,
+    search,
     syncLabel,
     syncMutation,
+    tab: search.tab ?? 'repositories',
+    total,
+    updateSearch,
+    visibleRepositories,
   }
 }
 
 function IntegrationDetailPage() {
   const canWrite = useHasPermission('integrations', 'write')
+  const [disconnectOpen, setDisconnectOpen] = useState(false)
+  const [webhookTarget, setWebhookTarget] =
+    useState<IntegrationRepository | null>(null)
   const pageState = useIntegrationDetailPageState(canWrite)
 
   if (pageState.status === 'loading') {
@@ -318,8 +302,8 @@ function IntegrationDetailPage() {
       <PageLayout width="wide">
         <PageMeta title={pageState.label} noindex />
         <Skeleton className="h-8 w-56" />
-        <Skeleton className="h-24 w-full" />
-        <Skeleton className="h-56 w-full" />
+        <Skeleton className="h-10 w-72" />
+        <Skeleton className="h-64 w-full" />
       </PageLayout>
     )
   }
@@ -341,7 +325,11 @@ function IntegrationDetailPage() {
   if (pageState.status === 'missing') return null
 
   const {
+    accountsEmptyDescription,
+    allowedRepositoryCount,
+    accountsTabLabel,
     canSyncInstallations,
+    deleteMutation,
     detail,
     gitLabWebhookUrl,
     gitlabAuthorizeMutation,
@@ -349,31 +337,95 @@ function IntegrationDetailPage() {
     handleSync,
     installations,
     installationsLabel,
+    installationsQuery,
     integration,
     integrationId,
     label,
+    networkSettingsQuery,
+    page,
+    pageSize,
     providerLabel,
     repositories,
-    repositoriesLabel,
-    sourceDescription,
+    repositoriesQuery,
+    runnerFilter,
+    search,
     syncLabel,
     syncMutation,
+    tab,
+    total,
+    updateSearch,
+    visibleRepositories,
   } = pageState
+  const needsGitLabAuthorization =
+    integration.provider === 'gitlab' &&
+    integration.auth_mode === 'oauth_app' &&
+    integration.status === 'inactive'
+  const manageHref =
+    integration.provider === 'github' && integration.app_slug
+      ? installations.length > 0
+        ? `https://github.com/apps/${integration.app_slug}/installations/select_target`
+        : `https://github.com/apps/${integration.app_slug}/installations/new`
+      : integration.provider === 'gitlab'
+        ? integration.host_url
+        : null
+  const manageLabel =
+    integration.provider === 'github'
+      ? installations.length > 0
+        ? 'Manage on GitHub'
+        : 'Install on GitHub'
+      : 'Open GitLab'
 
   return (
     <PageLayout width="wide">
       <PageMeta title={label} noindex />
       <PageHeader
         title={integration.display_name ?? integration.provider}
-        description={sourceDescription}
+        description={`Connected to ${integration.host_url}`}
         meta={
           <>
             <Badge variant={getIntegrationStatusVariant(integration.status)}>
               {integration.status}
             </Badge>
             <Badge variant="outline">{providerLabel}</Badge>
-            <span className="font-mono">{integration.id.slice(0, 8)}</span>
+            {!repositoriesQuery.isLoading && !repositoriesQuery.error ? (
+              <>
+                <span>
+                  {repositories.length}{' '}
+                  {repositories.length === 1 ? 'repository' : 'repositories'}
+                </span>
+                <span>{allowedRepositoryCount} allowed</span>
+              </>
+            ) : null}
           </>
+        }
+        actions={
+          canWrite ? (
+            <IntegrationHeaderActions
+              authorizePending={gitlabAuthorizeMutation.isPending}
+              canSync={canSyncInstallations}
+              manageHref={manageHref}
+              manageLabel={manageLabel}
+              needsAuthorization={needsGitLabAuthorization}
+              onAuthorize={() =>
+                gitlabAuthorizeMutation.mutate(
+                  {
+                    integration_id: integrationId,
+                    redirect_url: window.location.href,
+                  },
+                  {
+                    onError: (authorizationError) =>
+                      toast.error(
+                        `GitLab authorization failed: ${authorizationError.message}`,
+                      ),
+                  },
+                )
+              }
+              onDisconnect={() => setDisconnectOpen(true)}
+              onSync={handleSync}
+              syncLabel={syncLabel}
+              syncPending={syncMutation.isPending}
+            />
+          ) : null
         }
       />
 
@@ -385,195 +437,156 @@ function IntegrationDetailPage() {
         </Alert>
       ) : null}
 
-      <section className="grid gap-4 md:grid-cols-3">
-        <Card>
-          <CardContent>
-            <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Installations
-            </p>
-            <p className="mt-3 text-2xl font-bold tracking-tight">
-              {installations.length}
-            </p>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Connected accounts
-            </p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent>
-            <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Repositories
-            </p>
-            <p className="mt-3 text-2xl font-bold tracking-tight">
-              {repositories.length}
-            </p>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Synced repositories
-            </p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent>
-            <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Auth mode
-            </p>
-            <p className="mt-3 text-2xl font-bold tracking-tight">
-              {humanizeAuthMode(integration.auth_mode)}
-            </p>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Host: {integration.host_url}
-            </p>
-          </CardContent>
-        </Card>
-      </section>
+      <Tabs
+        value={tab}
+        onValueChange={(value) =>
+          updateSearch({
+            tab:
+              value === 'repositories'
+                ? undefined
+                : (value as Exclude<IntegrationDetailTab, 'repositories'>),
+          })
+        }
+      >
+        <TabsList variant="line" aria-label="Source details">
+          <TabsTrigger value="repositories">
+            Repositories
+            <span className="font-mono text-xs text-muted-foreground">
+              {repositoriesQuery.isLoading ? '…' : repositories.length}
+            </span>
+          </TabsTrigger>
+          <TabsTrigger value="accounts">
+            {accountsTabLabel}
+            <span className="font-mono text-xs text-muted-foreground">
+              {installationsQuery.isLoading ? '…' : installations.length}
+            </span>
+          </TabsTrigger>
+          <TabsTrigger value="connection">Connection</TabsTrigger>
+        </TabsList>
 
-      <IntegrationConnectionDetails
-        canWrite={canWrite}
-        gitLabWebhookUrl={gitLabWebhookUrl}
-        integration={integration}
-        lastWebhookAt={detail.last_webhook_at}
-      />
+        <TabsContent value="repositories" className="pt-4">
+          {integration.provider === 'gitlab' &&
+          canWrite &&
+          networkSettingsQuery.error ? (
+            <Alert variant="destructive" className="mb-4">
+              <HugeiconsIcon icon={InformationCircleIcon} size={16} />
+              <AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <span>
+                  Webhook actions are unavailable because the public URL could
+                  not be loaded.
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void networkSettingsQuery.refetch()}
+                >
+                  Retry
+                </Button>
+              </AlertDescription>
+            </Alert>
+          ) : null}
+          <IntegrationRepositoryInventory
+            canWrite={canWrite}
+            error={repositoriesQuery.error}
+            integration={integration}
+            isLoading={repositoriesQuery.isLoading}
+            onClearFilters={() =>
+              updateSearch({ q: undefined, runner: undefined, page: undefined })
+            }
+            onPageChange={(nextPage) =>
+              updateSearch({ page: nextPage === 1 ? undefined : nextPage })
+            }
+            onPageSizeChange={(nextPageSize) =>
+              updateSearch({
+                pageSize:
+                  nextPageSize === 20 ? undefined : (nextPageSize as 50 | 100),
+                page: undefined,
+              })
+            }
+            onRetry={() => void repositoriesQuery.refetch()}
+            onRunnerFilterChange={(nextFilter) =>
+              updateSearch({
+                runner: nextFilter === 'all' ? undefined : nextFilter,
+                page: undefined,
+              })
+            }
+            onSearch={(nextQuery) =>
+              updateSearch({
+                q: nextQuery.trim() || undefined,
+                page: undefined,
+              })
+            }
+            onWebhookTokenRequest={
+              integration.provider === 'gitlab' && gitLabWebhookUrl
+                ? setWebhookTarget
+                : undefined
+            }
+            page={page}
+            pageSize={pageSize}
+            query={search.q}
+            repositories={visibleRepositories}
+            repositoryCount={repositories.length}
+            runnerFilter={runnerFilter}
+            total={total}
+          />
+        </TabsContent>
 
-      {integration.provider === 'gitlab' && canWrite ? (
-        <GitLabWebhookTokens repositories={repositories} />
+        <TabsContent value="accounts" className="pt-4">
+          <IntegrationAccountsInventory
+            emptyDescription={accountsEmptyDescription}
+            error={installationsQuery.error}
+            installations={installations}
+            isLoading={installationsQuery.isLoading}
+            label={installationsLabel}
+            onRetry={() => void installationsQuery.refetch()}
+            primaryColumnLabel={
+              integration.provider === 'local_git' ? 'Path' : 'Account'
+            }
+          />
+        </TabsContent>
+
+        <TabsContent value="connection" className="pt-4">
+          <IntegrationConnectionDetails
+            canWrite={canWrite}
+            gitLabWebhookUrl={gitLabWebhookUrl}
+            integration={integration}
+            lastWebhookAt={detail.last_webhook_at}
+            networkSettingsError={networkSettingsQuery.error}
+            networkSettingsLoading={networkSettingsQuery.isLoading}
+            onRetryNetworkSettings={() => void networkSettingsQuery.refetch()}
+          />
+        </TabsContent>
+      </Tabs>
+
+      <AlertDialog open={disconnectOpen} onOpenChange={setDisconnectOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Disconnect source?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes credentials, installations, repository links, and
+              webhook behavior for{' '}
+              {integration.display_name ?? integration.provider}.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDisconnect}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? 'Disconnecting...' : 'Disconnect'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {integration.provider === 'gitlab' && canWrite && gitLabWebhookUrl ? (
+        <GitLabWebhookTokenDialogs
+          repository={webhookTarget}
+          webhookUrl={gitLabWebhookUrl}
+          onClose={() => setWebhookTarget(null)}
+        />
       ) : null}
-
-      {integration.provider === 'gitlab' && !detail.last_webhook_at ? (
-        <Alert>
-          <HugeiconsIcon icon={InformationCircleIcon} size={16} />
-          <AlertDescription>
-            Webhook readiness is pending. Generate a token for each project,
-            then add the copied URL and that project&apos;s token in GitLab,
-            enable Push events, and send a test delivery.
-          </AlertDescription>
-        </Alert>
-      ) : null}
-
-      {canWrite ? (
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
-              Actions
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="flex flex-wrap gap-2">
-            {integration.provider === 'gitlab' &&
-            integration.auth_mode === 'oauth_app' &&
-            integration.status === 'inactive' ? (
-              <Button
-                onClick={() =>
-                  gitlabAuthorizeMutation.mutate(
-                    {
-                      integration_id: integrationId,
-                      redirect_url: window.location.href,
-                    },
-                    {
-                      onError: (authorizationError) =>
-                        toast.error(
-                          `GitLab authorization failed: ${authorizationError.message}`,
-                        ),
-                    },
-                  )
-                }
-                disabled={gitlabAuthorizeMutation.isPending}
-              >
-                <HugeiconsIcon icon={LinkSquare02Icon} size={16} />
-                {gitlabAuthorizeMutation.isPending
-                  ? 'Redirecting...'
-                  : 'Authorize on GitLab'}
-              </Button>
-            ) : null}
-
-            {integration.provider === 'github' && integration.app_slug ? (
-              <Button
-                variant="outline"
-                render={
-                  <a
-                    href={
-                      installations.length > 0
-                        ? `https://github.com/apps/${integration.app_slug}/installations/select_target`
-                        : `https://github.com/apps/${integration.app_slug}/installations/new`
-                    }
-                    aria-label="Manage this source on GitHub"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  />
-                }
-                nativeButton={false}
-              >
-                <HugeiconsIcon icon={Setting07Icon} />
-                {installations.length > 0
-                  ? 'Manage on GitHub'
-                  : 'Install on GitHub'}
-              </Button>
-            ) : null}
-
-            {integration.provider === 'gitlab' ? (
-              <Button
-                variant="outline"
-                render={
-                  <a
-                    href={integration.host_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    aria-label="Open GitLab in a new tab"
-                  />
-                }
-                nativeButton={false}
-              >
-                <HugeiconsIcon icon={Setting07Icon} />
-                Open GitLab
-              </Button>
-            ) : null}
-
-            {canSyncInstallations ? (
-              <Button
-                variant="outline"
-                onClick={handleSync}
-                disabled={syncMutation.isPending}
-              >
-                <HugeiconsIcon icon={Refresh01Icon} />
-                {syncMutation.isPending ? 'Syncing...' : syncLabel}
-              </Button>
-            ) : null}
-
-            <AlertDialog>
-              <AlertDialogTrigger
-                render={
-                  <Button variant="destructive">
-                    <HugeiconsIcon icon={Delete02Icon} />
-                    Disconnect
-                  </Button>
-                }
-              />
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Disconnect source?</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    This removes credentials, installations, repository links,
-                    and webhook behavior.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogAction onClick={handleDisconnect}>
-                    Disconnect
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-          </CardContent>
-        </Card>
-      ) : null}
-
-      <IntegrationInventory
-        canWrite={canWrite}
-        installations={installations}
-        installationsLabel={installationsLabel}
-        integration={integration}
-        repositories={repositories}
-        repositoriesLabel={repositoriesLabel}
-      />
     </PageLayout>
   )
 }

--- a/apps/web/src/routes/settings/integrations/-gitlab-webhook-tokens.test.tsx
+++ b/apps/web/src/routes/settings/integrations/-gitlab-webhook-tokens.test.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react'
+import { act, fireEvent, render, screen, within } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { IntegrationRepository } from '@/lib/types'
+import { GitLabWebhookTokenDialogs } from './-gitlab-webhook-tokens'
+
+const mocks = vi.hoisted(() => ({ isPending: false, mutate: vi.fn() }))
+
+vi.mock('@/hooks/use-integrations', () => ({
+  useRotateGitLabRepositoryWebhookSecret: () => ({
+    isPending: mocks.isPending,
+    mutate: mocks.mutate,
+  }),
+}))
+
+const repository: IntegrationRepository = {
+  id: 'repository-1',
+  installation_id: 'installation-1',
+  external_id: '1',
+  full_name: 'group/mobile-app',
+  default_branch: 'main',
+  is_private: true,
+  allow_direct_macos_runner: false,
+  created_at: 1,
+  updated_at: 1,
+}
+
+function Harness() {
+  const [target, setTarget] = useState<IntegrationRepository | null>(repository)
+  return (
+    <GitLabWebhookTokenDialogs
+      repository={target}
+      webhookUrl="https://ci.example.test/v1/webhooks/gitlab"
+      onClose={() => setTarget(null)}
+    />
+  )
+}
+
+describe('GitLabWebhookTokenDialogs', () => {
+  beforeEach(() => {
+    mocks.isPending = false
+    mocks.mutate.mockReset()
+  })
+
+  it('confirms rotation, identifies the project, and clears the revealed token', async () => {
+    render(<Harness />)
+
+    expect(mocks.mutate).not.toHaveBeenCalled()
+    const confirmation = await screen.findByRole('alertdialog')
+    expect(within(confirmation).getByText(/group\/mobile-app/)).toBeTruthy()
+
+    fireEvent.click(
+      within(confirmation).getByRole('button', { name: 'Create token' }),
+    )
+    expect(mocks.mutate).toHaveBeenCalledTimes(1)
+    expect(mocks.mutate.mock.calls[0]?.[0]).toBe(repository.id)
+    expect(screen.getByRole('alertdialog')).toBeTruthy()
+
+    act(() => {
+      mocks.mutate.mock.calls[0]?.[1].onSuccess({
+        webhook_secret: 'one-time-secret',
+      })
+    })
+
+    const dialog = await screen.findByRole('dialog', {
+      name: 'Webhook token for group/mobile-app',
+    })
+    expect(within(dialog).getByDisplayValue('one-time-secret')).toBeTruthy()
+    expect(
+      within(dialog).getByDisplayValue(
+        'https://ci.example.test/v1/webhooks/gitlab',
+      ),
+    ).toBeTruthy()
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Done' }))
+    expect(screen.queryByDisplayValue('one-time-secret')).toBeNull()
+  })
+
+  it('cannot be dismissed while a token rotation is pending', async () => {
+    mocks.isPending = true
+    render(<Harness />)
+
+    const confirmation = await screen.findByRole('alertdialog')
+    const cancel = within(confirmation).getByRole('button', { name: 'Cancel' })
+    expect(cancel.hasAttribute('disabled')).toBe(true)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.getByRole('alertdialog')).toBeTruthy()
+  })
+})

--- a/apps/web/src/routes/settings/integrations/-gitlab-webhook-tokens.tsx
+++ b/apps/web/src/routes/settings/integrations/-gitlab-webhook-tokens.tsx
@@ -2,70 +2,151 @@ import { useState } from 'react'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { Copy01Icon, Refresh01Icon } from '@hugeicons/core-free-icons'
 
-import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table'
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
 import { useRotateGitLabRepositoryWebhookSecret } from '@/hooks/use-integrations'
 import { toast } from '@/lib/toast'
 import type { IntegrationRepository } from '@/lib/types'
 
-export function GitLabWebhookTokens({
-  repositories,
+interface RevealedWebhookToken {
+  repository: IntegrationRepository
+  secret: string
+}
+
+function copyToClipboard(value: string, label: string) {
+  void navigator.clipboard.writeText(value).then(
+    () => toast.success(`${label} copied`),
+    () => toast.error(`Could not copy ${label.toLocaleLowerCase()}`),
+  )
+}
+
+export function GitLabWebhookTokenDialogs({
+  onClose,
+  repository,
+  webhookUrl,
 }: {
-  repositories: Array<IntegrationRepository>
+  onClose: () => void
+  repository: IntegrationRepository | null
+  webhookUrl: string
 }) {
   const rotate = useRotateGitLabRepositoryWebhookSecret()
-  const [revealed, setRevealed] = useState<{
-    repositoryId: string
-    secret: string
-  } | null>(null)
+  const [revealed, setRevealed] = useState<RevealedWebhookToken | null>(null)
 
-  function rotateToken(repository: IntegrationRepository) {
-    rotate.mutate(repository.id, {
+  function generateToken() {
+    if (!repository) return
+    const target = repository
+    rotate.mutate(target.id, {
       onSuccess: (response) => {
         setRevealed({
-          repositoryId: repository.id,
+          repository: target,
           secret: response.webhook_secret,
         })
-        toast.success(`Webhook token rotated for ${repository.full_name}`)
+        onClose()
+        toast.success(`Webhook token created for ${target.full_name}`)
       },
       onError: (error) =>
-        toast.error(`Could not rotate webhook token: ${error.message}`),
+        toast.error(`Could not create webhook token: ${error.message}`),
     })
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
-          GitLab webhook tokens
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <p className="text-sm text-muted-foreground">
-          Each project uses its own token. Generating a token immediately
-          invalidates the previous token for that project.
-        </p>
-        {revealed ? (
-          <Alert>
-            <AlertDescription className="space-y-2">
-              <p>
-                Copy this token now. Oore stores it encrypted and will not show
-                it again.
+    <>
+      <AlertDialog
+        open={repository !== null}
+        onOpenChange={(open) => {
+          if (!open && !rotate.isPending) onClose()
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Create a webhook token?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This creates a new token for {repository?.full_name}. If the
+              project already has an Oore webhook token, it will stop working.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={rotate.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            <Button
+              type="button"
+              onClick={generateToken}
+              disabled={rotate.isPending}
+            >
+              <HugeiconsIcon icon={Refresh01Icon} />
+              {rotate.isPending ? 'Creating...' : 'Create token'}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <Dialog
+        open={revealed !== null}
+        onOpenChange={(open) => {
+          if (!open) setRevealed(null)
+        }}
+      >
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>
+              Webhook token for {revealed?.repository.full_name}
+            </DialogTitle>
+            <DialogDescription>
+              Add this URL and token to the project&apos;s GitLab webhook with
+              Push events enabled. The token is shown once.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <p className="text-xs font-medium text-muted-foreground">
+                Webhook URL
               </p>
               <div className="flex gap-2">
                 <Input
                   readOnly
-                  value={revealed.secret}
+                  value={webhookUrl}
+                  aria-label="GitLab webhook URL"
+                  className="font-mono text-xs"
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  aria-label="Copy GitLab webhook URL"
+                  onClick={() => copyToClipboard(webhookUrl, 'Webhook URL')}
+                >
+                  <HugeiconsIcon icon={Copy01Icon} />
+                </Button>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-xs font-medium text-muted-foreground">
+                Secret token
+              </p>
+              <div className="flex gap-2">
+                <Input
+                  readOnly
+                  value={revealed?.secret ?? ''}
                   aria-label="New GitLab webhook token"
                   className="font-mono"
                 />
@@ -75,56 +156,24 @@ export function GitLabWebhookTokens({
                   size="icon"
                   aria-label="Copy new GitLab webhook token"
                   onClick={() => {
-                    void navigator.clipboard.writeText(revealed.secret).then(
-                      () => toast.success('Webhook token copied'),
-                      () => toast.error('Could not copy webhook token'),
-                    )
+                    if (revealed) {
+                      copyToClipboard(revealed.secret, 'Webhook token')
+                    }
                   }}
                 >
                   <HugeiconsIcon icon={Copy01Icon} />
                 </Button>
               </div>
-            </AlertDescription>
-          </Alert>
-        ) : null}
-        {repositories.length === 0 ? (
-          <p className="text-sm text-muted-foreground">
-            Sync GitLab projects before generating webhook tokens.
-          </p>
-        ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Project</TableHead>
-                <TableHead className="w-44 text-right">Token</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {repositories.map((repository) => (
-                <TableRow key={repository.id}>
-                  <TableCell className="font-medium">
-                    {repository.full_name}
-                  </TableCell>
-                  <TableCell className="text-right">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      disabled={rotate.isPending}
-                      onClick={() => rotateToken(repository)}
-                    >
-                      <HugeiconsIcon icon={Refresh01Icon} />
-                      {rotate.isPending && rotate.variables === repository.id
-                        ? 'Rotating...'
-                        : 'Generate / rotate'}
-                    </Button>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        )}
-      </CardContent>
-    </Card>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" onClick={() => setRevealed(null)}>
+              Done
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }

--- a/apps/web/src/routes/settings/integrations/-integration-connection-details.tsx
+++ b/apps/web/src/routes/settings/integrations/-integration-connection-details.tsx
@@ -1,0 +1,144 @@
+import { Copy01Icon } from '@hugeicons/core-free-icons'
+import { HugeiconsIcon } from '@hugeicons/react'
+
+import { toast } from '@/lib/toast'
+import type { Integration } from '@/lib/types'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Table, TableBody, TableCell, TableRow } from '@/components/ui/table'
+
+function humanizeAuthMode(mode: string): string {
+  const labels: Record<string, string> = {
+    github_app_manifest: 'GitHub App (Manifest)',
+    github_app: 'GitHub App',
+    oauth_app: 'OAuth App',
+    pat: 'Personal Access Token',
+    personal_token: 'Personal Access Token',
+  }
+  return (
+    labels[mode] ??
+    mode
+      .replace(/_/g, ' ')
+      .replace(/\b\w/g, (character) => character.toUpperCase())
+  )
+}
+
+export function IntegrationConnectionDetails({
+  canWrite,
+  gitLabWebhookUrl,
+  integration,
+  lastWebhookAt,
+  networkSettingsError,
+  networkSettingsLoading,
+  onRetryNetworkSettings,
+}: {
+  canWrite: boolean
+  gitLabWebhookUrl: string | null
+  integration: Integration
+  lastWebhookAt: number | undefined
+  networkSettingsError: Error | null
+  networkSettingsLoading: boolean
+  onRetryNetworkSettings: () => void
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Connection</CardTitle>
+      </CardHeader>
+      <CardContent className="overflow-x-auto">
+        <Table>
+          <TableBody>
+            <TableRow>
+              <TableCell className="w-56 text-muted-foreground">
+                Provider
+              </TableCell>
+              <TableCell>{integration.provider}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell className="text-muted-foreground">Host URL</TableCell>
+              <TableCell>{integration.host_url}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell className="text-muted-foreground">Auth mode</TableCell>
+              <TableCell>{humanizeAuthMode(integration.auth_mode)}</TableCell>
+            </TableRow>
+            {integration.provider === 'gitlab' && canWrite ? (
+              <>
+                <TableRow>
+                  <TableCell className="text-muted-foreground">
+                    Webhook URL
+                  </TableCell>
+                  <TableCell>
+                    {networkSettingsLoading ? (
+                      <Skeleton className="h-6 w-72" />
+                    ) : networkSettingsError ? (
+                      <div className="flex items-center gap-3">
+                        <span className="text-sm text-destructive">
+                          Could not load webhook URL
+                        </span>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={onRetryNetworkSettings}
+                        >
+                          Retry
+                        </Button>
+                      </div>
+                    ) : gitLabWebhookUrl ? (
+                      <div className="flex items-center gap-2">
+                        <code className="font-mono text-xs">
+                          {gitLabWebhookUrl}
+                        </code>
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          aria-label="Copy GitLab webhook URL"
+                          title="Copy GitLab webhook URL"
+                          onClick={() => {
+                            void navigator.clipboard
+                              .writeText(gitLabWebhookUrl)
+                              .then(
+                                () => toast.success('Webhook URL copied'),
+                                () => toast.error('Could not copy webhook URL'),
+                              )
+                          }}
+                        >
+                          <HugeiconsIcon icon={Copy01Icon} />
+                        </Button>
+                      </div>
+                    ) : null}
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell className="text-muted-foreground">
+                    Last delivery for this source
+                  </TableCell>
+                  <TableCell>
+                    {lastWebhookAt
+                      ? new Date(lastWebhookAt * 1000).toLocaleString()
+                      : 'No delivery received'}
+                  </TableCell>
+                </TableRow>
+              </>
+            ) : null}
+            {integration.app_id ? (
+              <TableRow>
+                <TableCell className="text-muted-foreground">App ID</TableCell>
+                <TableCell className="font-mono text-xs">
+                  {integration.app_id}
+                </TableCell>
+              </TableRow>
+            ) : null}
+            <TableRow>
+              <TableCell className="text-muted-foreground">Created</TableCell>
+              <TableCell>
+                {new Date(integration.created_at * 1000).toLocaleString()}
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/src/routes/settings/integrations/-integration-header-actions.tsx
+++ b/apps/web/src/routes/settings/integrations/-integration-header-actions.tsx
@@ -1,0 +1,82 @@
+import {
+  Delete02Icon,
+  LinkSquare02Icon,
+  MoreHorizontalCircle01Icon,
+  Refresh01Icon,
+  Setting07Icon,
+} from '@hugeicons/core-free-icons'
+import { HugeiconsIcon } from '@hugeicons/react'
+
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+
+export function IntegrationHeaderActions({
+  authorizePending,
+  canSync,
+  manageHref,
+  manageLabel,
+  needsAuthorization,
+  onAuthorize,
+  onDisconnect,
+  onSync,
+  syncLabel,
+  syncPending,
+}: {
+  authorizePending: boolean
+  canSync: boolean
+  manageHref: string | null
+  manageLabel: string
+  needsAuthorization: boolean
+  onAuthorize: () => void
+  onDisconnect: () => void
+  onSync: () => void
+  syncLabel: string
+  syncPending: boolean
+}) {
+  return (
+    <>
+      {needsAuthorization ? (
+        <Button onClick={onAuthorize} disabled={authorizePending}>
+          <HugeiconsIcon icon={LinkSquare02Icon} size={16} />
+          {authorizePending ? 'Redirecting...' : 'Authorize GitLab'}
+        </Button>
+      ) : canSync ? (
+        <Button onClick={onSync} disabled={syncPending}>
+          <HugeiconsIcon icon={Refresh01Icon} />
+          {syncPending ? 'Syncing...' : syncLabel}
+        </Button>
+      ) : null}
+
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button variant="outline" size="icon" aria-label="Source actions" />
+          }
+        >
+          <HugeiconsIcon icon={MoreHorizontalCircle01Icon} />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-auto">
+          {manageHref ? (
+            <DropdownMenuItem
+              onClick={() =>
+                window.open(manageHref, '_blank', 'noopener,noreferrer')
+              }
+            >
+              <HugeiconsIcon icon={Setting07Icon} />
+              {manageLabel}
+            </DropdownMenuItem>
+          ) : null}
+          <DropdownMenuItem variant="destructive" onClick={onDisconnect}>
+            <HugeiconsIcon icon={Delete02Icon} />
+            Disconnect source
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </>
+  )
+}

--- a/apps/web/src/routes/settings/integrations/-integration-inventory-utils.ts
+++ b/apps/web/src/routes/settings/integrations/-integration-inventory-utils.ts
@@ -1,0 +1,39 @@
+import type { IntegrationRepository } from '@/lib/types'
+
+export type RepositoryRunnerFilter = 'all' | 'allowed' | 'blocked'
+
+export function filterIntegrationRepositories(
+  repositories: Array<IntegrationRepository>,
+  query: string | undefined,
+  runnerFilter: RepositoryRunnerFilter,
+): Array<IntegrationRepository> {
+  const normalizedQuery = query?.trim().toLocaleLowerCase()
+  return repositories
+    .filter((repository) => {
+      if (runnerFilter === 'allowed' && !repository.allow_direct_macos_runner) {
+        return false
+      }
+      if (runnerFilter === 'blocked' && repository.allow_direct_macos_runner) {
+        return false
+      }
+      if (!normalizedQuery) return true
+      return [
+        repository.full_name,
+        repository.default_branch,
+        repository.is_private ? 'private' : 'public',
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .toLocaleLowerCase()
+        .includes(normalizedQuery)
+    })
+    .sort((left, right) => left.full_name.localeCompare(right.full_name))
+}
+
+export function paginateIntegrationRepositories(
+  repositories: Array<IntegrationRepository>,
+  page: number,
+  pageSize: number,
+): Array<IntegrationRepository> {
+  return repositories.slice((page - 1) * pageSize, page * pageSize)
+}

--- a/apps/web/src/routes/settings/integrations/-integration-inventory.test.ts
+++ b/apps/web/src/routes/settings/integrations/-integration-inventory.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import type { IntegrationRepository } from '@/lib/types'
+import {
+  filterIntegrationRepositories,
+  paginateIntegrationRepositories,
+} from './-integration-inventory-utils'
+
+function repository(
+  index: number,
+  allowDirectRunner = false,
+): IntegrationRepository {
+  return {
+    id: `repository-${index}`,
+    installation_id: 'installation-1',
+    external_id: String(index),
+    full_name: `group/repository-${String(index).padStart(2, '0')}`,
+    default_branch: index % 2 === 0 ? 'main' : 'develop',
+    is_private: true,
+    allow_direct_macos_runner: allowDirectRunner,
+    created_at: 1,
+    updated_at: 1,
+  }
+}
+
+describe('integration repository inventory', () => {
+  const repositories = Array.from({ length: 31 }, (_, index) =>
+    repository(index + 1, (index + 1) % 3 === 0),
+  )
+
+  it('keeps a 31-repository source bounded to the requested page', () => {
+    const filtered = filterIntegrationRepositories(
+      repositories,
+      undefined,
+      'all',
+    )
+
+    expect(paginateIntegrationRepositories(filtered, 1, 20)).toHaveLength(20)
+    const secondPage = paginateIntegrationRepositories(filtered, 2, 20)
+    expect(secondPage).toHaveLength(11)
+    expect(secondPage[0]?.full_name).toBe('group/repository-21')
+  })
+
+  it('combines search and runner access filters', () => {
+    expect(
+      filterIntegrationRepositories(
+        repositories,
+        'repository-30',
+        'allowed',
+      ).map((item) => item.full_name),
+    ).toEqual(['group/repository-30'])
+
+    expect(
+      filterIntegrationRepositories(repositories, 'develop', 'blocked'),
+    ).toHaveLength(11)
+  })
+})

--- a/apps/web/src/routes/settings/integrations/-integration-inventory.tsx
+++ b/apps/web/src/routes/settings/integrations/-integration-inventory.tsx
@@ -1,12 +1,23 @@
+import { useState } from 'react'
+import { HugeiconsIcon } from '@hugeicons/react'
+import {
+  GitBranchIcon,
+  InformationCircleIcon,
+  MoreHorizontalCircle01Icon,
+  Refresh01Icon,
+  Search01Icon,
+} from '@hugeicons/core-free-icons'
+
 import RepositoryAvatar from '@/components/repository-avatar'
+import { CollectionPagination } from '@/components/collection-controls'
+import { CollectionSearchInput } from '@/components/collection-search-input'
 import { toast } from '@/lib/toast'
 import type {
   Integration,
   IntegrationInstallation,
   IntegrationRepository,
 } from '@/lib/types'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from '@/components/ui/alert'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -16,9 +27,25 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
-import { useUpdateRepositoryRunnerPolicy } from '@/hooks/use-integrations'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@/components/ui/empty'
+import { NativeSelect, NativeSelectOption } from '@/components/ui/native-select'
+import { Skeleton } from '@/components/ui/skeleton'
 import {
   Table,
   TableBody,
@@ -27,6 +54,8 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { useUpdateRepositoryRunnerPolicy } from '@/hooks/use-integrations'
+import type { RepositoryRunnerFilter } from './-integration-inventory-utils'
 
 function repositoryUrl(
   integration: Integration,
@@ -79,280 +108,496 @@ function RepositoryRunnerPolicy({
   repository,
 }: {
   canWrite: boolean
-  onChange: (allow: boolean) => void
+  onChange: () => void
   pending: boolean
   repository: IntegrationRepository
 }) {
-  const approved = repository.allow_direct_macos_runner
+  const allowed = repository.allow_direct_macos_runner
   return (
     <div className="flex items-center justify-end gap-2">
-      <Badge variant={approved ? 'success' : 'outline'}>
-        {approved ? 'Approved' : 'Needs approval'}
+      <Badge variant={allowed ? 'success' : 'outline'}>
+        {allowed ? 'Allowed' : 'Blocked'}
       </Badge>
       {canWrite ? (
-        <AlertDialog>
-          <AlertDialogTrigger
-            render={
-              <Button
-                size="sm"
-                variant="outline"
-                disabled={pending}
-                className="min-h-11 sm:min-h-8"
-              >
-                {pending ? 'Saving...' : approved ? 'Revoke' : 'Approve'}
-              </Button>
-            }
-          />
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>
-                {approved
-                  ? 'Revoke runner approval?'
-                  : 'Approve this repository?'}
-              </AlertDialogTitle>
-              <AlertDialogDescription>
-                {approved
-                  ? 'Running builds will finish, but queued builds for every project linked to this repository will wait.'
-                  : 'Build commands from every project linked to this repository will run with the macOS permissions of the runner account. Approve only code and contributors you would run directly on this Mac.'}
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>Cancel</AlertDialogCancel>
-              <AlertDialogAction onClick={() => onChange(!approved)}>
-                {approved ? 'Revoke approval' : 'Approve repository'}
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={pending}
+          className="min-h-11 sm:min-h-8"
+          onClick={onChange}
+        >
+          {pending ? 'Saving...' : allowed ? 'Block' : 'Allow'}
+        </Button>
       ) : null}
     </div>
   )
 }
 
-export function IntegrationInventory({
+function RepositoryWebhookAction({
+  onSelect,
+  repository,
+}: {
+  onSelect: () => void
+  repository: IntegrationRepository
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={`Webhook actions for ${repository.full_name}`}
+          />
+        }
+      >
+        <HugeiconsIcon icon={MoreHorizontalCircle01Icon} />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-auto">
+        <DropdownMenuItem onClick={onSelect}>
+          <HugeiconsIcon icon={Refresh01Icon} />
+          Create webhook token
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+function RepositoryRows({
   canWrite,
-  installations,
-  installationsLabel,
   integration,
+  onPolicySelect,
+  onWebhookSelect,
+  pendingRepositoryId,
   repositories,
-  repositoriesLabel,
 }: {
   canWrite: boolean
-  installations: Array<IntegrationInstallation>
-  installationsLabel: string
   integration: Integration
+  onPolicySelect: (repository: IntegrationRepository) => void
+  onWebhookSelect?: (repository: IntegrationRepository) => void
+  pendingRepositoryId?: string
   repositories: Array<IntegrationRepository>
-  repositoriesLabel: string
 }) {
-  const policyMutation = useUpdateRepositoryRunnerPolicy(integration.id)
-
-  function updateRunnerPolicy(
-    repository: IntegrationRepository,
-    allow: boolean,
-  ) {
-    policyMutation.mutate(
-      { repositoryId: repository.id, allow },
-      {
-        onSuccess: () =>
-          toast.success(
-            allow
-              ? `${repository.full_name} approved for Direct runner builds.`
-              : `${repository.full_name} runner approval revoked.`,
-          ),
-        onError: (error) =>
-          toast.error(`Failed to update repository approval: ${error.message}`),
-      },
-    )
-  }
-
+  const showWebhookActions =
+    integration.provider === 'gitlab' && canWrite && !!onWebhookSelect
   return (
     <>
-      <section aria-labelledby="installations-title" className="min-w-0">
-        <div className="flex items-center justify-between gap-4">
-          <h2
-            id="installations-title"
-            className="text-sm font-medium uppercase tracking-wider text-muted-foreground"
-          >
-            {installationsLabel}
-          </h2>
-          <span className="text-xs text-muted-foreground">
-            {installations.length} total
-          </span>
-        </div>
-
-        {installations.length === 0 ? (
-          <p className="mt-4 text-sm text-muted-foreground">
-            No{' '}
-            {integration.provider === 'gitlab'
-              ? 'GitLab account'
-              : 'installation'}{' '}
-            yet
-            {integration.provider === 'github' && integration.app_slug
-              ? ' — install your GitHub App to get started.'
-              : '.'}
-          </p>
-        ) : (
-          <>
-            <div className="mt-2 divide-y sm:hidden">
-              {installations.map((installation) => (
-                <article key={installation.id} className="space-y-2 py-4">
-                  <div className="flex items-start justify-between gap-3">
-                    <h3 className="min-w-0 truncate font-medium">
-                      {installation.account_name}
-                    </h3>
-                    <Badge variant="outline">
-                      {installation.account_type ?? 'Account'}
-                    </Badge>
-                  </div>
-                  <p className="truncate font-mono text-xs text-muted-foreground">
-                    {installation.external_id}
-                  </p>
-                </article>
-              ))}
+      <div className="divide-y sm:hidden">
+        {repositories.map((repository) => (
+          <article key={repository.id} className="space-y-3 py-4">
+            <div className="flex items-start justify-between gap-3">
+              <RepositoryIdentity
+                integration={integration}
+                repository={repository}
+              />
+              {showWebhookActions ? (
+                <RepositoryWebhookAction
+                  repository={repository}
+                  onSelect={() => onWebhookSelect(repository)}
+                />
+              ) : null}
             </div>
-
-            <div className="mt-2 hidden sm:block">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Account</TableHead>
-                    <TableHead>Type</TableHead>
-                    <TableHead className="hidden lg:table-cell">
-                      External ID
-                    </TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {installations.map((installation) => (
-                    <TableRow key={installation.id}>
-                      <TableCell className="font-medium">
-                        {installation.account_name}
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant="outline">
-                          {installation.account_type ?? 'Account'}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="hidden font-mono text-xs text-muted-foreground lg:table-cell">
-                        {installation.external_id}
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+            <div className="flex items-center justify-between gap-3 pl-10">
+              <span className="truncate font-mono text-xs text-muted-foreground">
+                {repository.default_branch ?? 'Default branch not set'}
+              </span>
+              <Badge variant={repository.is_private ? 'secondary' : 'outline'}>
+                {repository.is_private ? 'Private' : 'Public'}
+              </Badge>
             </div>
-          </>
-        )}
-      </section>
+            <RepositoryRunnerPolicy
+              canWrite={canWrite}
+              onChange={() => onPolicySelect(repository)}
+              pending={pendingRepositoryId === repository.id}
+              repository={repository}
+            />
+          </article>
+        ))}
+      </div>
 
-      <section aria-labelledby="repositories-title" className="min-w-0">
-        <div className="flex items-center justify-between gap-4">
-          <h2
-            id="repositories-title"
-            className="text-sm font-medium uppercase tracking-wider text-muted-foreground"
-          >
-            {repositoriesLabel}
-          </h2>
-          <span className="text-xs text-muted-foreground">
-            {repositories.length} total
-          </span>
-        </div>
-
-        {repositories.length === 0 ? (
-          <p className="mt-4 text-sm text-muted-foreground">
-            No{' '}
-            {integration.provider === 'gitlab'
-              ? 'GitLab projects'
-              : 'repositories'}{' '}
-            synced yet.
-          </p>
-        ) : (
-          <>
-            <div className="mt-2 divide-y sm:hidden">
-              {repositories.map((repository) => (
-                <article key={repository.id} className="space-y-2 py-4">
+      <div className="hidden sm:block">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Repository</TableHead>
+              <TableHead>Default branch</TableHead>
+              <TableHead className="hidden lg:table-cell">Visibility</TableHead>
+              <TableHead className="text-right">Direct runner</TableHead>
+              {showWebhookActions ? (
+                <TableHead className="w-10">
+                  <span className="sr-only">Webhook actions</span>
+                </TableHead>
+              ) : null}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {repositories.map((repository) => (
+              <TableRow key={repository.id}>
+                <TableCell>
                   <RepositoryIdentity
                     integration={integration}
                     repository={repository}
                   />
-                  <div className="flex items-center justify-between gap-3 pl-10">
-                    <span className="truncate font-mono text-xs text-muted-foreground">
-                      {repository.default_branch ?? 'Branch not set'}
-                    </span>
-                    <Badge
-                      variant={repository.is_private ? 'secondary' : 'outline'}
-                    >
-                      {repository.is_private ? 'Private' : 'Public'}
-                    </Badge>
-                  </div>
+                </TableCell>
+                <TableCell className="font-mono text-xs text-muted-foreground">
+                  {repository.default_branch ?? 'Not set'}
+                </TableCell>
+                <TableCell className="hidden lg:table-cell">
+                  <Badge
+                    variant={repository.is_private ? 'secondary' : 'outline'}
+                  >
+                    {repository.is_private ? 'Private' : 'Public'}
+                  </Badge>
+                </TableCell>
+                <TableCell>
                   <RepositoryRunnerPolicy
                     canWrite={canWrite}
-                    onChange={(allow) => updateRunnerPolicy(repository, allow)}
-                    pending={
-                      policyMutation.isPending &&
-                      policyMutation.variables.repositoryId === repository.id
-                    }
+                    onChange={() => onPolicySelect(repository)}
+                    pending={pendingRepositoryId === repository.id}
                     repository={repository}
                   />
-                </article>
-              ))}
-            </div>
-
-            <div className="mt-2 hidden sm:block">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Repository</TableHead>
-                    <TableHead>Default branch</TableHead>
-                    <TableHead className="hidden lg:table-cell">
-                      Visibility
-                    </TableHead>
-                    <TableHead className="text-right">Direct runner</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {repositories.map((repository) => (
-                    <TableRow key={repository.id}>
-                      <TableCell>
-                        <RepositoryIdentity
-                          integration={integration}
-                          repository={repository}
-                        />
-                      </TableCell>
-                      <TableCell className="font-mono text-xs text-muted-foreground">
-                        {repository.default_branch ?? '—'}
-                      </TableCell>
-                      <TableCell className="hidden lg:table-cell">
-                        <Badge
-                          variant={
-                            repository.is_private ? 'secondary' : 'outline'
-                          }
-                        >
-                          {repository.is_private ? 'Private' : 'Public'}
-                        </Badge>
-                      </TableCell>
-                      <TableCell>
-                        <RepositoryRunnerPolicy
-                          canWrite={canWrite}
-                          onChange={(allow) =>
-                            updateRunnerPolicy(repository, allow)
-                          }
-                          pending={
-                            policyMutation.isPending &&
-                            policyMutation.variables.repositoryId ===
-                              repository.id
-                          }
-                          repository={repository}
-                        />
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-          </>
-        )}
-      </section>
+                </TableCell>
+                {showWebhookActions ? (
+                  <TableCell>
+                    <RepositoryWebhookAction
+                      repository={repository}
+                      onSelect={() => onWebhookSelect(repository)}
+                    />
+                  </TableCell>
+                ) : null}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
     </>
+  )
+}
+
+export function IntegrationRepositoryInventory({
+  canWrite,
+  error,
+  integration,
+  isLoading,
+  onClearFilters,
+  onPageChange,
+  onPageSizeChange,
+  onRetry,
+  onRunnerFilterChange,
+  onSearch,
+  onWebhookTokenRequest,
+  page,
+  pageSize,
+  query,
+  repositories,
+  repositoryCount,
+  runnerFilter,
+  total,
+}: {
+  canWrite: boolean
+  error: Error | null
+  integration: Integration
+  isLoading: boolean
+  onClearFilters: () => void
+  onPageChange: (page: number) => void
+  onPageSizeChange: (pageSize: number) => void
+  onRetry: () => void
+  onRunnerFilterChange: (filter: RepositoryRunnerFilter) => void
+  onSearch: (query: string) => void
+  onWebhookTokenRequest?: (repository: IntegrationRepository) => void
+  page: number
+  pageSize: number
+  query?: string
+  repositories: Array<IntegrationRepository>
+  repositoryCount: number
+  runnerFilter: RepositoryRunnerFilter
+  total: number
+}) {
+  const policyMutation = useUpdateRepositoryRunnerPolicy(integration.id)
+  const [policyTarget, setPolicyTarget] =
+    useState<IntegrationRepository | null>(null)
+  const repositoryKind =
+    integration.provider === 'gitlab' ? 'projects' : 'repositories'
+
+  function updateRunnerPolicy() {
+    if (!policyTarget) return
+    const target = policyTarget
+    const allow = !target.allow_direct_macos_runner
+    setPolicyTarget(null)
+    policyMutation.mutate(
+      { repositoryId: target.id, allow },
+      {
+        onSuccess: () =>
+          toast.success(
+            allow
+              ? `${target.full_name} can now run builds.`
+              : `${target.full_name} is blocked from new builds.`,
+          ),
+        onError: (mutationError) =>
+          toast.error(
+            `Could not update ${target.full_name}: ${mutationError.message}`,
+          ),
+      },
+    )
+  }
+
+  const showControls =
+    isLoading || repositoryCount > 0 || !!query || runnerFilter !== 'all'
+  const showPagination =
+    !isLoading && !error && (total > 20 || page > 1 || pageSize !== 20)
+
+  return (
+    <section aria-label="Repository access" className="min-w-0 space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Only allowed repositories can run builds on this Mac. Leaving the rest
+        blocked is expected.
+      </p>
+
+      {showControls ? (
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <CollectionSearchInput
+            initialValue={query ?? ''}
+            onSearch={onSearch}
+            placeholder={`Search ${repositoryKind}`}
+            ariaLabel={`Search ${repositoryKind}`}
+          />
+          <NativeSelect
+            className="w-full sm:w-44"
+            aria-label="Filter by runner access"
+            value={runnerFilter}
+            onChange={(event) =>
+              onRunnerFilterChange(event.target.value as RepositoryRunnerFilter)
+            }
+          >
+            <NativeSelectOption value="all">
+              All runner states
+            </NativeSelectOption>
+            <NativeSelectOption value="blocked">Blocked</NativeSelectOption>
+            <NativeSelectOption value="allowed">Allowed</NativeSelectOption>
+          </NativeSelect>
+        </div>
+      ) : null}
+
+      {error ? (
+        <Alert variant="destructive">
+          <HugeiconsIcon icon={InformationCircleIcon} size={16} />
+          <AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <span>
+              Could not load {repositoryKind}: {error.message}
+            </span>
+            <Button variant="outline" size="sm" onClick={onRetry}>
+              Retry
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {isLoading ? (
+        <div className="space-y-3" aria-label={`Loading ${repositoryKind}`}>
+          {Array.from({ length: 5 }, (_, index) => (
+            <Skeleton key={index} className="h-12 w-full" />
+          ))}
+        </div>
+      ) : null}
+
+      {!isLoading && !error && repositoryCount === 0 ? (
+        <Empty className="bg-card">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <HugeiconsIcon icon={GitBranchIcon} />
+            </EmptyMedia>
+            <EmptyTitle>No synced {repositoryKind}</EmptyTitle>
+            <EmptyDescription>
+              Sync this source to discover the {repositoryKind} you can use.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : null}
+
+      {!isLoading && !error && repositoryCount > 0 && total === 0 ? (
+        <Empty className="bg-card">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <HugeiconsIcon icon={Search01Icon} />
+            </EmptyMedia>
+            <EmptyTitle>No matching {repositoryKind}</EmptyTitle>
+            <EmptyDescription>
+              Try a different search or runner state.
+            </EmptyDescription>
+          </EmptyHeader>
+          <EmptyContent>
+            <Button variant="outline" onClick={onClearFilters}>
+              Clear filters
+            </Button>
+          </EmptyContent>
+        </Empty>
+      ) : null}
+
+      {!isLoading && !error && repositories.length > 0 ? (
+        <RepositoryRows
+          canWrite={canWrite}
+          integration={integration}
+          onPolicySelect={setPolicyTarget}
+          onWebhookSelect={onWebhookTokenRequest}
+          pendingRepositoryId={
+            policyMutation.isPending
+              ? policyMutation.variables.repositoryId
+              : undefined
+          }
+          repositories={repositories}
+        />
+      ) : null}
+
+      {showPagination ? (
+        <CollectionPagination
+          page={page}
+          pageSize={pageSize}
+          total={total}
+          onPageChange={onPageChange}
+          onPageSizeChange={onPageSizeChange}
+        />
+      ) : null}
+
+      <AlertDialog
+        open={policyTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setPolicyTarget(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {policyTarget?.allow_direct_macos_runner
+                ? 'Block new builds?'
+                : 'Allow builds on this Mac?'}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {policyTarget?.allow_direct_macos_runner
+                ? `Running builds will finish. New builds for projects linked to ${policyTarget.full_name} will wait.`
+                : `Build commands from every project linked to ${policyTarget?.full_name ?? 'this repository'} will run with the runner account's macOS permissions.`}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={updateRunnerPolicy}>
+              {policyTarget?.allow_direct_macos_runner
+                ? 'Block new builds'
+                : 'Allow builds'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </section>
+  )
+}
+
+export function IntegrationAccountsInventory({
+  emptyDescription,
+  error,
+  installations,
+  isLoading,
+  label,
+  onRetry,
+  primaryColumnLabel = 'Account',
+}: {
+  emptyDescription: string
+  error: Error | null
+  installations: Array<IntegrationInstallation>
+  isLoading: boolean
+  label: string
+  onRetry: () => void
+  primaryColumnLabel?: string
+}) {
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <HugeiconsIcon icon={InformationCircleIcon} size={16} />
+        <AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <span>
+            Could not load {label.toLocaleLowerCase()}: {error.message}
+          </span>
+          <Button variant="outline" size="sm" onClick={onRetry}>
+            Retry
+          </Button>
+        </AlertDescription>
+      </Alert>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <div
+        className="space-y-3"
+        aria-label={`Loading ${label.toLocaleLowerCase()}`}
+      >
+        {Array.from({ length: 3 }, (_, index) => (
+          <Skeleton key={index} className="h-12 w-full" />
+        ))}
+      </div>
+    )
+  }
+
+  if (installations.length === 0) {
+    return (
+      <Empty className="bg-card">
+        <EmptyHeader>
+          <EmptyTitle>No {label.toLocaleLowerCase()}</EmptyTitle>
+          <EmptyDescription>{emptyDescription}</EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    )
+  }
+
+  return (
+    <div className="min-w-0">
+      <div className="divide-y sm:hidden">
+        {installations.map((installation) => (
+          <article key={installation.id} className="space-y-2 py-4">
+            <div className="flex items-start justify-between gap-3">
+              <h3 className="min-w-0 truncate font-medium">
+                {installation.account_name}
+              </h3>
+              <Badge variant="outline">
+                {installation.account_type ?? 'Account'}
+              </Badge>
+            </div>
+            <p className="truncate font-mono text-xs text-muted-foreground">
+              {installation.external_id}
+            </p>
+          </article>
+        ))}
+      </div>
+
+      <div className="hidden sm:block">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>{primaryColumnLabel}</TableHead>
+              <TableHead>Type</TableHead>
+              <TableHead className="hidden lg:table-cell">
+                External ID
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {installations.map((installation) => (
+              <TableRow key={installation.id}>
+                <TableCell className="font-medium">
+                  {installation.account_name}
+                </TableCell>
+                <TableCell>
+                  <Badge variant="outline">
+                    {installation.account_type ?? 'Account'}
+                  </Badge>
+                </TableCell>
+                <TableCell className="hidden font-mono text-xs text-muted-foreground lg:table-cell">
+                  {installation.external_id}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
   )
 }

--- a/apps/web/src/stores/ui-store.test.ts
+++ b/apps/web/src/stores/ui-store.test.ts
@@ -4,19 +4,33 @@ import { useUiStore } from './ui-store'
 
 beforeEach(() => {
   localStorage.clear()
-  useUiStore.setState({ commandPaletteOpen: false, sidebarOpen: true })
+  useUiStore.setState({
+    commandPaletteOpen: false,
+    directRunnerTrustNoticeAcknowledgements: {},
+    sidebarOpen: true,
+  })
 })
 
 describe('useUiStore', () => {
-  it('persists only the sidebar preference', () => {
+  it('persists sidebar and direct runner trust acknowledgements', () => {
     useUiStore.getState().setSidebarOpen(false)
     useUiStore.getState().setCommandPaletteOpen(true)
+    useUiStore
+      .getState()
+      .acknowledgeDirectRunnerTrustNotice(
+        'direct-runner-protocol-4:instance-1:user-1',
+      )
 
     const stored = JSON.parse(
       localStorage.getItem('oore-ui-preferences') ?? '{}',
     ) as { state?: Record<string, unknown> }
 
-    expect(stored.state).toEqual({ sidebarOpen: false })
+    expect(stored.state).toEqual({
+      directRunnerTrustNoticeAcknowledgements: {
+        'direct-runner-protocol-4:instance-1:user-1': true,
+      },
+      sidebarOpen: false,
+    })
   })
 
   it('restores the sidebar preference from a previous session', async () => {
@@ -28,5 +42,31 @@ describe('useUiStore', () => {
     await useUiStore.persist.rehydrate()
 
     expect(useUiStore.getState().sidebarOpen).toBe(false)
+    expect(
+      useUiStore.getState().directRunnerTrustNoticeAcknowledgements,
+    ).toEqual({})
+  })
+
+  it('restores direct runner trust acknowledgements', async () => {
+    localStorage.setItem(
+      'oore-ui-preferences',
+      JSON.stringify({
+        state: {
+          directRunnerTrustNoticeAcknowledgements: {
+            'direct-runner-protocol-4:instance-1:user-1': true,
+          },
+          sidebarOpen: true,
+        },
+        version: 0,
+      }),
+    )
+
+    await useUiStore.persist.rehydrate()
+
+    expect(
+      useUiStore.getState().directRunnerTrustNoticeAcknowledgements,
+    ).toEqual({
+      'direct-runner-protocol-4:instance-1:user-1': true,
+    })
   })
 })

--- a/apps/web/src/stores/ui-store.ts
+++ b/apps/web/src/stores/ui-store.ts
@@ -3,7 +3,9 @@ import { persist } from 'zustand/middleware'
 
 interface UiStoreState {
   commandPaletteOpen: boolean
+  directRunnerTrustNoticeAcknowledgements: Record<string, true>
   sidebarOpen: boolean
+  acknowledgeDirectRunnerTrustNotice: (noticeKey: string) => void
   setCommandPaletteOpen: (open: boolean) => void
   setSidebarOpen: (open: boolean) => void
   toggleCommandPalette: () => void
@@ -13,7 +15,15 @@ export const useUiStore = create<UiStoreState>()(
   persist(
     (set) => ({
       commandPaletteOpen: false,
+      directRunnerTrustNoticeAcknowledgements: {},
       sidebarOpen: true,
+      acknowledgeDirectRunnerTrustNotice: (noticeKey) =>
+        set((state) => ({
+          directRunnerTrustNoticeAcknowledgements: {
+            ...state.directRunnerTrustNoticeAcknowledgements,
+            [noticeKey]: true,
+          },
+        })),
       setCommandPaletteOpen: (commandPaletteOpen) =>
         set({ commandPaletteOpen }),
       setSidebarOpen: (sidebarOpen) => set({ sidebarOpen }),
@@ -22,7 +32,11 @@ export const useUiStore = create<UiStoreState>()(
     }),
     {
       name: 'oore-ui-preferences',
-      partialize: (state) => ({ sidebarOpen: state.sidebarOpen }),
+      partialize: (state) => ({
+        directRunnerTrustNoticeAcknowledgements:
+          state.directRunnerTrustNoticeAcknowledgements,
+        sidebarOpen: state.sidebarOpen,
+      }),
     },
   ),
 )

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -14,6 +14,14 @@ Rules:
 
 ## 2026-07-18
 
+- **Source trust controls at repository scale**:
+  - Source details now open on one searchable, runner-state-filtered repository inventory with 20/50/100 pagination. Accounts and connection metadata live in separate tabs, while sync and provider actions stay in the page header.
+  - Direct runner access uses neutral Allowed/Blocked controls and states that leaving repositories blocked is expected. The global trust notice is acknowledged once per user and instance; it no longer treats approval of every discovered repository as setup completion.
+  - GitLab webhook tokens are created only from a selected project action. Rotation requires confirmation, the one-time reveal names the project and includes the webhook URL, and closing the dialog clears the secret from the page.
+  - Repository and account query failures now render explicit retry states instead of appearing as empty inventories.
+  - Frontend Quality: https://linear.app/oorebuild/document/feature-frontend-product-quality-and-build-experience-overhaul-c257decee5c5
+  - Product Trust feature doc: https://linear.app/oorebuild/document/feature-product-trust-hardening-release-592dfc525e77
+
 - **Direct macOS runner trust policy**:
   - The supported V1 runner now executes checkout and repository commands directly as the runner's macOS account. The unsupported Seatbelt profile and temporary Swift sandbox workaround are removed; private workspaces, cleanup, checkout credential scoping, environment scrubbing, late one-time signing grants, fixed signer selection, artifact verification, cancellation, logging, and managed service updates remain.
   - Runner protocol v4 prevents older sandboxed runners from silently claiming new jobs. Direct runner execution and every repository approval default off, only Owners and Admins may change them, and the claim query skips policy-blocked jobs while already-running builds drain normally. Queued build responses and the UI report the exact policy block reason.


### PR DESCRIPTION
Redesigns source details around a compact, searchable, paginated repository inventory; keeps repository trust explicit and opt-in; moves GitLab webhook token creation into a selected-project action; and makes the direct-runner notice dismissible once per user and instance. Validation: make validate, 14 focused frontend tests, React Doctor with no issues, and an independent UX/security review with no blockers.