### PR TITLE
fix(update): supervise web backend upgrades

### DIFF
--- a/apps/site/public/uninstall
+++ b/apps/site/public/uninstall
@@ -11,6 +11,8 @@ DATA_DIR="$HOME/Library/Application Support/oore"
 DAEMON_LAUNCH_AGENT_LABEL="build.oore.oored"
 DAEMON_LAUNCH_AGENT_PLIST="$HOME/Library/LaunchAgents/$DAEMON_LAUNCH_AGENT_LABEL.plist"
 DAEMON_LAUNCH_DAEMON_PLIST="/Library/LaunchDaemons/$DAEMON_LAUNCH_AGENT_LABEL.plist"
+UPDATER_LAUNCH_DAEMON_LABEL="build.oore.oore-updater"
+UPDATER_LAUNCH_DAEMON_PLIST="/Library/LaunchDaemons/$UPDATER_LAUNCH_DAEMON_LABEL.plist"
 RUNNER_LAUNCH_AGENT_LABEL="build.oore.oore-runner"
 RUNNER_LAUNCH_AGENT_PLIST="$HOME/Library/LaunchAgents/$RUNNER_LAUNCH_AGENT_LABEL.plist"
 RUNNER_LAUNCH_DAEMON_PLIST="/Library/LaunchDaemons/$RUNNER_LAUNCH_AGENT_LABEL.plist"
@@ -333,6 +335,13 @@ remove_runner_service() {
     "legacy runner launch agent"
 }
 
+remove_updater_service() {
+  remove_system_launchd_service \
+    "$UPDATER_LAUNCH_DAEMON_LABEL" \
+    "$UPDATER_LAUNCH_DAEMON_PLIST" \
+    "backend updater"
+}
+
 stop_local_web() {
   if [[ -f "$WEB_PID_FILE" ]]; then
     local pid=""
@@ -452,12 +461,14 @@ main() {
 
   if [[ ! -d "$OORE_INSTALL_ROOT" ]] \
     && [[ ! -f "$DAEMON_LAUNCH_DAEMON_PLIST" ]] \
+    && [[ ! -f "$UPDATER_LAUNCH_DAEMON_PLIST" ]] \
     && [[ ! -f "$RUNNER_LAUNCH_DAEMON_PLIST" ]] \
     && [[ ! -f "$DAEMON_LAUNCH_AGENT_PLIST" ]] \
     && [[ ! -f "$RUNNER_LAUNCH_AGENT_PLIST" ]] \
     && [[ ! -f "$WEB_LAUNCH_AGENT_PLIST" ]] \
     && [[ ! -f "$WEB_SYSTEMD_SERVICE_FILE" ]] \
     && ! system_launchd_job_is_loaded "$DAEMON_LAUNCH_AGENT_LABEL" \
+    && ! system_launchd_job_is_loaded "$UPDATER_LAUNCH_DAEMON_LABEL" \
     && ! system_launchd_job_is_loaded "$RUNNER_LAUNCH_AGENT_LABEL" \
     && ! user_launchd_job_is_loaded "$DAEMON_LAUNCH_AGENT_LABEL" \
     && ! user_launchd_job_is_loaded "$RUNNER_LAUNCH_AGENT_LABEL" \
@@ -475,6 +486,7 @@ main() {
   fi
 
   remove_runner_service
+  remove_updater_service
   remove_daemon_launch_agent
   stop_daemon
   stop_local_web

--- a/crates/oore-contract/src/lib.rs
+++ b/crates/oore-contract/src/lib.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::path::PathBuf;
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
@@ -409,6 +410,15 @@ pub struct RuntimeUpdateStatus {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     pub managed_service: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DeferredRuntimeUpdateRequest {
+    pub parent_pid: u32,
+    pub database: PathBuf,
+    pub key: PathBuf,
+    pub daemon_url: String,
+    pub status: PathBuf,
 }
 
 // ── User management types ───────────────────────────────────────

--- a/crates/oore/src/main.rs
+++ b/crates/oore/src/main.rs
@@ -14,13 +14,13 @@ use chrono::{Local, TimeZone};
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use oore_contract::{
     ApiError, BootstrapTokenRecord, BootstrapTokenVerifyRequest, BootstrapTokenVerifyResponse,
-    LOCAL_RECOVERY_MAX_TTL_SECS, LOCAL_RECOVERY_MIN_TTL_SECS, LOCAL_RECOVERY_SOCKET_DIR,
-    LOCAL_RECOVERY_SOCKET_FILE, ListBuildsResponse, ListRunnersResponse, LocalLoginRequest,
-    LocalLoginResponse, LocalRecoveryMintRequest, LocalRecoveryMintResponse, OidcConfigureRequest,
-    OidcConfigureResponse, RegisterRunnerResponse, RemoteAuthMode, RuntimeMode,
-    SetupCompleteResponse, SetupOidcStartRequest, SetupOidcStartResponse, SetupOidcVerifyRequest,
-    SetupOidcVerifyResponse, SetupState, SetupStateFile, SetupStatus, UserProfileResponse,
-    parse_repository_pipeline_yaml,
+    DeferredRuntimeUpdateRequest, LOCAL_RECOVERY_MAX_TTL_SECS, LOCAL_RECOVERY_MIN_TTL_SECS,
+    LOCAL_RECOVERY_SOCKET_DIR, LOCAL_RECOVERY_SOCKET_FILE, ListBuildsResponse, ListRunnersResponse,
+    LocalLoginRequest, LocalLoginResponse, LocalRecoveryMintRequest, LocalRecoveryMintResponse,
+    OidcConfigureRequest, OidcConfigureResponse, RegisterRunnerResponse, RemoteAuthMode,
+    RuntimeMode, SetupCompleteResponse, SetupOidcStartRequest, SetupOidcStartResponse,
+    SetupOidcVerifyRequest, SetupOidcVerifyResponse, SetupState, SetupStateFile, SetupStatus,
+    UserProfileResponse, parse_repository_pipeline_yaml,
 };
 use oore_runner::RunnerConfig;
 use rand::RngCore;
@@ -95,6 +95,8 @@ enum Commands {
     Version,
     /// Update oore and oored to the latest release
     Update(UpdateArgs),
+    #[command(hide = true)]
+    UpdateSupervisor(UpdateSupervisorArgs),
     /// Create, verify, or restore an encrypted-state backup
     Backup(BackupArgs),
 }
@@ -249,6 +251,12 @@ struct UpdateArgs {
 
     #[arg(long, hide = true)]
     deferred_status_file: Option<PathBuf>,
+}
+
+#[derive(Debug, Args)]
+struct UpdateSupervisorArgs {
+    #[arg(long)]
+    request_file: PathBuf,
 }
 
 #[derive(Debug, Args)]
@@ -7590,6 +7598,66 @@ async fn handle_deferred_update(args: UpdateArgs) -> anyhow::Result<()> {
         .await
 }
 
+async fn handle_update_supervisor(args: UpdateSupervisorArgs) -> anyhow::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let install_root = resolve_install_root()?;
+    let expected = install_root
+        .join("run/runtime-update-queue")
+        .join("request.json");
+    anyhow::ensure!(
+        args.request_file == expected,
+        "runtime update request must be {}",
+        expected.display()
+    );
+    let metadata = fs::symlink_metadata(&args.request_file)
+        .with_context(|| format!("failed to inspect {}", args.request_file.display()))?;
+    anyhow::ensure!(
+        metadata.file_type().is_file(),
+        "runtime update request is not a file"
+    );
+    anyhow::ensure!(
+        metadata.uid() == unsafe { libc::geteuid() },
+        "runtime update request is owned by another user"
+    );
+    anyhow::ensure!(
+        metadata.permissions().mode() & 0o077 == 0,
+        "runtime update request permissions are too broad"
+    );
+
+    let active = install_root
+        .join("run")
+        .join(format!("runtime-update-active-{}.json", std::process::id()));
+    fs::rename(&args.request_file, &active).context("failed to claim runtime update request")?;
+    let result = async {
+        let request: DeferredRuntimeUpdateRequest = serde_json::from_slice(
+            &fs::read(&active).context("failed to read runtime update request")?,
+        )
+        .context("invalid runtime update request")?;
+        handle_deferred_update(UpdateArgs {
+            check: false,
+            force: false,
+            channel: None,
+            repo: None,
+            staged_release: None,
+            ensure_managed_runner: false,
+            deferred_parent_pid: Some(request.parent_pid),
+            deferred_state_file: Some(request.database),
+            deferred_key_file: Some(request.key),
+            deferred_daemon_url: Some(request.daemon_url),
+            deferred_status_file: Some(request.status),
+        })
+        .await
+    }
+    .await;
+    let cleanup = fs::remove_file(&active).context("failed to clear runtime update request");
+    match (result, cleanup) {
+        (Err(error), _) => Err(error),
+        (Ok(()), Err(error)) => Err(error),
+        (Ok(()), Ok(())) => Ok(()),
+    }
+}
+
 async fn handle_update(args: UpdateArgs) -> anyhow::Result<()> {
     let install_root = resolve_install_root()?;
     let defer_daemon_restart = std::env::var_os("OORE_UPDATE_DEFER_DAEMON_RESTART").is_some();
@@ -8034,6 +8102,11 @@ fn main() -> anyhow::Result<()> {
             let runtime =
                 tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
             runtime.block_on(handle_update(args))?;
+        }
+        Commands::UpdateSupervisor(args) => {
+            let runtime =
+                tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
+            runtime.block_on(handle_update_supervisor(args))?;
         }
         Commands::Backup(args) => match args.command {
             BackupSubcommand::Create(args) => backup_create(args)?,

--- a/crates/oored/src/runtime_updates.rs
+++ b/crates/oored/src/runtime_updates.rs
@@ -1,4 +1,3 @@
-use std::ffi::OsString;
 use std::fs;
 use std::io::Write;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
@@ -11,7 +10,9 @@ use anyhow::Context;
 use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
-use oore_contract::{ApiError, RuntimeUpdatePhase, RuntimeUpdateStatus};
+use oore_contract::{
+    ApiError, DeferredRuntimeUpdateRequest, RuntimeUpdatePhase, RuntimeUpdateStatus,
+};
 use tokio::sync::RwLock;
 
 use crate::AppState;
@@ -20,13 +21,18 @@ use crate::store::write_audit_log;
 use crate::util::api_err;
 
 const SYSTEM_SERVICE_PLIST: &str = "/Library/LaunchDaemons/build.oore.oored.plist";
+const UPDATE_SERVICE_PLIST: &str = "/Library/LaunchDaemons/build.oore.oore-updater.plist";
+const UPDATE_SERVICE: &str = "system/build.oore.oore-updater";
 const UPDATE_STATUS_FILE: &str = ".runtime-update-status.json";
-const UPDATE_LOG_FILE: &str = "runtime-update.log";
+const UPDATE_REQUEST_DIR: &str = "run/runtime-update-queue";
+const UPDATE_REQUEST_FILE: &str = "request.json";
 
 pub type RuntimeUpdateState = Arc<RwLock<RuntimeUpdateStatus>>;
 
 fn managed_service_installed() -> bool {
-    cfg!(target_os = "macos") && Path::new(SYSTEM_SERVICE_PLIST).is_file()
+    cfg!(target_os = "macos")
+        && Path::new(SYSTEM_SERVICE_PLIST).is_file()
+        && Path::new(UPDATE_SERVICE_PLIST).is_file()
 }
 
 fn install_root_from_current_exe() -> anyhow::Result<PathBuf> {
@@ -148,43 +154,72 @@ fn loopback_daemon_url() -> anyhow::Result<String> {
 }
 
 struct DeferredUpdateInvocation {
-    oore: PathBuf,
     parent_pid: u32,
     database: PathBuf,
     key: PathBuf,
     daemon_url: String,
     status: PathBuf,
-    log: PathBuf,
-    label: String,
 }
 
-impl DeferredUpdateInvocation {
-    fn launchctl_args(&self) -> Vec<OsString> {
-        vec![
-            "submit".into(),
-            "-l".into(),
-            self.label.clone().into(),
-            "-o".into(),
-            self.log.as_os_str().to_owned(),
-            "-e".into(),
-            self.log.as_os_str().to_owned(),
-            "--".into(),
-            "/usr/bin/env".into(),
-            "OORE_UPDATE_DEFER_DAEMON_RESTART=1".into(),
-            self.oore.as_os_str().to_owned(),
-            "update".into(),
-            "--deferred-parent-pid".into(),
-            self.parent_pid.to_string().into(),
-            "--deferred-state-file".into(),
-            self.database.as_os_str().to_owned(),
-            "--deferred-key-file".into(),
-            self.key.as_os_str().to_owned(),
-            "--deferred-daemon-url".into(),
-            self.daemon_url.clone().into(),
-            "--deferred-status-file".into(),
-            self.status.as_os_str().to_owned(),
-        ]
+impl From<DeferredUpdateInvocation> for DeferredRuntimeUpdateRequest {
+    fn from(invocation: DeferredUpdateInvocation) -> Self {
+        Self {
+            parent_pid: invocation.parent_pid,
+            database: invocation.database,
+            key: invocation.key,
+            daemon_url: invocation.daemon_url,
+            status: invocation.status,
+        }
     }
+}
+
+fn write_update_request(path: &Path, request: &DeferredRuntimeUpdateRequest) -> anyhow::Result<()> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let parent = path
+        .parent()
+        .context("runtime update request has no parent")?;
+    fs::create_dir_all(parent)?;
+    let temporary = parent.join(format!(".{UPDATE_REQUEST_FILE}.{}.tmp", std::process::id()));
+    let mut file = fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .mode(0o600)
+        .open(&temporary)?;
+    if let Err(error) = (|| -> anyhow::Result<()> {
+        serde_json::to_writer(&mut file, request)?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+        fs::rename(&temporary, path)?;
+        fs::File::open(parent)?.sync_all()?;
+        Ok(())
+    })() {
+        let _ = fs::remove_file(&temporary);
+        return Err(error).context("failed to publish the runtime update request");
+    }
+    Ok(())
+}
+
+fn start_update_supervisor(
+    path: &Path,
+    request: &DeferredRuntimeUpdateRequest,
+) -> anyhow::Result<()> {
+    write_update_request(path, request)?;
+    let output = Command::new("/bin/launchctl")
+        .args(["kickstart", UPDATE_SERVICE])
+        .output()
+        .context("failed to start the managed update supervisor")?;
+    if !output.status.success() {
+        let _ = fs::remove_file(path);
+        let diagnostic = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let suffix = if diagnostic.is_empty() {
+            String::new()
+        } else {
+            format!(": {diagnostic}")
+        };
+        anyhow::bail!("managed update supervisor did not start{suffix}");
+    }
+    Ok(())
 }
 
 pub async fn get_status(
@@ -250,30 +285,31 @@ pub async fn start_update(
             error.to_string(),
         )
     })?;
-    let logs = install_root.join("logs");
-    fs::create_dir_all(&logs).map_err(|error| {
-        api_err(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "runtime_update_unavailable",
-            format!("Failed to prepare the update log: {error}"),
-        )
-    })?;
+    let request_path = install_root
+        .join(UPDATE_REQUEST_DIR)
+        .join(UPDATE_REQUEST_FILE);
+    if request_path.exists() {
+        return Err(api_err(
+            StatusCode::CONFLICT,
+            "runtime_update_in_progress",
+            "A backend update request is already queued",
+        ));
+    }
+    fs::create_dir_all(request_path.parent().expect("request path has a parent")).map_err(
+        |error| {
+            api_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "runtime_update_unavailable",
+                format!("Failed to prepare the update queue: {error}"),
+            )
+        },
+    )?;
     let invocation = DeferredUpdateInvocation {
-        oore,
         parent_pid: std::process::id(),
         database,
         key,
         daemon_url,
         status: status_path.clone(),
-        log: logs.join(UPDATE_LOG_FILE),
-        label: format!(
-            "build.oore.runtime-update.{}.{}",
-            std::process::id(),
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_nanos()
-        ),
     };
 
     {
@@ -292,7 +328,7 @@ pub async fn start_update(
             return Err(api_err(
                 StatusCode::CONFLICT,
                 "runtime_update_unmanaged",
-                "Backend updates from the web require the managed macOS launchd service",
+                "Backend updates from the web require the managed macOS update supervisor; run the installer once from Terminal to finish service setup",
             ));
         }
         if matches!(
@@ -334,20 +370,17 @@ pub async fn start_update(
     }
 
     let result = tokio::task::spawn_blocking(move || {
-        Command::new("/bin/launchctl")
-            .args(invocation.launchctl_args())
-            .output()
+        start_update_supervisor(&request_path, &invocation.into())
     })
     .await;
     let failure = match result {
-        Ok(Ok(output)) if output.status.success() => None,
-        Ok(Ok(output)) => Some(String::from_utf8_lossy(&output.stderr).trim().to_string()),
+        Ok(Ok(())) => None,
         Ok(Err(error)) => Some(error.to_string()),
         Err(error) => Some(error.to_string()),
     };
     if let Some(failure) = failure {
         let diagnostic = if failure.is_empty() {
-            "launchd rejected the backend update job".to_string()
+            "Could not queue the backend update".to_string()
         } else {
             failure.chars().take(2_000).collect()
         };
@@ -373,31 +406,45 @@ mod tests {
     use super::*;
 
     #[test]
-    fn launchd_job_carries_the_complete_deferred_update_contract() {
+    fn queued_request_carries_the_complete_deferred_update_contract() {
         let invocation = DeferredUpdateInvocation {
-            oore: "/opt/oore/bin/oore".into(),
             parent_pid: 42,
             database: "/data/oore.db".into(),
             key: "/data/encryption.key".into(),
             daemon_url: "http://127.0.0.1:8787".into(),
             status: "/opt/oore/.runtime-update-status.json".into(),
-            log: "/opt/oore/logs/runtime-update.log".into(),
-            label: "build.oore.runtime-update.test".into(),
         };
-        let arguments = invocation
-            .launchctl_args()
-            .into_iter()
-            .map(|value| value.to_string_lossy().into_owned())
-            .collect::<Vec<_>>();
-        for required in [
-            "OORE_UPDATE_DEFER_DAEMON_RESTART=1",
-            "--deferred-parent-pid",
-            "--deferred-state-file",
-            "--deferred-key-file",
-            "--deferred-daemon-url",
-            "--deferred-status-file",
-        ] {
-            assert!(arguments.iter().any(|argument| argument == required));
-        }
+        let request = DeferredRuntimeUpdateRequest::from(invocation);
+        assert_eq!(request.parent_pid, 42);
+        assert_eq!(request.database, Path::new("/data/oore.db"));
+        assert_eq!(request.key, Path::new("/data/encryption.key"));
+        assert_eq!(request.daemon_url, "http://127.0.0.1:8787");
+        assert_eq!(
+            request.status,
+            Path::new("/opt/oore/.runtime-update-status.json")
+        );
+    }
+
+    #[test]
+    fn queued_request_is_private_and_complete_before_publish() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join(UPDATE_REQUEST_FILE);
+        let request = DeferredRuntimeUpdateRequest {
+            parent_pid: 42,
+            database: "/data/oore.db".into(),
+            key: "/data/encryption.key".into(),
+            daemon_url: "http://127.0.0.1:8787".into(),
+            status: "/opt/oore/.runtime-update-status.json".into(),
+        };
+
+        write_update_request(&path, &request).unwrap();
+
+        assert_eq!(path.metadata().unwrap().permissions().mode() & 0o777, 0o600);
+        let persisted: DeferredRuntimeUpdateRequest =
+            serde_json::from_slice(&fs::read(path).unwrap()).unwrap();
+        assert_eq!(persisted.parent_pid, 42);
+        assert_eq!(persisted.status, request.status);
     }
 }

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -14,6 +14,11 @@ Rules:
 
 ## 2026-07-21
 
+- **Independent web-update supervisor**:
+  - Managed macOS installs now include a least-privilege launchd updater job. The backend writes a private, validated request and kickstarts that pre-installed job, allowing the daemon and runner to restart without terminating the rollback-safe update transaction.
+  - Existing managed installations add the supervisor during their next terminal installer upgrade; later backend updates remain one-click from the web UI.
+  - Runtime updates feature doc: https://linear.app/oorebuild/document/feature-runtime-updates-from-the-web-ui-6b648f19a3f9
+
 - **Stopped legacy daemon upgrades**:
   - Managed updates can now recover the compiled package version from pre-`package-version` daemons when the existing backend is stopped, preserving rollback verification for upgrades from older alpha releases.
   - Runtime updates feature doc: https://linear.app/oorebuild/document/feature-runtime-updates-from-the-web-ui-6b648f19a3f9

--- a/scripts/install-acceptance.sh
+++ b/scripts/install-acceptance.sh
@@ -206,6 +206,10 @@ OORE_INSTALL_ROOT="$service_bin_dir"
 LOG_DIR="$service_bin_dir/logs"
 DAEMON_LOG="$LOG_DIR/oored.log"
 DAEMON_LAUNCH_DAEMON_PLIST="$service_bin_dir/build.oore.oored.plist"
+UPDATER_LAUNCH_DAEMON_PLIST="$service_bin_dir/build.oore.oore-updater.plist"
+UPDATER_QUEUE_DIR="$service_bin_dir/run/runtime-update-queue"
+UPDATER_REQUEST_FILE="$UPDATER_QUEUE_DIR/request.json"
+UPDATER_LOG="$LOG_DIR/runtime-update.log"
 sudo() {
   printf '%s\n' "$*" >> "$sudo_call"
   case "$1" in
@@ -237,6 +241,7 @@ if command -v plutil >/dev/null 2>&1; then
   render_system_daemon_plist appbuilder | plutil -lint - >/dev/null
 fi
 install_daemon_service
+install_update_service
 install_runner_service
 grep -q -- '^uninstall-service$' "$oored_call"
 grep -q -- '^runner install-service --managed-local --daemon-url http://127.0.0.1:8787$' "$oore_call"
@@ -249,6 +254,7 @@ grep -q -- '^/usr/bin/install -o root -g wheel -m 0600 /dev/null .*build.oore.oo
 grep -q -- '^/usr/bin/tee .*build.oore.oored.plist.install.' "$sudo_call"
 grep -q -- '^/bin/launchctl bootstrap system .*build.oore.oored.plist$' "$sudo_call"
 grep -q -- '^/bin/launchctl kickstart -k system/build.oore.oored$' "$sudo_call"
+grep -q -- '^/bin/launchctl bootstrap system .*build.oore.oore-updater.plist$' "$sudo_call"
 if grep -q -- "$service_bin_dir/oored install-service\|$service_bin_dir/oored uninstall-service" "$sudo_call"; then
   echo '[install-acceptance] user-owned oored crossed the sudo boundary' >&2
   exit 1
@@ -268,6 +274,12 @@ grep -q -- '<string>appbuilder</string>' "$DAEMON_LAUNCH_DAEMON_PLIST"
 grep -q -- "<string>$service_bin_dir/oored</string>" "$DAEMON_LAUNCH_DAEMON_PLIST"
 grep -q -- '<string>https://ci.example.test/?a=1&amp;b=2</string>' "$DAEMON_LAUNCH_DAEMON_PLIST"
 grep -q -- '<key>OORE_WARPGATE_TICKET</key>' "$DAEMON_LAUNCH_DAEMON_PLIST"
+if grep -q -- '<key>QueueDirectories</key>' "$UPDATER_LAUNCH_DAEMON_PLIST"; then
+  echo '[install-acceptance] updater service should be explicitly kickstarted' >&2
+  exit 1
+fi
+grep -q -- '<string>update-supervisor</string>' "$UPDATER_LAUNCH_DAEMON_PLIST"
+grep -q -- "<string>$UPDATER_REQUEST_FILE</string>" "$UPDATER_LAUNCH_DAEMON_PLIST"
 grep -q -- '<string>opaque-ticket</string>' "$DAEMON_LAUNCH_DAEMON_PLIST"
 unset -f sudo id curl_quick
 rm -rf "$service_bin_dir"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,6 +60,11 @@ WEB_SYSTEMD_SERVICE_FILE="$WEB_SYSTEMD_USER_DIR/$WEB_SYSTEMD_SERVICE_NAME"
 DAEMON_SERVICE_LABEL="build.oore.oored"
 DAEMON_LAUNCH_DAEMON_PLIST="/Library/LaunchDaemons/$DAEMON_SERVICE_LABEL.plist"
 DAEMON_LAUNCH_AGENT_PLIST="$HOME/Library/LaunchAgents/$DAEMON_SERVICE_LABEL.plist"
+UPDATER_SERVICE_LABEL="build.oore.oore-updater"
+UPDATER_LAUNCH_DAEMON_PLIST="/Library/LaunchDaemons/$UPDATER_SERVICE_LABEL.plist"
+UPDATER_QUEUE_DIR="$OORE_INSTALL_ROOT/run/runtime-update-queue"
+UPDATER_REQUEST_FILE="$UPDATER_QUEUE_DIR/request.json"
+UPDATER_LOG="$LOG_DIR/runtime-update.log"
 RUNNER_SERVICE_LABEL="build.oore.oore-runner"
 DAEMON_URL="$OORE_DAEMON_URL"
 WEB_BACKEND_URL="$OORE_WEB_BACKEND_URL"
@@ -1770,6 +1775,75 @@ install_daemon_service() {
   return 0
 }
 
+render_system_updater_plist() {
+  local service_user="$1"
+  cat <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>$UPDATER_SERVICE_LABEL</string>
+    <key>UserName</key>
+    <string>$(xml_escape "$service_user")</string>
+    <key>SessionCreate</key>
+    <true/>
+    <key>ProgramArguments</key>
+    <array>
+      <string>$(xml_escape "$BIN_DIR/oore")</string>
+      <string>update-supervisor</string>
+      <string>--request-file</string>
+      <string>$(xml_escape "$UPDATER_REQUEST_FILE")</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>HOME</key>
+      <string>$(xml_escape "$HOME")</string>
+      <key>PATH</key>
+      <string>$(xml_escape "$PATH")</string>
+      <key>OORE_INSTALL_ROOT</key>
+      <string>$(xml_escape "$OORE_INSTALL_ROOT")</string>
+    </dict>
+    <key>WorkingDirectory</key>
+    <string>$(xml_escape "$OORE_INSTALL_ROOT")</string>
+    <key>StandardOutPath</key>
+    <string>$(xml_escape "$UPDATER_LOG")</string>
+    <key>StandardErrorPath</key>
+    <string>$(xml_escape "$UPDATER_LOG")</string>
+  </dict>
+</plist>
+EOF
+}
+
+install_update_service() {
+  ensure_dependency sudo
+  local service_user
+  local plist_tmp="$UPDATER_LAUNCH_DAEMON_PLIST.install.$$"
+  service_user="$(id -un)"
+
+  mkdir -p "$UPDATER_QUEUE_DIR" "$LOG_DIR" || return 1
+  chmod 0700 "$UPDATER_QUEUE_DIR" || return 1
+  sudo /bin/rm -f "$plist_tmp" || return 1
+  sudo /usr/bin/install -o root -g wheel -m 0600 /dev/null "$plist_tmp" || return 1
+  if ! render_system_updater_plist "$service_user" \
+    | sudo /usr/bin/tee "$plist_tmp" >/dev/null; then
+    sudo /bin/rm -f "$plist_tmp" >/dev/null 2>&1 || true
+    return 1
+  fi
+  if ! sudo /bin/chmod 0600 "$plist_tmp" \
+    || ! sudo /usr/bin/plutil -lint "$plist_tmp" >/dev/null; then
+    sudo /bin/rm -f "$plist_tmp" >/dev/null 2>&1 || true
+    return 1
+  fi
+  sudo /bin/launchctl bootout "system/$UPDATER_SERVICE_LABEL" >/dev/null 2>&1 || true
+  sudo /bin/launchctl remove "$UPDATER_SERVICE_LABEL" >/dev/null 2>&1 || true
+  sudo /bin/mv -f "$plist_tmp" "$UPDATER_LAUNCH_DAEMON_PLIST" || return 1
+  sudo /bin/launchctl bootstrap system "$UPDATER_LAUNCH_DAEMON_PLIST" >/dev/null 2>&1 \
+    || return 1
+  sudo /bin/launchctl print "system/$UPDATER_SERVICE_LABEL" >/dev/null 2>&1 \
+    || return 1
+}
+
 runner_loopback_url() {
   local address="${OORE_DAEMON_LISTEN#http://}"
   local loopback="127.0.0.1"
@@ -1808,6 +1882,7 @@ install_runner_service() {
 
 install_backend_services() {
   install_daemon_service || return 1
+  install_update_service || return 1
   install_runner_service || return 1
 }
 
@@ -2557,6 +2632,7 @@ main() {
     # an existing managed backend. Do not mutate backend configuration or
     # reinstall services after it has committed.
     step "Finalizing upgrade..."
+    install_update_service || exit 1
     step_done "backend + runner verified"
     printf '\n%bOore CI is up to date.%b\n' "$UI_BOLD$UI_SUCCESS" "$UI_RESET"
     log "The existing managed backend, runner, and managed web UI (when configured) were restarted and verified."

--- a/scripts/uninstall-acceptance.sh
+++ b/scripts/uninstall-acceptance.sh
@@ -38,6 +38,7 @@ assert_system_uninstall_uses_root_tools() (
   local uninstaller_lib="$case_dir/uninstall-lib.sh"
   local sudo_log="$case_dir/sudo.log"
   local daemon_loaded=1
+  local updater_loaded=1
   local runner_loaded=1
 
   export HOME="$case_dir/home"
@@ -48,8 +49,9 @@ assert_system_uninstall_uses_root_tools() (
   source "$uninstaller_lib"
 
   DAEMON_LAUNCH_DAEMON_PLIST="$case_dir/build.oore.oored.plist"
+  UPDATER_LAUNCH_DAEMON_PLIST="$case_dir/build.oore.oore-updater.plist"
   RUNNER_LAUNCH_DAEMON_PLIST="$case_dir/build.oore.oore-runner.plist"
-  touch "$DAEMON_LAUNCH_DAEMON_PLIST" "$RUNNER_LAUNCH_DAEMON_PLIST"
+  touch "$DAEMON_LAUNCH_DAEMON_PLIST" "$UPDATER_LAUNCH_DAEMON_PLIST" "$RUNNER_LAUNCH_DAEMON_PLIST"
   sudo() {
     printf '%s\n' "$*" >> "$sudo_log"
 
@@ -63,11 +65,13 @@ assert_system_uninstall_uses_root_tools() (
     if [[ "${1:-}" == "/bin/launchctl" && "${2:-}" == "bootout" ]]; then
       case "${3:-}" in
         system/build.oore.oored) daemon_loaded=0 ;;
+        system/build.oore.oore-updater) updater_loaded=0 ;;
         system/build.oore.oore-runner) runner_loaded=0 ;;
       esac
     elif [[ "${1:-}" == "/bin/launchctl" && "${2:-}" == "print" ]]; then
       case "${3:-}" in
         system/build.oore.oored) [[ "$daemon_loaded" -eq 1 ]] ;;
+        system/build.oore.oore-updater) [[ "$updater_loaded" -eq 1 ]] ;;
         system/build.oore.oore-runner) [[ "$runner_loaded" -eq 1 ]] ;;
         *) return 1 ;;
       esac
@@ -82,6 +86,7 @@ assert_system_uninstall_uses_root_tools() (
     if [[ "${1:-}" == "print" ]]; then
       case "${2:-}" in
         system/build.oore.oored) [[ "$daemon_loaded" -eq 1 ]] ;;
+        system/build.oore.oore-updater) [[ "$updater_loaded" -eq 1 ]] ;;
         system/build.oore.oore-runner) [[ "$runner_loaded" -eq 1 ]] ;;
         *) return 1 ;;
       esac
@@ -91,6 +96,7 @@ assert_system_uninstall_uses_root_tools() (
   }
 
   remove_runner_service
+  remove_updater_service
   remove_daemon_launch_agent
 
   grep -q -- '^-v$' "$sudo_log"
@@ -98,11 +104,16 @@ assert_system_uninstall_uses_root_tools() (
   grep -q -- '^-n /bin/launchctl remove build.oore.oore-runner$' "$sudo_log"
   grep -q -- '^-n /bin/launchctl print system/build.oore.oore-runner$' "$sudo_log"
   grep -q -- "^-n /bin/rm -f $RUNNER_LAUNCH_DAEMON_PLIST$" "$sudo_log"
+  grep -q -- '^-n /bin/launchctl bootout system/build.oore.oore-updater$' "$sudo_log"
+  grep -q -- '^-n /bin/launchctl remove build.oore.oore-updater$' "$sudo_log"
+  grep -q -- '^-n /bin/launchctl print system/build.oore.oore-updater$' "$sudo_log"
+  grep -q -- "^-n /bin/rm -f $UPDATER_LAUNCH_DAEMON_PLIST$" "$sudo_log"
   grep -q -- '^-n /bin/launchctl bootout system/build.oore.oored$' "$sudo_log"
   grep -q -- '^-n /bin/launchctl remove build.oore.oored$' "$sudo_log"
   grep -q -- '^-n /bin/launchctl print system/build.oore.oored$' "$sudo_log"
   grep -q -- "^-n /bin/rm -f $DAEMON_LAUNCH_DAEMON_PLIST$" "$sudo_log"
   [[ ! -e "$RUNNER_LAUNCH_DAEMON_PLIST" ]]
+  [[ ! -e "$UPDATER_LAUNCH_DAEMON_PLIST" ]]
   [[ ! -e "$DAEMON_LAUNCH_DAEMON_PLIST" ]]
 )
 
@@ -122,6 +133,7 @@ assert_legacy_mode_without_system_jobs_skips_sudo() (
 
   printf 'all\n' > "$OORE_INSTALL_ROOT/INSTALL_MODE"
   DAEMON_LAUNCH_DAEMON_PLIST="$case_dir/missing-oored.plist"
+  UPDATER_LAUNCH_DAEMON_PLIST="$case_dir/missing-updater.plist"
   RUNNER_LAUNCH_DAEMON_PLIST="$case_dir/missing-runner.plist"
   sudo() {
     printf '%s\n' "$*" >> "$sudo_log"
@@ -132,6 +144,7 @@ assert_legacy_mode_without_system_jobs_skips_sudo() (
   }
 
   remove_runner_service
+  remove_updater_service
   remove_daemon_launch_agent
 
   [[ ! -e "$sudo_log" ]]

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -11,6 +11,8 @@ DATA_DIR="$HOME/Library/Application Support/oore"
 DAEMON_LAUNCH_AGENT_LABEL="build.oore.oored"
 DAEMON_LAUNCH_AGENT_PLIST="$HOME/Library/LaunchAgents/$DAEMON_LAUNCH_AGENT_LABEL.plist"
 DAEMON_LAUNCH_DAEMON_PLIST="/Library/LaunchDaemons/$DAEMON_LAUNCH_AGENT_LABEL.plist"
+UPDATER_LAUNCH_DAEMON_LABEL="build.oore.oore-updater"
+UPDATER_LAUNCH_DAEMON_PLIST="/Library/LaunchDaemons/$UPDATER_LAUNCH_DAEMON_LABEL.plist"
 RUNNER_LAUNCH_AGENT_LABEL="build.oore.oore-runner"
 RUNNER_LAUNCH_AGENT_PLIST="$HOME/Library/LaunchAgents/$RUNNER_LAUNCH_AGENT_LABEL.plist"
 RUNNER_LAUNCH_DAEMON_PLIST="/Library/LaunchDaemons/$RUNNER_LAUNCH_AGENT_LABEL.plist"
@@ -333,6 +335,13 @@ remove_runner_service() {
     "legacy runner launch agent"
 }
 
+remove_updater_service() {
+  remove_system_launchd_service \
+    "$UPDATER_LAUNCH_DAEMON_LABEL" \
+    "$UPDATER_LAUNCH_DAEMON_PLIST" \
+    "backend updater"
+}
+
 stop_local_web() {
   if [[ -f "$WEB_PID_FILE" ]]; then
     local pid=""
@@ -452,12 +461,14 @@ main() {
 
   if [[ ! -d "$OORE_INSTALL_ROOT" ]] \
     && [[ ! -f "$DAEMON_LAUNCH_DAEMON_PLIST" ]] \
+    && [[ ! -f "$UPDATER_LAUNCH_DAEMON_PLIST" ]] \
     && [[ ! -f "$RUNNER_LAUNCH_DAEMON_PLIST" ]] \
     && [[ ! -f "$DAEMON_LAUNCH_AGENT_PLIST" ]] \
     && [[ ! -f "$RUNNER_LAUNCH_AGENT_PLIST" ]] \
     && [[ ! -f "$WEB_LAUNCH_AGENT_PLIST" ]] \
     && [[ ! -f "$WEB_SYSTEMD_SERVICE_FILE" ]] \
     && ! system_launchd_job_is_loaded "$DAEMON_LAUNCH_AGENT_LABEL" \
+    && ! system_launchd_job_is_loaded "$UPDATER_LAUNCH_DAEMON_LABEL" \
     && ! system_launchd_job_is_loaded "$RUNNER_LAUNCH_AGENT_LABEL" \
     && ! user_launchd_job_is_loaded "$DAEMON_LAUNCH_AGENT_LABEL" \
     && ! user_launchd_job_is_loaded "$RUNNER_LAUNCH_AGENT_LABEL" \
@@ -475,6 +486,7 @@ main() {
   fi
 
   remove_runner_service
+  remove_updater_service
   remove_daemon_launch_agent
   stop_daemon
   stop_local_web


### PR DESCRIPTION
## Summary
- replace rejected ephemeral system-domain launchd submission with a pre-installed least-privilege updater service
- queue a private validated request and kickstart the updater without sudo from the backend
- install and remove the supervisor with the managed service lifecycle

## Verification
- live UI update on appbuilder.zero.tech: 0.1.32-alpha.12 -> 0.1.32-alpha.13
- backend and managed runner returned healthy; runner acknowledged alpha.13
- make validate
- installer and uninstaller acceptance suites