### PR TITLE
fix(installer): accept false boolean values

### DIFF
--- a/scripts/install-acceptance.sh
+++ b/scripts/install-acceptance.sh
@@ -305,6 +305,14 @@ should_open_browser
 OORE_NO_OPEN=1
 ! should_open_browser
 
+validate_optional_bool_env TEST_BOOL true
+validate_optional_bool_env TEST_BOOL false
+if bool_error="$(validate_optional_bool_env TEST_BOOL invalid 2>&1)"; then
+  echo '[install-acceptance] expected invalid optional boolean to fail' >&2
+  exit 1
+fi
+[[ "$bool_error" == *"TEST_BOOL must be one of"* ]]
+
 LOCAL_WEB_URL="http://127.0.0.1:4173"
 curl_quick() { printf '<html>not oore-web</html>\n'; }
 if is_local_web_healthy; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -626,8 +626,9 @@ validate_optional_bool_env() {
 
   if normalize_bool "$value"; then
     return 0
+  else
+    status="$?"
   fi
-  status="$?"
   if [[ "$status" -eq 1 ]]; then
     return 0
   fi


### PR DESCRIPTION
## What changed

- preserve `normalize_bool`'s status when a valid false value is supplied
- cover true, false, and invalid optional boolean inputs in installer acceptance

## Why

The alpha installer defaults `OORE_WEB_BROWSER_TRANSPORT_PROTECTED` to `false`. The validator lost the command status after the `if`, so that valid default was rejected and installation stopped.

## Validation

- `bash scripts/install-acceptance.sh`
- `make validate`
