### PR TITLE
fix(runner): allow headless codesigning identity access

### DIFF
--- a/crates/oore-runner/src/lib.rs
+++ b/crates/oore-runner/src/lib.rs
@@ -1695,7 +1695,7 @@ fn install_ios_signing_bundle(
         run_security_command_with_strings(&[
             "set-key-partition-list".to_string(),
             "-S".to_string(),
-            "apple:".to_string(),
+            "apple-tool:,apple:,codesign:".to_string(),
             "-s".to_string(),
             "-k".to_string(),
             keychain_password.clone(),

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -12,6 +12,12 @@ Rules:
 - Any code change under `apps/`, `crates/`, `tools/`, etc. must add an entry here.
 - Include a Linear issue/doc link for each entry.
 
+## 2026-07-23
+
+- **Headless iOS signing key access**:
+  - Temporary build keychains now grant the complete Apple codesigning partition set, allowing the managed launchd runner to use imported distribution identities without an interactive keychain prompt.
+  - Product Trust feature doc: https://linear.app/oorebuild/document/feature-product-trust-hardening-release-592dfc525e77
+
 ## 2026-07-21
 
 - **Independent web-update supervisor**:


### PR DESCRIPTION
## Summary
- grant imported signing keys the Apple tool and codesign partitions required by a launchd runner
- keep the temporary per-build keychain and existing cleanup unchanged

## Root cause
The runner replaced the imported key ACL with only the `apple:` partition. In the managed LaunchDaemon session, `codesign` cannot prompt and fails with `errSecInternalComponent`; the complete Apple CI partition list is `apple-tool:,apple:,codesign:`.

## Validation
- reproduced twice on the alpha.14 managed runner
- synthetic SSH keychain signing succeeds, confirming the failure is specific to the headless service session
- `cargo test -p oore-runner`
- `make validate`