### PR TITLE
fix(release): preserve executable binary modes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,39 +225,42 @@ jobs:
           mkdir -p "$stage_web_darwin_arm/bin" "$stage_web_darwin_x64/bin"
           mkdir -p "$stage_web_linux_arm/bin" "$stage_web_linux_x64/bin"
 
-          cp "dist/rust/arm64/oored" "$stage_arm/bin/oored"
-          cp "dist/rust/arm64/oore"  "$stage_arm/bin/oore"
-          cp "dist/oore-web-arm64" "$stage_arm/bin/oore-web"
+          install -m 0755 "dist/rust/arm64/oored" "$stage_arm/bin/oored"
+          install -m 0755 "dist/rust/arm64/oore"  "$stage_arm/bin/oore"
+          install -m 0755 "dist/oore-web-arm64" "$stage_arm/bin/oore-web"
           cp -R "apps/web/dist" "$stage_arm/web-dist"
           cp "LICENSE" "$stage_arm/LICENSE"
           printf '%s\n' "$ver" > "$stage_arm/VERSION"
 
-          cp "dist/rust/x86_64/oored" "$stage_x64/bin/oored"
-          cp "dist/rust/x86_64/oore"  "$stage_x64/bin/oore"
-          cp "dist/oore-web-x86_64" "$stage_x64/bin/oore-web"
+          install -m 0755 "dist/rust/x86_64/oored" "$stage_x64/bin/oored"
+          install -m 0755 "dist/rust/x86_64/oore"  "$stage_x64/bin/oore"
+          install -m 0755 "dist/oore-web-x86_64" "$stage_x64/bin/oore-web"
           cp -R "apps/web/dist" "$stage_x64/web-dist"
           cp "LICENSE" "$stage_x64/LICENSE"
           printf '%s\n' "$ver" > "$stage_x64/VERSION"
 
-          cp "dist/oore-web-arm64" "$stage_web_darwin_arm/bin/oore-web"
+          install -m 0755 "dist/oore-web-arm64" "$stage_web_darwin_arm/bin/oore-web"
           cp -R "apps/web/dist" "$stage_web_darwin_arm/web-dist"
           cp "LICENSE" "$stage_web_darwin_arm/LICENSE"
           printf '%s\n' "$ver" > "$stage_web_darwin_arm/VERSION"
 
-          cp "dist/oore-web-x86_64" "$stage_web_darwin_x64/bin/oore-web"
+          install -m 0755 "dist/oore-web-x86_64" "$stage_web_darwin_x64/bin/oore-web"
           cp -R "apps/web/dist" "$stage_web_darwin_x64/web-dist"
           cp "LICENSE" "$stage_web_darwin_x64/LICENSE"
           printf '%s\n' "$ver" > "$stage_web_darwin_x64/VERSION"
 
-          cp "dist/oore-web-linux-arm64" "$stage_web_linux_arm/bin/oore-web"
+          install -m 0755 "dist/oore-web-linux-arm64" "$stage_web_linux_arm/bin/oore-web"
           cp -R "apps/web/dist" "$stage_web_linux_arm/web-dist"
           cp "LICENSE" "$stage_web_linux_arm/LICENSE"
           printf '%s\n' "$ver" > "$stage_web_linux_arm/VERSION"
 
-          cp "dist/oore-web-linux-x86_64" "$stage_web_linux_x64/bin/oore-web"
+          install -m 0755 "dist/oore-web-linux-x86_64" "$stage_web_linux_x64/bin/oore-web"
           cp -R "apps/web/dist" "$stage_web_linux_x64/web-dist"
           cp "LICENSE" "$stage_web_linux_x64/LICENSE"
           printf '%s\n' "$ver" > "$stage_web_linux_x64/VERSION"
+
+          [[ -x "$stage_arm/bin/oore" && -x "$stage_arm/bin/oored" && -x "$stage_arm/bin/oore-web" ]]
+          [[ -x "$stage_x64/bin/oore" && -x "$stage_x64/bin/oored" && -x "$stage_x64/bin/oore-web" ]]
 
           out="dist/releases/$tag"
           arm_asset="$(printf 'oore_%s_darwin_arm64.tar.gz' "$ver")"

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -14,6 +14,10 @@ Rules:
 
 ## 2026-07-21
 
+- **Executable release binaries**:
+  - Release packaging now restores executable modes after the GitHub artifact handoff and fails before archive creation if the staged macOS binaries are not executable.
+  - Release channels doc: https://linear.app/oorebuild/document/release-channels-alpha-beta-stable-via-woodpecker-github-releases-993db297927a
+
 - **Boot-safe, no-worry Direct runner operation**:
   - macOS `all` and `backend` installs now enroll the local Direct runner and install it as a separate system LaunchDaemon alongside `oored`. Both services start at boot as the selected non-root account without requiring a GUI login, and repairing the runner with `oore runner install-service --managed-local` also repairs local enrollment without adopting a manually registered external runner config.
   - Hosts upgrading from earlier login-session daemon/runner jobs rerun the current installer for their installed release channel. Before any shell-side replacement, it delegates the verified archive to the candidate updater transaction, which drains active work, snapshots the release and database, converts both services to boot-time LaunchDaemons, verifies backend readiness and the runner heartbeat, and restores the old data, release, and service definitions on failure. After this migration, boot recovery and future managed updates are automatic.


### PR DESCRIPTION
## What changed

- stage every release binary with mode `0755`
- fail packaging if the macOS backend archives contain non-executable staged binaries

## Root cause

The GitHub artifact handoff normalized the Rust binaries to `0644`. The installer correctly rejected the resulting archive before replacing anything.

## Validation

- reproduced `0644` modes in the published `v0.1.32-alpha.10` archive
- round-tripped that binary through the corrected packaging path as `0755`
- `make validate`
