### PR TITLE
fix(runner): authorize temporary iOS signing keychain

### DIFF
--- a/crates/oore-runner/src/lib.rs
+++ b/crates/oore-runner/src/lib.rs
@@ -1636,7 +1636,7 @@ fn install_ios_signing_bundle(
         prepared_profiles.push((profile.bundle_id.clone(), profile_ref, work_path));
     }
 
-    let journal = IosCleanupJournal {
+    let mut journal = IosCleanupJournal {
         keychain_path: keychain_path.clone(),
         original_default_keychain: None,
         original_keychains: Vec::new(),
@@ -1678,6 +1678,33 @@ fn install_ios_signing_bundle(
             "21600".to_string(),
             keychain_path_str.clone(),
         ])?;
+
+        let original_default_keychain =
+            parse_keychain_list(&run_security_command(&["default-keychain", "-d", "user"])?)
+                .into_iter()
+                .next()
+                .context("user keychain domain has no default keychain")?;
+        let original_keychains =
+            parse_keychain_list(&run_security_command(&["list-keychains", "-d", "user"])?);
+        anyhow::ensure!(
+            !original_keychains.is_empty(),
+            "user keychain search list is empty"
+        );
+        journal.original_default_keychain = Some(original_default_keychain);
+        journal.original_keychains = original_keychains.clone();
+        write_ios_cleanup_journal(&journal_path, &journal)?;
+        run_security_command_with_strings(
+            &[
+                "list-keychains".to_string(),
+                "-d".to_string(),
+                "user".to_string(),
+                "-s".to_string(),
+                keychain_path_str.clone(),
+            ]
+            .into_iter()
+            .chain(original_keychains)
+            .collect::<Vec<_>>(),
+        )?;
 
         run_security_command_with_strings(&[
             "import".to_string(),

--- a/crates/oored/src/pipeline_ios_signing.rs
+++ b/crates/oored/src/pipeline_ios_signing.rs
@@ -789,7 +789,6 @@ fn reexport_p12_legacy_blocking(
     let cert_out = run_openssl_pkcs12(&[
         "-in",
         old_p12_path.to_string_lossy().as_ref(),
-        "-clcerts",
         "-nokeys",
         "-passin",
         &passin,
@@ -3398,6 +3397,75 @@ pub async fn get_job_ios_signing(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn legacy_p12_reexport_preserves_certificate_chain() {
+        let scratch = SigningScratch::new().expect("create signing scratch");
+        let password = "test-password";
+        for name in ["leaf", "intermediate"] {
+            let status = Command::new("openssl")
+                .args([
+                    "req",
+                    "-x509",
+                    "-newkey",
+                    "rsa:2048",
+                    "-nodes",
+                    "-keyout",
+                    scratch.path(&format!("{name}.key")).to_str().unwrap(),
+                    "-out",
+                    scratch.path(&format!("{name}.crt")).to_str().unwrap(),
+                    "-days",
+                    "1",
+                    "-subj",
+                    &format!("/CN={name}"),
+                ])
+                .output()
+                .expect("generate certificate")
+                .status;
+            assert!(status.success());
+        }
+        let input = scratch.path("input.p12");
+        let status = Command::new("openssl")
+            .args([
+                "pkcs12",
+                "-export",
+                "-inkey",
+                scratch.path("leaf.key").to_str().unwrap(),
+                "-in",
+                scratch.path("leaf.crt").to_str().unwrap(),
+                "-certfile",
+                scratch.path("intermediate.crt").to_str().unwrap(),
+                "-out",
+                input.to_str().unwrap(),
+                "-passout",
+                &format!("pass:{password}"),
+            ])
+            .output()
+            .expect("create p12 chain")
+            .status;
+        assert!(status.success());
+
+        let (reexported, reexported_password) =
+            reexport_p12_legacy_blocking(&fs::read(input).unwrap(), password).unwrap();
+        let output = scratch.path("output.p12");
+        fs::write(&output, reexported).unwrap();
+        let certificates = run_openssl_pkcs12(&[
+            "-in",
+            output.to_str().unwrap(),
+            "-nokeys",
+            "-passin",
+            &format!("pass:{reexported_password}"),
+        ])
+        .expect("inspect re-exported p12");
+        assert!(certificates.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&certificates.stdout)
+                .matches("BEGIN CERTIFICATE")
+                .count(),
+            2,
+            "re-export must retain the intermediate certificate"
+        );
+    }
 
     #[test]
     fn signing_scratch_removes_material_on_success_and_error() {

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -15,7 +15,8 @@ Rules:
 ## 2026-07-23
 
 - **Headless iOS signing key access**:
-  - Temporary build keychains now grant the complete Apple codesigning partition set, allowing the managed launchd runner to use imported distribution identities without an interactive keychain prompt.
+  - Temporary build keychains now grant the complete Apple codesigning partition set and are added to the user keychain search list for the duration of the build. This lets the managed launchd runner authorize imported distribution identities without an interactive prompt; cleanup removes only Oore's temporary keychain and preserves the user's existing default and search list entries.
+  - Legacy P12 normalization now preserves intermediate certificates instead of exporting only the leaf signing certificate.
   - Product Trust feature doc: https://linear.app/oorebuild/document/feature-product-trust-hardening-release-592dfc525e77
 
 ## 2026-07-21
@@ -41,7 +42,7 @@ Rules:
   - Build snapshots are bound to the exact trusted repository ID. Relinking a project cancels queued or only-scheduled snapshots from the old source, claims and reruns reject stale source identities, and assigned or running GitLab work drains through its original build-bound checkout instead of the project's mutable link.
   - Source sync retains repository and provider-installation rows while assigned or running snapshots still reference them, so in-flight checkouts keep their immutable dependency chain. Explicit integration disconnect returns `409 Conflict` until those active builds finish; queued or scheduled work is canceled when the source is removed.
   - External-fork pull and merge requests remain blocked. Direct mode continues to mean trusted-code execution with the runner account's authority, not hostile-code isolation; manually registered runners on another Mac remain supported.
-  - iOS signing keeps provisioning profiles inside the private job workspace and passes a temporary keychain explicitly to signing tools without changing the user's default keychain, search list, or globally installed profiles.
+  - iOS signing keeps provisioning profiles inside the private job workspace and passes a temporary keychain explicitly to signing tools. The runner temporarily prepends that keychain to the user's search list for non-interactive Apple signing, then removes only its own entry during cleanup; it does not change the default keychain or install profiles globally.
   - Product Trust feature doc: https://linear.app/oorebuild/document/feature-product-trust-hardening-release-592dfc525e77
   - Platform Contract: https://linear.app/oorebuild/document/platform-contract-v1-7c0f39d2c666
   - Runtime updates feature doc: https://linear.app/oorebuild/document/feature-runtime-updates-from-the-web-ui-6b648f19a3f9


### PR DESCRIPTION
Fixes the managed macOS runner iOS signing preflight failure (`errSecInternalComponent`).

- temporarily prepends the per-build keychain to the user search list and records cleanup state before mutation
- preserves the existing default/search-list entries and removes only Oore’s keychain during cleanup
- preserves intermediate certificates during legacy P12 normalization

Live acceptance on `appbuilder.zero.tech` using the encrypted Zerodha signing credential:
- prior runner behavior: deterministic `errSecInternalComponent`
- broader import ACL (`-A`): still failed
- temporary search-list membership: codesign preflight passed
- post-test keychain state restored to the login keychain only

Validation: `make validate`