### PR TITLE
fix(runner): restore boot-safe service alignment

### DIFF
--- a/apps/docs-site/docs/guides/signing/ios-manual-signing.md
+++ b/apps/docs-site/docs/guides/signing/ios-manual-signing.md
@@ -15,12 +15,14 @@ Upload your signing certificate and provisioning profile directly to Oore CI for
 - A [pipeline](/guides/projects/pipeline-config) configured for iOS builds
 - A macOS runner installed with `oore runner install-service`
 
-::: info Headless signing
+::: info Runner login for Apple signing
 The Direct runner is a boot-time system LaunchDaemon running as its configured
-non-root account. iOS signing does not require an active GUI login. Oore keeps
-profiles inside the private job workspace and passes its temporary keychain
-explicitly to signing tools; it does not change the user's default keychain,
-keychain search list, or globally installed provisioning profiles.
+non-root account, so ordinary and Android builds remain available before login.
+Apple signing requires that account to have an active macOS login session. If
+it does not, a build already configured for iOS stops before checkout and asks
+you to log in and retry. Oore keeps profiles inside the private job workspace,
+temporarily selects its build keychain for fixed signing commands, then restores
+the previous default and search list; it does not install profiles globally.
 :::
 
 ## Steps

--- a/apps/docs-site/docs/operations/troubleshooting.md
+++ b/apps/docs-site/docs/operations/troubleshooting.md
@@ -74,6 +74,12 @@ For a backend-host runner, repair enrollment and the boot-time service by runnin
 administrator access for launchd setup; do not run the whole command with
 `sudo`.
 
+If the web UI says managed service repair is required, rerun the current
+installer for the host's installed channel. Alpha.17 and alpha.18 need this
+one-time repair because their runner plist cannot be converted by the
+unprivileged web updater. Existing runner identity and project configuration are
+preserved.
+
 ### Runner claiming but builds failing immediately
 
 Check the build logs for errors. Common causes:
@@ -81,6 +87,7 @@ Check the build logs for errors. Common causes:
 - Flutter/FVM not installed on the runner machine
 - Incorrect Flutter version requested
 - Missing Xcode for iOS builds
+- No active login session for the runner account when Apple signing is enabled
 
 Run `oore doctor --all` on the runner machine to verify the toolchain.
 

--- a/apps/docs-site/docs/operations/upgrade.md
+++ b/apps/docs-site/docs/operations/upgrade.md
@@ -51,6 +51,14 @@ processes, and rolls back on failure. After this transition, use `oore update`
 normally.
 :::
 
+::: warning One-time repair for alpha.17 and alpha.18
+Those alpha releases installed a runner service topology that the web updater
+cannot repair without administrator authorization. The backend update button is
+disabled on an affected host. Run the current installer once for the same
+channel; it snapshots and repairs the service transactionally. Later updates
+remain available from the web UI.
+:::
+
 ### Source checkout update
 
 ```bash

--- a/apps/web/src/components/runtime-update-dialog.tsx
+++ b/apps/web/src/components/runtime-update-dialog.tsx
@@ -27,7 +27,10 @@ import {
 } from '@/components/ui/dialog'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Spinner } from '@/components/ui/spinner'
-import { formatReleaseNotes } from '@/components/runtime-update-utils'
+import {
+  formatReleaseNotes,
+  installerCommand,
+} from '@/components/runtime-update-utils'
 
 function updateButtonLabel(phase: string | undefined, pending: boolean) {
   if (pending) return 'Starting...'
@@ -79,9 +82,15 @@ function RuntimeUpdateCard({
           </span>
         </div>
         {!managed ? (
-          <p className="mt-2 text-xs text-muted-foreground">
-            Install this runtime as a managed service to update it here.
-          </p>
+          <div className="mt-2 space-y-2 text-xs text-muted-foreground">
+            <p>
+              Run the current installer once from Terminal to finish or repair
+              managed service setup.
+            </p>
+            <code className="block break-all rounded-md bg-muted p-2 font-mono text-foreground">
+              {installerCommand(release.channel)}
+            </code>
+          </div>
         ) : null}
       </CardContent>
       <CardFooter>

--- a/apps/web/src/components/runtime-update-notice.test.tsx
+++ b/apps/web/src/components/runtime-update-notice.test.tsx
@@ -79,4 +79,39 @@ describe('RuntimeUpdateNotice', () => {
         .getAttribute('href'),
     ).toBe(release.changelog_url)
   })
+
+  it('requires the one-time installer repair for a wrapper runner service', async () => {
+    useRuntimeUpdates.mockReturnValue({
+      frontendRelease: { data: release },
+      backendRelease: { data: release },
+      backendUpdate: { data: { managed_service: false, phase: 'idle' } },
+      startFrontendUpdate: { data: undefined, isPending: false, mutate: vi.fn() },
+      startBackendUpdate: { data: undefined, isPending: false, mutate: vi.fn() },
+    })
+
+    render(
+      <SidebarProvider>
+        <RuntimeUpdateNotice />
+      </SidebarProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /Updates available/i }))
+
+    const dialog = await screen.findByRole('dialog')
+    expect(
+      within(dialog).getByText(
+        /Run the current installer once from Terminal to finish or repair managed service setup/i,
+      ),
+    ).toBeTruthy()
+    expect(
+      within(dialog).getByText(
+        'curl -fsSL https://alpha.oore.pages.dev/install | OORE_CHANNEL=alpha bash',
+      ),
+    ).toBeTruthy()
+    expect(
+      within(dialog)
+        .getAllByRole('button', { name: 'Update now' })[1]
+        .hasAttribute('disabled'),
+    ).toBe(true)
+  })
 })

--- a/apps/web/src/components/runtime-update-utils.ts
+++ b/apps/web/src/components/runtime-update-utils.ts
@@ -6,3 +6,10 @@ export function formatReleaseNotes(notes: string): string {
     .replace(/\*\*([^*]+)\*\*/g, '$1')
     .trim()
 }
+
+export function installerCommand(channel: string): string {
+  if (channel === 'alpha' || channel === 'beta') {
+    return `curl -fsSL https://${channel}.oore.pages.dev/install | OORE_CHANNEL=${channel} bash`
+  }
+  return 'curl -fsSL https://oore.build/install | bash'
+}

--- a/apps/web/src/components/settings/preferences-runtime-overview.tsx
+++ b/apps/web/src/components/settings/preferences-runtime-overview.tsx
@@ -3,6 +3,7 @@ import { HugeiconsIcon } from '@hugeicons/react'
 import { Download04Icon } from '@hugeicons/core-free-icons'
 import type { PreferencesPageState } from '@/routes/settings/preferences'
 import { runtimeUpdateActive } from '@/components/settings/preferences-utils'
+import { installerCommand } from '@/components/runtime-update-utils'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
@@ -159,9 +160,18 @@ export function RuntimeOverview({ state }: { state: PreferencesPageState }) {
               </Button>
               {runtimeUpdates.backendUpdate.data &&
               !runtimeUpdates.backendUpdate.data.managed_service ? (
-                <p className="mt-2 text-xs text-muted-foreground">
-                  Install oored as the managed macOS service to update it here.
-                </p>
+                <div className="mt-2 space-y-2 text-xs text-muted-foreground">
+                  <p>
+                    Run the current installer once from Terminal to finish or
+                    repair managed service setup. Later backend updates remain
+                    available here.
+                  </p>
+                  <code className="block break-all rounded-md bg-muted p-2 font-mono text-foreground">
+                    {installerCommand(
+                      runtimeUpdates.backendRelease.data.channel,
+                    )}
+                  </code>
+                </div>
               ) : null}
             </>
           ) : null}

--- a/crates/oore-runner/src/lib.rs
+++ b/crates/oore-runner/src/lib.rs
@@ -1223,20 +1223,46 @@ impl Drop for IosSigningCleanup {
 }
 
 fn run_security_command(args: &[&str]) -> anyhow::Result<String> {
-    let output = Command::new("/usr/bin/security")
-        .args(args)
+    run_security_command_with_strings(
+        &args
+            .iter()
+            .map(|value| value.to_string())
+            .collect::<Vec<_>>(),
+    )
+}
+
+fn user_bootstrap_command_arguments(uid: u32, program: &str, args: &[String]) -> Vec<String> {
+    ["asuser".to_string(), uid.to_string(), program.to_string()]
+        .into_iter()
+        .chain(args.iter().cloned())
+        .collect()
+}
+
+fn user_bootstrap_command(program: &str, args: &[String]) -> Command {
+    let mut command = Command::new("/bin/launchctl");
+    command.args(user_bootstrap_command_arguments(
+        unsafe { libc::geteuid() },
+        program,
+        args,
+    ));
+    command
+}
+
+fn require_ios_signing_user_session() -> anyhow::Result<()> {
+    let uid = unsafe { libc::geteuid() };
+    let output = Command::new("/bin/launchctl")
+        .args(["print", &format!("gui/{uid}")])
         .output()
-        .map_err(|e| anyhow::anyhow!("failed to execute security command: {e}"))?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("security command failed: {stderr}");
-    }
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+        .context("failed to inspect the runner account login session")?;
+    anyhow::ensure!(
+        output.status.success(),
+        "iOS signing requires an active macOS login session. Log into the runner account and retry the build"
+    );
+    Ok(())
 }
 
 fn run_security_command_with_strings(args: &[String]) -> anyhow::Result<String> {
-    let output = Command::new("/usr/bin/security")
-        .args(args)
+    let output = user_bootstrap_command("/usr/bin/security", args)
         .output()
         .map_err(|e| anyhow::anyhow!("failed to execute security command: {e}"))?;
     if !output.status.success() {
@@ -1554,6 +1580,19 @@ fn install_ios_signing_bundle(
     signing_workspace: &Path,
     bundle: &RunnerIosSigningBundle,
 ) -> anyhow::Result<(IosSigningMaterialization, IosSigningCleanup)> {
+    install_ios_signing_bundle_with_session_check(
+        signing_workspace,
+        bundle,
+        require_ios_signing_user_session,
+    )
+}
+
+fn install_ios_signing_bundle_with_session_check(
+    signing_workspace: &Path,
+    bundle: &RunnerIosSigningBundle,
+    require_session: impl FnOnce() -> anyhow::Result<()>,
+) -> anyhow::Result<(IosSigningMaterialization, IosSigningCleanup)> {
+    require_session()?;
     if bundle.team_id.trim().is_empty() {
         anyhow::bail!("iOS signing bundle team_id is empty");
     }
@@ -1713,17 +1752,11 @@ fn install_ios_signing_bundle(
             keychain_path_str.clone(),
         ])?;
 
-        run_security_command_with_strings(&[
-            "import".to_string(),
-            p12_path.display().to_string(),
-            "-f".to_string(),
-            "pkcs12".to_string(),
-            "-k".to_string(),
-            keychain_path_str.clone(),
-            "-P".to_string(),
-            bundle.p12_password.clone(),
-            "-A".to_string(),
-        ])?;
+        run_security_command_with_strings(&ios_keychain_import_arguments(
+            &p12_path,
+            &keychain_path,
+            &bundle.p12_password,
+        ))?;
 
         run_security_command_with_strings(&[
             "set-key-partition-list".to_string(),
@@ -1830,11 +1863,32 @@ fn install_ios_signing_bundle(
     }
 }
 
+fn ios_keychain_import_arguments(
+    p12_path: &Path,
+    keychain_path: &Path,
+    password: &str,
+) -> Vec<String> {
+    vec![
+        "import".to_string(),
+        p12_path.display().to_string(),
+        "-f".to_string(),
+        "pkcs12".to_string(),
+        "-k".to_string(),
+        keychain_path.display().to_string(),
+        "-P".to_string(),
+        password.to_string(),
+        "-T".to_string(),
+        "/usr/bin/codesign".to_string(),
+    ]
+}
+
 fn run_ios_signing_tool(program: &str, args: Vec<String>, action: &str) -> anyhow::Result<String> {
-    let output = Command::new(program)
-        .args(&args)
-        .output()
-        .map_err(|error| anyhow::anyhow!("failed to {action}: {error}"))?;
+    let output = if program == "/usr/bin/codesign" {
+        user_bootstrap_command(program, &args).output()
+    } else {
+        Command::new(program).args(&args).output()
+    }
+    .map_err(|error| anyhow::anyhow!("failed to {action}: {error}"))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -3722,6 +3776,20 @@ fn add_checkout_proxy_config(
     ]);
 }
 
+fn snapshot_requests_ios(snapshot: &serde_json::Value) -> bool {
+    let platforms = snapshot
+        .get("selected_platforms")
+        .filter(|value| !value.is_null())
+        .or_else(|| {
+            snapshot
+                .get("ui_execution_config")
+                .and_then(|config| config.get("platforms"))
+        });
+    platforms
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|platforms| platforms.iter().any(|platform| platform == "ios"))
+}
+
 async fn execute_build(
     job: &ClaimedJob,
     client: &reqwest::Client,
@@ -3757,10 +3825,51 @@ async fn execute_build(
     let snapshot = &job.config_snapshot;
     let mut steps = Vec::new();
     let mut log_seq: i64 = 0;
+    let mut ios_signing_source: Option<&str> = None;
+    let mut ios_signing_bundle: Option<RunnerIosSigningBundle> = None;
+    let ios_signing_checked_before_checkout = snapshot_requests_ios(snapshot);
 
     if let Err(e) = check_build_active(client, daemon_url, config, &job.build_id, &authority).await
     {
         return (steps, Err(e));
+    }
+
+    if ios_signing_checked_before_checkout {
+        match fetch_job_ios_signing(
+            client,
+            daemon_url,
+            config,
+            &job.build_id,
+            &job.signing_token,
+        )
+        .await
+        {
+            Ok(Some(server_payload)) => {
+                if let Some(mut bundle) = server_payload.bundle {
+                    if let Err(error) = require_ios_signing_user_session() {
+                        zeroize_ios_signing_bundle(&mut bundle);
+                        return (steps, Err(error));
+                    }
+                    let signing_source = match bundle.mode {
+                        oore_contract::IosSigningMode::Manual => "manual",
+                        oore_contract::IosSigningMode::Api => "api",
+                        oore_contract::IosSigningMode::Hybrid => "hybrid",
+                    };
+                    ios_signing_bundle = Some(bundle);
+                    ios_signing_source = Some(signing_source);
+                    println!("Reserved iOS signing bundle before repository checkout");
+                }
+            }
+            Ok(None) => {}
+            Err(error) => {
+                return (
+                    steps,
+                    Err(anyhow::anyhow!(
+                        "Failed to load iOS signing bundle before checkout. Aborting to avoid unsigned iOS artifacts: {error}"
+                    )),
+                );
+            }
+        }
     }
 
     let repo_url = snapshot
@@ -3911,8 +4020,6 @@ async fn execute_build(
     let mut signing_source: Option<&str> = None;
     let mut signing_variant: Option<AndroidSigningBuildType> = None;
     let mut signing_inputs: Option<AndroidSigningInputs> = None;
-    let mut ios_signing_source: Option<&str> = None;
-    let mut ios_signing_bundle: Option<RunnerIosSigningBundle> = None;
     let build_commands = execution_plan.stage_commands.build.as_slice();
     match determine_android_signing_variant(build_commands) {
         Ok(Some(variant)) => {
@@ -3956,9 +4063,10 @@ async fn execute_build(
         Err(e) => return (steps, Err(e)),
     }
 
-    if build_commands
-        .iter()
-        .any(|command| is_ios_flutter_build_command(command))
+    if !ios_signing_checked_before_checkout
+        && build_commands
+            .iter()
+            .any(|command| is_ios_flutter_build_command(command))
     {
         match fetch_job_ios_signing(
             client,
@@ -3970,7 +4078,11 @@ async fn execute_build(
         .await
         {
             Ok(Some(server_payload)) => {
-                if let Some(bundle) = server_payload.bundle {
+                if let Some(mut bundle) = server_payload.bundle {
+                    if let Err(error) = require_ios_signing_user_session() {
+                        zeroize_ios_signing_bundle(&mut bundle);
+                        return (steps, Err(error));
+                    }
                     let signing_source = match bundle.mode {
                         oore_contract::IosSigningMode::Manual => "manual",
                         oore_contract::IosSigningMode::Api => "api",
@@ -5194,6 +5306,92 @@ mod tests {
         ));
         fs::create_dir_all(&dir).expect("create temp dir");
         dir
+    }
+
+    #[test]
+    fn apple_signing_commands_enter_only_the_user_bootstrap() {
+        let arguments = user_bootstrap_command_arguments(
+            501,
+            "/usr/bin/codesign",
+            &["--verify".to_string(), "/tmp/App.app".to_string()],
+        );
+
+        assert_eq!(
+            arguments,
+            [
+                "asuser",
+                "501",
+                "/usr/bin/codesign",
+                "--verify",
+                "/tmp/App.app",
+            ]
+        );
+    }
+
+    #[test]
+    fn ios_snapshot_selection_is_known_before_checkout() {
+        assert!(snapshot_requests_ios(&serde_json::json!({
+            "selected_platforms": ["ios"]
+        })));
+        assert!(!snapshot_requests_ios(&serde_json::json!({
+            "selected_platforms": ["android"],
+            "ui_execution_config": { "platforms": ["android", "ios"] }
+        })));
+        assert!(snapshot_requests_ios(&serde_json::json!({
+            "ui_execution_config": { "platforms": ["android", "ios"] }
+        })));
+    }
+
+    #[test]
+    fn ios_private_key_access_is_scoped_to_codesign() {
+        let arguments = ios_keychain_import_arguments(
+            Path::new("/tmp/identity.p12"),
+            Path::new("/tmp/build.keychain-db"),
+            "secret",
+        );
+
+        assert_eq!(
+            arguments,
+            [
+                "import",
+                "/tmp/identity.p12",
+                "-f",
+                "pkcs12",
+                "-k",
+                "/tmp/build.keychain-db",
+                "-P",
+                "secret",
+                "-T",
+                "/usr/bin/codesign",
+            ]
+        );
+    }
+
+    #[test]
+    fn missing_login_session_fails_before_ios_signing_state_is_created() {
+        let parent = temp_workspace();
+        let signing_workspace = parent.join("signing");
+        let bundle = RunnerIosSigningBundle {
+            enabled: true,
+            mode: oore_contract::IosSigningMode::Manual,
+            team_id: "TEAM".to_string(),
+            export_method: "ad-hoc".to_string(),
+            p12_filename: "identity.p12".to_string(),
+            p12_base64: "unused".to_string(),
+            p12_password: "unused".to_string(),
+            provisioning_profiles: Vec::new(),
+        };
+
+        let error =
+            install_ios_signing_bundle_with_session_check(&signing_workspace, &bundle, || {
+                anyhow::bail!("Log into the runner account and retry the build")
+            })
+            .err()
+            .expect("missing session must fail before signing setup");
+
+        assert!(error.to_string().contains("Log into the runner account"));
+        assert!(!signing_workspace.exists());
+        cleanup_workspace(&parent);
     }
 
     fn release_marker_for(path: &Path, generation: u128) -> String {

--- a/crates/oore/src/main.rs
+++ b/crates/oore/src/main.rs
@@ -4591,18 +4591,21 @@ fn managed_runner_update_service_from_program_arguments(
 }
 
 fn runner_command_from_program_arguments(program_arguments: &[String]) -> &[String] {
-    if program_arguments.first().map(String::as_str) == Some("/bin/launchctl")
+    if runner_service_uses_user_bootstrap_wrapper(program_arguments) {
+        &program_arguments[8..]
+    } else {
+        program_arguments
+    }
+}
+
+fn runner_service_uses_user_bootstrap_wrapper(program_arguments: &[String]) -> bool {
+    program_arguments.first().map(String::as_str) == Some("/bin/launchctl")
         && program_arguments.get(1).map(String::as_str) == Some("asuser")
         && program_arguments.get(3).map(String::as_str) == Some("/usr/bin/sudo")
         && program_arguments.get(4).map(String::as_str) == Some("-E")
         && program_arguments.get(5).map(String::as_str) == Some("-H")
         && program_arguments.get(6).map(String::as_str) == Some("-u")
         && program_arguments.len() > 8
-    {
-        &program_arguments[8..]
-    } else {
-        program_arguments
-    }
 }
 
 fn value_from_program_arguments(program_arguments: &[String], option: &str) -> Option<String> {
@@ -4812,6 +4815,12 @@ fn managed_runner_update_service(install_root: &Path) -> anyhow::Result<Option<&
     ))
 }
 
+fn managed_runner_service_requires_repair(plist: &Path) -> anyhow::Result<bool> {
+    Ok(runner_service_uses_user_bootstrap_wrapper(
+        &plist_program_arguments(plist)?,
+    ))
+}
+
 fn managed_runner_process_pid() -> anyhow::Result<Option<u32>> {
     let (_, system) = managed_service_plist(RUNNER_SERVICE_LABEL)?;
     let service = if system {
@@ -4849,17 +4858,8 @@ fn render_runner_launch_daemon(
     log_path: &Path,
     path: &str,
     user: &str,
-    uid: &str,
 ) -> String {
     let values = [
-        "/bin/launchctl".to_string(),
-        "asuser".to_string(),
-        uid.to_string(),
-        "/usr/bin/sudo".to_string(),
-        "-E".to_string(),
-        "-H".to_string(),
-        "-u".to_string(),
-        user.to_string(),
         executable.display().to_string(),
         "runner".to_string(),
         "start".to_string(),
@@ -4879,6 +4879,10 @@ fn render_runner_launch_daemon(
 <dict>
     <key>Label</key>
     <string>{RUNNER_SERVICE_LABEL}</string>
+    <key>UserName</key>
+    <string>{}</string>
+    <key>SessionCreate</key>
+    <true/>
     <key>ProgramArguments</key>
     <array>
 {arguments}
@@ -4905,6 +4909,7 @@ fn render_runner_launch_daemon(
 </dict>
 </plist>
 "#,
+        launchd_xml_escape(user),
         launchd_xml_escape(&home.display().to_string()),
         launchd_xml_escape(path),
         oore_runner::RUNNER_SERVICE_ACK_PATH_ENV,
@@ -4913,68 +4918,6 @@ fn render_runner_launch_daemon(
         launchd_xml_escape(&log_path.display().to_string()),
         launchd_xml_escape(&log_path.display().to_string()),
     )
-}
-
-fn migrate_runner_service_to_user_bootstrap(plist: &Path) -> anyhow::Result<bool> {
-    let document = plist_json(plist)?;
-    if document.get("UserName").is_none() {
-        return Ok(false);
-    }
-    let user = document
-        .get("UserName")
-        .and_then(serde_json::Value::as_str)
-        .context("managed runner service has no runner account")?;
-    anyhow::ensure!(!user.is_empty() && user != "root", "invalid runner account");
-    let uid_output = std::process::Command::new("/usr/bin/id")
-        .args(["-u", user])
-        .output()
-        .context("failed to resolve the managed runner account")?;
-    anyhow::ensure!(
-        uid_output.status.success(),
-        "managed runner account does not exist"
-    );
-    let uid = String::from_utf8(uid_output.stdout)?.trim().to_string();
-    let spec = managed_runner_service_spec_from_document(&document)?
-        .context("managed runner service is missing authenticated readiness")?;
-    let environment = document
-        .get("EnvironmentVariables")
-        .and_then(serde_json::Value::as_object)
-        .context("managed runner service has no environment")?;
-    let required_environment = |key: &str| {
-        environment
-            .get(key)
-            .and_then(serde_json::Value::as_str)
-            .with_context(|| format!("managed runner service has no {key}"))
-    };
-    let home = PathBuf::from(required_environment("HOME")?);
-    let path = required_environment("PATH")?;
-    let working_dir = PathBuf::from(
-        document
-            .get("WorkingDirectory")
-            .and_then(serde_json::Value::as_str)
-            .context("managed runner service has no working directory")?,
-    );
-    let log_path = PathBuf::from(
-        document
-            .get("StandardOutPath")
-            .and_then(serde_json::Value::as_str)
-            .context("managed runner service has no log path")?,
-    );
-    let rendered = render_runner_launch_daemon(
-        &spec.executable,
-        &spec.config,
-        &spec.acknowledgement,
-        &home,
-        &working_dir,
-        &log_path,
-        path,
-        user,
-        &uid,
-    );
-    let service = format!("system/{RUNNER_SERVICE_LABEL}");
-    stop_system_launchd_service(&service)?;
-    write_system_runner_plist(&rendered)?;
-    Ok(true)
 }
 
 fn current_user_launchd_domain() -> anyhow::Result<(String, String)> {
@@ -5426,7 +5369,6 @@ async fn handle_runner_install_service_inner(
     }
 
     let user = current_user_name()?;
-    let uid = current_user_id()?;
     if args.managed_local && args.config.is_some() {
         anyhow::bail!("--managed-local cannot be combined with --config");
     }
@@ -5594,7 +5536,6 @@ async fn handle_runner_install_service_inner(
             &log_path,
             &path,
             &user,
-            &uid,
         );
         let plist = match write_system_runner_plist(&rendered) {
             Ok(plist) => plist,
@@ -6563,6 +6504,11 @@ struct ManagedRunnerServiceSnapshot {
     configs: Vec<(PathBuf, Option<Vec<u8>>)>,
 }
 
+trait ManagedRunnerServiceRollback {
+    fn stop_and_restore_files(&self) -> anyhow::Result<()>;
+    fn start(&self) -> anyhow::Result<()>;
+}
+
 impl ManagedRunnerServiceSnapshot {
     fn capture() -> anyhow::Result<Self> {
         let system_plist = system_runner_plist();
@@ -6618,7 +6564,9 @@ impl ManagedRunnerServiceSnapshot {
             configs,
         })
     }
+}
 
+impl ManagedRunnerServiceRollback for ManagedRunnerServiceSnapshot {
     fn stop_and_restore_files(&self) -> anyhow::Result<()> {
         let active_acknowledgement = self
             .system_plist
@@ -6961,13 +6909,6 @@ impl UpdateServiceControl for LiveUpdateServiceControl<'_> {
             let (plist, system) = managed_service_plist(label)?;
             if system {
                 let service = format!("system/{RUNNER_SERVICE_LABEL}");
-                if migrate_runner_service_to_user_bootstrap(&plist)? {
-                    start_system_runner_service(&plist, &service, true)?;
-                    if let Some(ack) = ack {
-                        ack.wait_for(activation).await?;
-                    }
-                    return Ok(());
-                }
                 ensure_system_runner_service_active(&plist, &service, previous_pid)?;
                 if let Some(ack) = ack {
                     ack.wait_for(activation).await?;
@@ -7098,14 +7039,6 @@ impl UpdateServiceControl for DeferredUpdateServiceControl<'_> {
             system,
             "deferred updates require the boot-time runner service"
         );
-        if migrate_runner_service_to_user_bootstrap(&plist)? {
-            let service = format!("system/{RUNNER_SERVICE_LABEL}");
-            start_system_runner_service(&plist, &service, true)?;
-            if let Some(ack) = ack {
-                ack.wait_for(activation).await?;
-            }
-            return Ok(());
-        }
         let spec = managed_runner_service_spec(&plist)?;
         if let Some(spec) = &spec {
             clear_runner_service_acknowledgement(&spec.acknowledgement)?;
@@ -7306,7 +7239,7 @@ async fn install_release_with_rollback<C: UpdateServiceControl>(
     channel: ReleaseChannel,
     repo: &str,
     daemon_migration: Option<&ManagedDaemonServiceMigration>,
-    runner_migration: Option<&ManagedRunnerServiceSnapshot>,
+    runner_migration: Option<&dyn ManagedRunnerServiceRollback>,
     claim_barrier: Option<&RunnerClaimBarrier>,
     services: &UpdateServicePlan,
     rollback_state: Option<&UpdateRollbackState>,
@@ -7603,6 +7536,10 @@ async fn run_deferred_update(args: &UpdateArgs, status_path: &Path) -> anyhow::R
         "web updates require the boot-time managed runner service"
     );
     anyhow::ensure!(
+        !managed_runner_service_requires_repair(&runner_plist)?,
+        "this runner service needs a one-time repair; run the current installer from Terminal before updating from the web UI"
+    );
+    anyhow::ensure!(
         managed_runner_update_service(&install_root)?.is_some(),
         "managed runner service does not use the selected Oore install"
     );
@@ -7868,6 +7805,14 @@ async fn handle_update(args: UpdateArgs) -> anyhow::Result<()> {
     let daemon_service_is_installed = daemon_service_plist.is_file();
     let daemon_was_loaded = launchd_service_loaded(DAEMON_SERVICE_LABEL);
     let (runner_plist, runner_is_system) = managed_service_plist(RUNNER_SERVICE_LABEL)?;
+    let runner_service_requires_repair = runner_plist.is_file()
+        && runner_is_system
+        && managed_runner_service_requires_repair(&runner_plist)?;
+    if runner_service_requires_repair && !args.ensure_managed_runner {
+        anyhow::bail!(
+            "this runner service needs a one-time repair; rerun the verified installer for the installed channel before using ordinary updates"
+        );
+    }
     let (web_plist, web_is_system) = managed_service_plist(WEB_SERVICE_LABEL)?;
     let web_is_managed = launchd_service_loaded(WEB_SERVICE_LABEL);
     if (daemon_service_is_installed && daemon_service_is_system)
@@ -8111,7 +8056,9 @@ async fn handle_update(args: UpdateArgs) -> anyhow::Result<()> {
         channel,
         &repo,
         daemon_migration.as_ref(),
-        runner_migration.as_ref(),
+        runner_migration
+            .as_ref()
+            .map(|snapshot| snapshot as &dyn ManagedRunnerServiceRollback),
         Some(&barrier),
         &services,
         Some(&rollback_state),
@@ -8338,17 +8285,13 @@ mod tests {
             Path::new("/Users/me/.oore/logs/oore-runner.log"),
             "/usr/bin:/bin",
             "me",
-            "501",
         );
 
         assert!(plist.contains("<string>build.oore.oore-runner</string>"));
-        assert!(!plist.contains("<key>UserName</key>"));
-        assert!(plist.contains("<string>/bin/launchctl</string>"));
-        assert!(plist.contains("<string>asuser</string>\n        <string>501</string>"));
-        assert!(plist.contains("<string>/usr/bin/sudo</string>"));
-        assert!(plist.contains(
-            "<string>-E</string>\n        <string>-H</string>\n        <string>-u</string>\n        <string>me</string>"
-        ));
+        assert!(plist.contains("<key>UserName</key>\n    <string>me</string>"));
+        assert!(plist.contains("<key>SessionCreate</key>\n    <true/>"));
+        assert!(!plist.contains("<string>/bin/launchctl</string>"));
+        assert!(!plist.contains("<string>/usr/bin/sudo</string>"));
         assert!(!plist.contains("LimitLoadToSessionType"));
         assert!(plist.contains("<string>/Users/me/.oore/bin/oore</string>"));
         assert!(plist.contains("<string>runner</string>\n        <string>start</string>"));
@@ -8430,13 +8373,36 @@ mod tests {
             Path::new("/Users/a&b/runner.log"),
             "/usr/bin:/a&b",
             "a&b",
-            "501",
         );
 
         assert!(plist.contains("/Users/a&amp;b/oore"));
         assert!(plist.contains("/Users/a&amp;b/runner-service-ack.json"));
         assert!(plist.contains("/usr/bin:/a&amp;b"));
         assert!(plist.contains("<string>a&amp;b</string>"));
+    }
+
+    #[test]
+    fn wrapped_alpha_runner_service_requires_installer_repair() {
+        let arguments = vec![
+            "/bin/launchctl",
+            "asuser",
+            "501",
+            "/usr/bin/sudo",
+            "-E",
+            "-H",
+            "-u",
+            "appbuilder",
+            "/Users/appbuilder/.oore/bin/oore",
+            "runner",
+            "start",
+            "--config",
+            "/Users/appbuilder/.oore/managed-runner.json",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+
+        assert!(runner_service_uses_user_bootstrap_wrapper(&arguments));
     }
 
     #[test]
@@ -9145,6 +9111,32 @@ mod tests {
         rollback_saw_restored_database: bool,
     }
 
+    struct SimulatedRunnerServiceRollback {
+        plist: PathBuf,
+        config: PathBuf,
+        previous_plist: Vec<u8>,
+        previous_config: Vec<u8>,
+        was_loaded: bool,
+        running: std::cell::Cell<bool>,
+        ready: std::cell::Cell<bool>,
+    }
+
+    impl ManagedRunnerServiceRollback for SimulatedRunnerServiceRollback {
+        fn stop_and_restore_files(&self) -> anyhow::Result<()> {
+            self.running.set(false);
+            self.ready.set(false);
+            fs::write(&self.plist, &self.previous_plist)?;
+            fs::write(&self.config, &self.previous_config)?;
+            Ok(())
+        }
+
+        fn start(&self) -> anyhow::Result<()> {
+            self.running.set(self.was_loaded);
+            self.ready.set(self.was_loaded);
+            Ok(())
+        }
+    }
+
     impl UpdateServiceControl for MigrationFailureControl {
         fn restart_managed_service(&mut self, label: &str) -> anyhow::Result<()> {
             if label == DAEMON_SERVICE_LABEL
@@ -9320,6 +9312,114 @@ mod tests {
         assert!(control.daemon_stopped);
         assert!(control.rollback_saw_restored_database);
         assert_eq!(fs::read(database).unwrap(), expected_database);
+    }
+
+    #[tokio::test]
+    async fn wrapper_repair_failure_restores_release_database_and_runner_service_snapshot() {
+        let (temp, install, stage, release_snapshot) = prepare_update_transaction();
+        let database = temp.path().join("state/oore.db");
+        let key = temp.path().join("state/master.key");
+        fs::create_dir_all(database.parent().unwrap()).unwrap();
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(
+                SqliteConnectOptions::new()
+                    .filename(&database)
+                    .create_if_missing(true),
+            )
+            .await
+            .unwrap();
+        sqlx::query("CREATE TABLE state (value TEXT NOT NULL)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO state (value) VALUES ('before')")
+            .execute(&pool)
+            .await
+            .unwrap();
+        pool.close().await;
+        fs::write(&key, [9_u8; 32]).unwrap();
+
+        let backup = temp.path().join("backup.tar.gz");
+        let backup_database = database.clone();
+        let backup_key = key.clone();
+        let backup_output = backup.clone();
+        tokio::task::spawn_blocking(move || {
+            create_backup_archive(&backup_database, &backup_key, &backup_output)
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        let unpacked = tempfile::tempdir().unwrap();
+        let unpack_backup_path = backup.clone();
+        let unpacked_path = unpacked.path().to_path_buf();
+        tokio::task::spawn_blocking(move || unpack_backup(&unpack_backup_path, &unpacked_path))
+            .await
+            .unwrap()
+            .unwrap();
+        let previous_database = fs::read(unpacked.path().join(BACKUP_DATABASE_FILE)).unwrap();
+        fs::write(&database, b"candidate database migration").unwrap();
+
+        let plist = temp.path().join("build.oore.oore-runner.plist");
+        let config = temp.path().join("managed-runner.json");
+        let previous_plist = b"alpha.18 launchctl asuser sudo wrapper".to_vec();
+        let previous_config = b"original runner identity and registration".to_vec();
+        fs::write(&plist, b"candidate canonical UserName SessionCreate plist").unwrap();
+        fs::write(&config, b"candidate config").unwrap();
+        let runner_snapshot = SimulatedRunnerServiceRollback {
+            plist: plist.clone(),
+            config: config.clone(),
+            previous_plist: previous_plist.clone(),
+            previous_config: previous_config.clone(),
+            was_loaded: true,
+            running: std::cell::Cell::new(true),
+            ready: std::cell::Cell::new(true),
+        };
+        let rollback = UpdateRollbackState {
+            backup,
+            database: database.clone(),
+            key,
+        };
+        let services = UpdateServicePlan {
+            runner_service: None,
+            ..runner_update_plan(false, false)
+        };
+        let mut control = MigrationFailureControl {
+            install_root: install.clone(),
+            database: database.clone(),
+            expected_database: previous_database.clone(),
+            readiness_failed: false,
+            daemon_stopped: false,
+            rollback_saw_restored_database: false,
+        };
+
+        let error = install_release_with_rollback(
+            &stage,
+            &install,
+            &release_snapshot,
+            ReleaseChannel::Stable,
+            "oorebuild/oore",
+            None,
+            Some(&runner_snapshot),
+            None,
+            &services,
+            Some(&rollback),
+            &mut control,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("post-migration readiness"));
+        assert_eq!(
+            fs::read_to_string(install.join("bin/oore")).unwrap(),
+            "old-binary"
+        );
+        assert_eq!(fs::read(&database).unwrap(), previous_database);
+        assert_eq!(fs::read(plist).unwrap(), previous_plist);
+        assert_eq!(fs::read(config).unwrap(), previous_config);
+        assert!(runner_snapshot.running.get());
+        assert!(runner_snapshot.ready.get());
+        assert!(control.rollback_saw_restored_database);
     }
 
     fn v2_marker_has_identity(marker: &str, identity: &str) -> bool {

--- a/crates/oored/src/runtime_updates.rs
+++ b/crates/oored/src/runtime_updates.rs
@@ -22,6 +22,7 @@ use crate::util::api_err;
 
 const SYSTEM_SERVICE_PLIST: &str = "/Library/LaunchDaemons/build.oore.oored.plist";
 const UPDATE_SERVICE_PLIST: &str = "/Library/LaunchDaemons/build.oore.oore-updater.plist";
+const RUNNER_SERVICE_PLIST: &str = "/Library/LaunchDaemons/build.oore.oore-runner.plist";
 const UPDATE_SERVICE: &str = "system/build.oore.oore-updater";
 const UPDATE_STATUS_FILE: &str = ".runtime-update-status.json";
 const UPDATE_REQUEST_DIR: &str = "run/runtime-update-queue";
@@ -33,6 +34,35 @@ fn managed_service_installed() -> bool {
     cfg!(target_os = "macos")
         && Path::new(SYSTEM_SERVICE_PLIST).is_file()
         && Path::new(UPDATE_SERVICE_PLIST).is_file()
+        && runner_service_is_update_ready(Path::new(RUNNER_SERVICE_PLIST))
+}
+
+fn runner_program_arguments_are_update_ready(arguments: &[String]) -> bool {
+    let uses_alpha_wrapper = arguments.first().map(String::as_str) == Some("/bin/launchctl")
+        && arguments.get(1).map(String::as_str) == Some("asuser")
+        && arguments.get(3).map(String::as_str) == Some("/usr/bin/sudo")
+        && arguments.get(4).map(String::as_str) == Some("-E")
+        && arguments.get(5).map(String::as_str) == Some("-H")
+        && arguments.get(6).map(String::as_str) == Some("-u");
+    !uses_alpha_wrapper
+        && arguments.get(1).map(String::as_str) == Some("runner")
+        && arguments.get(2).map(String::as_str) == Some("start")
+}
+
+fn runner_service_is_update_ready(path: &Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+    let Ok(output) = Command::new("/usr/bin/plutil")
+        .args(["-extract", "ProgramArguments", "json", "-o", "-"])
+        .arg(path)
+        .output()
+    else {
+        return false;
+    };
+    output.status.success()
+        && serde_json::from_slice::<Vec<String>>(&output.stdout)
+            .is_ok_and(|arguments| runner_program_arguments_are_update_ready(&arguments))
 }
 
 fn install_root_from_current_exe() -> anyhow::Result<PathBuf> {
@@ -328,7 +358,7 @@ pub async fn start_update(
             return Err(api_err(
                 StatusCode::CONFLICT,
                 "runtime_update_unmanaged",
-                "Backend updates from the web require the managed macOS update supervisor; run the installer once from Terminal to finish service setup",
+                "Backend updates from the web require the current managed macOS services; run the installer once from Terminal to finish or repair service setup",
             ));
         }
         if matches!(
@@ -404,6 +434,40 @@ pub async fn start_update(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn direct_runner_service_is_ready_for_web_updates() {
+        let arguments = [
+            "/Users/appbuilder/.oore/bin/oore",
+            "runner",
+            "start",
+            "--config",
+            "/Users/appbuilder/.oore/managed-runner.json",
+        ]
+        .map(str::to_string);
+
+        assert!(runner_program_arguments_are_update_ready(&arguments));
+    }
+
+    #[test]
+    fn wrapped_alpha_runner_service_requires_installer_repair() {
+        let arguments = [
+            "/bin/launchctl",
+            "asuser",
+            "501",
+            "/usr/bin/sudo",
+            "-E",
+            "-H",
+            "-u",
+            "appbuilder",
+            "/Users/appbuilder/.oore/bin/oore",
+            "runner",
+            "start",
+        ]
+        .map(str::to_string);
+
+        assert!(!runner_program_arguments_are_update_ready(&arguments));
+    }
 
     #[test]
     fn queued_request_carries_the_complete_deferred_update_contract() {

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -14,6 +14,14 @@ Rules:
 
 ## 2026-07-23
 
+- **Boot-safe runner and bounded Apple signing session**:
+  - Managed runners again start directly as their configured non-root account from a system LaunchDaemon, so backend, Android, and unsigned work recover before GUI login. Only fixed `security` and `codesign` commands enter the active user bootstrap; an iOS-signed build fails before checkout with login-and-retry guidance when its snapshot identifies iOS, with a fail-closed pre-build fallback for legacy repository-only configuration.
+  - Imported iOS private keys are scoped to `/usr/bin/codesign` instead of every application. The temporary keychain remains the user-domain default and first search entry only during signing, with the previous state restored during cleanup.
+  - The web updater rejects the alpha.17/alpha.18 wrapper plist before staging an update. Affected hosts run the verified installer once so its existing service snapshot and rollback transaction can repair the plist with administrator authorization; later web updates remain one-click.
+  - Product Trust feature doc: https://linear.app/oorebuild/document/feature-product-trust-hardening-release-592dfc525e77
+  - Platform Contract: https://linear.app/oorebuild/document/platform-contract-v1-7c0f39d2c666
+  - Runtime updates feature doc: https://linear.app/oorebuild/document/feature-runtime-updates-from-the-web-ui-6b648f19a3f9
+
 - **Headless iOS signing key access**:
   - Temporary build keychains now grant imported private keys non-interactive application access plus the complete Apple codesigning partition set, become the user-domain default, and are added to the user keychain search list for the duration of the build. The managed boot-time service preserves Oore's private acknowledgement environment, enters the runner account's user bootstrap session, and then drops privileges, so macOS Security can authorize codesign without an interactive prompt; readiness authenticates the actual runner child rather than the privilege-dropping monitor. Cleanup restores the user's previous default, removes only Oore's temporary keychain, and preserves the other search list entries.
   - Legacy P12 normalization now preserves intermediate certificates instead of exporting only the leaf signing certificate.


### PR DESCRIPTION
## Summary
- restore the managed runner as a direct UserName/SessionCreate LaunchDaemon
- scope GUI bootstrap use to fixed Apple security/codesign commands and fail signed iOS work early when logged out
- detect alpha.17/18 wrapper services as one-time installer repairs and keep UI updates unprivileged
- preserve rollback of release, database, plist/config, service state, and runner readiness
- update public signing, upgrade, and troubleshooting docs

## Validation
- make release-smoke
- make validate
- focused wrapper rollback, login-session, signing ACL, runtime-update UI, lint, build, docs, and Clippy checks
- GitHub Docs, Frontend, and Rust checks

## Post-release fresh-Mac acceptance
- clean installation on a separate personal Mac
- cold boot and readiness before GUI login
- clean signed-iOS failure while logged out
- logged-in Android+iOS build and APK/IPA publication
- default/search keychain restoration

appbuilder.zero.tech is an on-prem production device and is explicitly excluded from reboot/logout acceptance testing. Fresh-host testing will use a separately provided personal Mac after this alpha release.