### PR TITLE
fix(update): support stopped legacy daemons

### DIFF
--- a/crates/oore/src/main.rs
+++ b/crates/oore/src/main.rs
@@ -7202,7 +7202,7 @@ struct PreparedUpdateRelease {
 }
 
 fn compiled_daemon_package_version(executable: &Path) -> anyhow::Result<String> {
-    let output = std::process::Command::new(executable)
+    let package_output = std::process::Command::new(executable)
         .arg("package-version")
         .output()
         .with_context(|| {
@@ -7211,10 +7211,22 @@ fn compiled_daemon_package_version(executable: &Path) -> anyhow::Result<String> 
                 executable.display()
             )
         })?;
-    anyhow::ensure!(
-        output.status.success(),
-        "candidate daemon did not report its compiled package version"
-    );
+    let output = if package_output.status.success() {
+        package_output
+    } else {
+        let empty_install_root =
+            tempfile::tempdir().context("failed to prepare legacy daemon package version probe")?;
+        let legacy_output = std::process::Command::new(executable)
+            .arg("version")
+            .env("OORE_INSTALL_ROOT", empty_install_root.path())
+            .output()
+            .with_context(|| format!("failed to inspect legacy daemon {}", executable.display()))?;
+        anyhow::ensure!(
+            legacy_output.status.success(),
+            "daemon did not report its compiled package version"
+        );
+        legacy_output
+    };
     let version = String::from_utf8(output.stdout)?.trim().to_string();
     anyhow::ensure!(
         !version.is_empty(),
@@ -7990,6 +8002,20 @@ fn main() -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn package_version_probe_supports_legacy_daemons() {
+        let temp = tempfile::tempdir().unwrap();
+        let daemon = temp.path().join("oored");
+        fs::write(
+            &daemon,
+            "#!/bin/sh\n[ \"$1\" = version ] && [ ! -f \"$OORE_INSTALL_ROOT/VERSION\" ] && printf '0.1.10\\n'\n",
+        )
+        .unwrap();
+        set_executable(&daemon).unwrap();
+
+        assert_eq!(compiled_daemon_package_version(&daemon).unwrap(), "0.1.10");
+    }
 
     #[test]
     fn backup_output_is_private_before_first_write() {

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -14,6 +14,10 @@ Rules:
 
 ## 2026-07-21
 
+- **Stopped legacy daemon upgrades**:
+  - Managed updates can now recover the compiled package version from pre-`package-version` daemons when the existing backend is stopped, preserving rollback verification for upgrades from older alpha releases.
+  - Runtime updates feature doc: https://linear.app/oorebuild/document/feature-runtime-updates-from-the-web-ui-6b648f19a3f9
+
 - **Executable release binaries**:
   - Release packaging now restores executable modes after the GitHub artifact handoff and fails before archive creation if the staged macOS binaries are not executable.
   - Release channels doc: https://linear.app/oorebuild/document/release-channels-alpha-beta-stable-via-woodpecker-github-releases-993db297927a


### PR DESCRIPTION
## What changed

- keep the strict `package-version` probe for current daemons
- fall back to the legacy `version` command with an empty install root for older stopped daemons
- cover the compatibility path with a focused regression test

## Root cause

`v0.1.32-alpha.8` predates the hidden `package-version` command. When its backend was stopped, rollback preparation tried that unsupported command instead of reading the running daemon health response and aborted before mutation.

## Validation

- verified the actual alpha.8 daemon rejects `package-version` and reports compiled version `0.1.10` through the isolated fallback
- `cargo test -p oore package_version_probe_supports_legacy_daemons`
- `make validate`
