### PR TITLE
feat(runner): manage Flutter toolchain automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,6 +228,7 @@ jobs:
           install -m 0755 "dist/rust/arm64/oored" "$stage_arm/bin/oored"
           install -m 0755 "dist/rust/arm64/oore"  "$stage_arm/bin/oore"
           install -m 0755 "dist/oore-web-arm64" "$stage_arm/bin/oore-web"
+          bash tools/stage-fvm.sh arm64 "$stage_arm"
           cp -R "apps/web/dist" "$stage_arm/web-dist"
           cp "LICENSE" "$stage_arm/LICENSE"
           printf '%s\n' "$ver" > "$stage_arm/VERSION"
@@ -235,6 +236,7 @@ jobs:
           install -m 0755 "dist/rust/x86_64/oored" "$stage_x64/bin/oored"
           install -m 0755 "dist/rust/x86_64/oore"  "$stage_x64/bin/oore"
           install -m 0755 "dist/oore-web-x86_64" "$stage_x64/bin/oore-web"
+          bash tools/stage-fvm.sh x86_64 "$stage_x64"
           cp -R "apps/web/dist" "$stage_x64/web-dist"
           cp "LICENSE" "$stage_x64/LICENSE"
           printf '%s\n' "$ver" > "$stage_x64/VERSION"
@@ -259,8 +261,8 @@ jobs:
           cp "LICENSE" "$stage_web_linux_x64/LICENSE"
           printf '%s\n' "$ver" > "$stage_web_linux_x64/VERSION"
 
-          [[ -x "$stage_arm/bin/oore" && -x "$stage_arm/bin/oored" && -x "$stage_arm/bin/oore-web" ]]
-          [[ -x "$stage_x64/bin/oore" && -x "$stage_x64/bin/oored" && -x "$stage_x64/bin/oore-web" ]]
+          [[ -x "$stage_arm/bin/oore" && -x "$stage_arm/bin/oored" && -x "$stage_arm/bin/oore-web" && -x "$stage_arm/bin/fvm" && -x "$stage_arm/libexec/fvm/fvm" ]]
+          [[ -x "$stage_x64/bin/oore" && -x "$stage_x64/bin/oored" && -x "$stage_x64/bin/oore-web" && -x "$stage_x64/bin/fvm" && -x "$stage_x64/libexec/fvm/fvm" ]]
 
           out="dist/releases/$tag"
           arm_asset="$(printf 'oore_%s_darwin_arm64.tar.gz' "$ver")"

--- a/apps/docs-site/docs/concepts/build-execution.md
+++ b/apps/docs-site/docs/concepts/build-execution.md
@@ -52,8 +52,8 @@ The runner clones the repository at the specified branch and commit. For GitHub 
 
 The runner prepares the build environment:
 
-1. **Flutter version** — Checks for `.fvmrc` in the repo, falls back to `flutter_version` from config
-2. **FVM install** — Runs `fvm install` to ensure the correct Flutter version is available
+1. **Flutter version** — Checks for `.fvmrc`, then `flutter_version`, then Oore-managed stable Flutter
+2. **Managed SDK** — Uses Oore's bundled FVM to download and cache the selected Flutter SDK when needed
 3. **Environment** — Sets environment variables from the pipeline config
 
 ### 6. Build

--- a/apps/docs-site/docs/getting-started/first-build.md
+++ b/apps/docs-site/docs/getting-started/first-build.md
@@ -51,7 +51,9 @@ artifacts:
 
 Push the file to your repository. Oore CI reads this file at build time — no UI configuration needed.
 
-If your repository includes a `.fvmrc` file, Oore CI uses that Flutter version automatically. The `flutter_version` field in `.oore.yaml` is a fallback.
+If your repository includes a `.fvmrc` file, Oore CI uses that Flutter version
+automatically. The `flutter_version` field is a fallback; otherwise Oore
+downloads and caches stable Flutter automatically.
 
 ### Option B: Configure via the UI
 
@@ -139,7 +141,9 @@ Run `oore doctor` to check your toolchain:
 oore doctor
 ```
 
-Ensure `fvm` and `flutter` are installed and accessible.
+Oore bundles FVM and downloads the selected Flutter SDK automatically. If this
+check fails, update or reinstall Oore. Android builds still require an Android
+SDK, and Apple builds require full Xcode.
 
 ### "No .oore.yaml found" but UI pipeline exists
 

--- a/apps/docs-site/docs/getting-started/prerequisites.md
+++ b/apps/docs-site/docs/getting-started/prerequisites.md
@@ -25,29 +25,24 @@ The one-line installer (`curl -fsSL https://oore.build/install | bash`) requires
 
 macOS includes these by default.
 
-## Required tools for running Flutter build jobs
+## Managed Flutter toolchain
 
-After install, runners/build hosts should have:
+Oore includes FVM in the release and manages Flutter versions for each build.
+You do not need to install FVM or Flutter before installing Oore.
 
-- `git`
-- `fvm`
-- `flutter`
-- `xcodebuild`
+Version resolution is:
 
-Install FVM via Homebrew:
+1. The repository's `.fvmrc`
+2. The pipeline's `flutter_version`
+3. Oore-managed stable Flutter
 
-```bash
-brew tap leoafarias/fvm
-brew install fvm
-```
+The selected SDK downloads automatically on the first build and is cached for
+later builds.
 
-Verify:
+Platform SDKs remain host requirements:
 
-```bash
-fvm --version
-flutter --version
-xcodebuild -version
-```
+- Android builds require a supported JDK and Android SDK.
+- iOS and macOS builds require full Xcode, not only the Command Line Tools.
 
 ## Optional tools for source development
 

--- a/apps/docs-site/docs/guides/projects/pipeline-config.md
+++ b/apps/docs-site/docs/guides/projects/pipeline-config.md
@@ -136,7 +136,8 @@ For Flutter version resolution:
 
 1. `.fvmrc` in the repository — **highest priority**
 2. `flutter_version` in `.oore.yaml` — **fallback**
-3. Pipeline's Flutter version setting in the UI — **final fallback**
+3. Pipeline's Flutter version setting in the UI — **fallback**
+4. Oore-managed stable Flutter — **default**
 
 ## Validation
 

--- a/apps/docs-site/docs/guides/projects/pipeline-ui-fallback.md
+++ b/apps/docs-site/docs/guides/projects/pipeline-ui-fallback.md
@@ -26,7 +26,7 @@ If your repository doesn't contain a `.oore.yaml` file, you can configure the pi
 | ------------------- | ----------------------------------------------------------------- |
 | **Name**            | A label for this pipeline (e.g., "Android Release", "iOS Ad Hoc") |
 | **Platforms**       | Select target platforms: Android, iOS, macOS                      |
-| **Flutter version** | Optional fallback version (overridden by `.fvmrc` in the repo)    |
+| **Flutter version** | Optional fallback version; `.fvmrc` wins and managed stable is the default |
 | **Enabled**         | Toggle the pipeline on/off                                        |
 
 ### 3. Configure build commands

--- a/apps/docs-site/docs/operations/troubleshooting.md
+++ b/apps/docs-site/docs/operations/troubleshooting.md
@@ -84,9 +84,9 @@ preserved.
 
 Check the build logs for errors. Common causes:
 
-- Flutter/FVM not installed on the runner machine
+- Oore's managed FVM binary is missing after an incomplete install or update
 - Incorrect Flutter version requested
-- Missing Xcode for iOS builds
+- Missing Android SDK or full Xcode for the selected platform
 - No active login session for the runner account when Apple signing is enabled
 
 Run `oore doctor --all` on the runner machine to verify the toolchain.

--- a/apps/docs-site/docs/reference/cli/oore-doctor.md
+++ b/apps/docs-site/docs/reference/cli/oore-doctor.md
@@ -25,7 +25,7 @@ oore doctor [--json] [--platform android|ios|macos]... [--all]
 
 `oore doctor` reports status for:
 
-- Core runner tools: `git`, `fvm`, and `flutter`
+- Core runner tools: `git`, Oore's bundled `fvm`, and the managed Flutter SDK
 - Managed runner lifecycle on macOS: the boot-time system service is installed, running, and recently authenticated to the backend, with explicit warnings for a stopped or crash-looping service, a process that is up but has not authenticated successfully, and the legacy login-session runner
 - Android (with `--platform android`): Java and an `ANDROID_HOME` / `ANDROID_SDK_ROOT` SDK with Platform-Tools
 - iOS/macOS (with `--platform ios` or `--platform macos`): `xcode-select -p` and `xcodebuild -version`

--- a/apps/docs-site/docs/reference/config/oore-yaml.md
+++ b/apps/docs-site/docs/reference/config/oore-yaml.md
@@ -101,4 +101,5 @@ Patterns are workspace-relative. Absolute paths, parent traversal, and symlink t
 
 1. `.fvmrc` in repo root — highest priority
 2. `flutter_version` in `.oore.yaml` — fallback
-3. Pipeline Flutter version setting in UI — final fallback
+3. Pipeline Flutter version setting in UI — fallback
+4. Oore-managed stable Flutter — default

--- a/apps/web/src/components/pipeline-form-basic-sections.tsx
+++ b/apps/web/src/components/pipeline-form-basic-sections.tsx
@@ -191,11 +191,10 @@ export function PipelineIdentityAndConfigSection({
                       />
                     </FormControl>
                     <p className="text-xs text-muted-foreground">
-                      If set, runner executes Flutter commands using{' '}
-                      <span className="font-mono">fvm use &lt;version&gt;</span>
-                      . If unset, oore will auto-read{' '}
-                      <span className="font-mono">.fvmrc</span> from the repo
-                      when present.
+                      Oore uses <span className="font-mono">.fvmrc</span> when
+                      present, then this value, then managed stable Flutter.
+                      The SDK downloads automatically on the first build and is
+                      cached for later builds.
                     </p>
                     <FormMessage />
                   </FormItem>

--- a/apps/web/src/routes/projects/$projectId/pipelines/new.tsx
+++ b/apps/web/src/routes/projects/$projectId/pipelines/new.tsx
@@ -251,7 +251,10 @@ function RepositoryWorkflowSummary({
         </div>
         <div>
           <p className="text-xs text-muted-foreground">Flutter</p>
-          <p>{execution.flutter_version ?? 'Detected from .fvmrc or runner'}</p>
+          <p>
+            {execution.flutter_version ??
+              'Detected from .fvmrc or Oore-managed stable'}
+          </p>
         </div>
         <div>
           <p className="text-xs text-muted-foreground">Commands</p>

--- a/crates/oore-runner/src/lib.rs
+++ b/crates/oore-runner/src/lib.rs
@@ -208,7 +208,32 @@ fn repository_shell_command(script: &str, workspace: &Path) -> tokio::process::C
         .arg(script)
         .current_dir(workspace)
         .env_remove(RUNNER_SERVICE_ACK_PATH_ENV);
+    if let Some(install_root) = bundled_fvm_install_root() {
+        configure_bundled_fvm_environment(&mut command, &install_root);
+    }
     command
+}
+
+fn bundled_fvm_install_root() -> Option<PathBuf> {
+    let executable = std::env::current_exe().ok()?;
+    let bin = executable.parent()?;
+    let install_root = bin.parent()?;
+    (bin.join("fvm").is_file() && install_root.join("libexec/fvm/fvm").is_file())
+        .then(|| install_root.to_path_buf())
+}
+
+fn configure_bundled_fvm_environment(command: &mut tokio::process::Command, install_root: &Path) {
+    let mut paths = vec![install_root.join("bin")];
+    if let Some(current) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&current));
+    }
+    if let Ok(path) = std::env::join_paths(paths) {
+        command.env("PATH", path);
+    }
+    command.env(
+        "FVM_CACHE_PATH",
+        install_root.join("toolchains").join("flutter"),
+    );
 }
 
 fn write_private_file(path: &Path, content: &[u8]) -> std::io::Result<()> {
@@ -1231,23 +1256,6 @@ fn run_security_command(args: &[&str]) -> anyhow::Result<String> {
     )
 }
 
-fn user_bootstrap_command_arguments(uid: u32, program: &str, args: &[String]) -> Vec<String> {
-    ["asuser".to_string(), uid.to_string(), program.to_string()]
-        .into_iter()
-        .chain(args.iter().cloned())
-        .collect()
-}
-
-fn user_bootstrap_command(program: &str, args: &[String]) -> Command {
-    let mut command = Command::new("/bin/launchctl");
-    command.args(user_bootstrap_command_arguments(
-        unsafe { libc::geteuid() },
-        program,
-        args,
-    ));
-    command
-}
-
 fn require_ios_signing_user_session() -> anyhow::Result<()> {
     let uid = unsafe { libc::geteuid() };
     let output = Command::new("/bin/launchctl")
@@ -1262,7 +1270,8 @@ fn require_ios_signing_user_session() -> anyhow::Result<()> {
 }
 
 fn run_security_command_with_strings(args: &[String]) -> anyhow::Result<String> {
-    let output = user_bootstrap_command("/usr/bin/security", args)
+    let output = Command::new("/usr/bin/security")
+        .args(args)
         .output()
         .map_err(|e| anyhow::anyhow!("failed to execute security command: {e}"))?;
     if !output.status.success() {
@@ -1883,12 +1892,10 @@ fn ios_keychain_import_arguments(
 }
 
 fn run_ios_signing_tool(program: &str, args: Vec<String>, action: &str) -> anyhow::Result<String> {
-    let output = if program == "/usr/bin/codesign" {
-        user_bootstrap_command(program, &args).output()
-    } else {
-        Command::new(program).args(&args).output()
-    }
-    .map_err(|error| anyhow::anyhow!("failed to {action}: {error}"))?;
+    let output = Command::new(program)
+        .args(&args)
+        .output()
+        .map_err(|error| anyhow::anyhow!("failed to {action}: {error}"))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -3141,6 +3148,8 @@ struct FvmRcConfig {
     flutter: String,
 }
 
+const DEFAULT_MANAGED_FLUTTER_VERSION: &str = "stable";
+
 #[derive(Debug, Clone)]
 struct ResolvedExecutionPlan {
     stage_commands: PipelineCommandStages,
@@ -3248,6 +3257,36 @@ fn apply_fvm_wrappers(stage_commands: PipelineCommandStages) -> PipelineCommandS
             .map(|cmd| maybe_wrap_with_fvm(&cmd))
             .collect(),
     }
+}
+
+fn command_uses_flutter_toolchain(command: &str) -> bool {
+    let trimmed = command.trim();
+    maybe_wrap_with_fvm(trimmed) != trimmed
+        || trimmed == "fvm flutter"
+        || trimmed == "fvm dart"
+        || trimmed.starts_with("fvm flutter ")
+        || trimmed.starts_with("fvm dart ")
+}
+
+fn apply_managed_flutter_toolchain(
+    stage_commands: PipelineCommandStages,
+    version: &str,
+) -> PipelineCommandStages {
+    let requires_flutter = stage_commands
+        .pre_build
+        .iter()
+        .chain(&stage_commands.build)
+        .chain(&stage_commands.post_build)
+        .any(|command| command_uses_flutter_toolchain(command));
+    if !requires_flutter {
+        return stage_commands;
+    }
+
+    let mut stage_commands = apply_fvm_wrappers(stage_commands);
+    stage_commands
+        .pre_build
+        .insert(0, format!("fvm use {version} --force --skip-pub-get"));
+    stage_commands
 }
 
 fn validate_artifact_patterns(patterns: &[String]) -> anyhow::Result<Vec<String>> {
@@ -3544,15 +3583,13 @@ fn resolve_execution_plan(
         let file_config = apply_run_platform_selection(file_config, snapshot)?;
         let resolved_flutter_version = fvmrc_version
             .clone()
-            .or_else(|| file_config.flutter_version.clone());
+            .or_else(|| file_config.flutter_version.clone())
+            .unwrap_or_else(|| DEFAULT_MANAGED_FLUTTER_VERSION.to_string());
         let include_defaults = file_config.commands.build.is_empty();
-        let mut stage_commands = materialize_stage_commands(&file_config, include_defaults);
-        if let Some(version) = resolved_flutter_version {
-            stage_commands = apply_fvm_wrappers(stage_commands);
-            stage_commands
-                .pre_build
-                .insert(0, format!("fvm use {version} --force"));
-        }
+        let stage_commands = apply_managed_flutter_toolchain(
+            materialize_stage_commands(&file_config, include_defaults),
+            &resolved_flutter_version,
+        );
 
         return Ok(ResolvedExecutionPlan {
             stage_commands,
@@ -3563,14 +3600,13 @@ fn resolve_execution_plan(
     }
 
     let fallback = apply_run_platform_selection(load_ui_execution_config(snapshot)?, snapshot)?;
-    let resolved_flutter_version = fvmrc_version.or_else(|| fallback.flutter_version.clone());
-    let mut stage_commands = materialize_stage_commands(&fallback, true);
-    if let Some(version) = resolved_flutter_version {
-        stage_commands = apply_fvm_wrappers(stage_commands);
-        stage_commands
-            .pre_build
-            .insert(0, format!("fvm use {version} --force"));
-    }
+    let resolved_flutter_version = fvmrc_version
+        .or_else(|| fallback.flutter_version.clone())
+        .unwrap_or_else(|| DEFAULT_MANAGED_FLUTTER_VERSION.to_string());
+    let stage_commands = apply_managed_flutter_toolchain(
+        materialize_stage_commands(&fallback, true),
+        &resolved_flutter_version,
+    );
     Ok(ResolvedExecutionPlan {
         stage_commands,
         artifact_patterns: fallback.artifact_patterns,
@@ -5309,22 +5345,12 @@ mod tests {
     }
 
     #[test]
-    fn apple_signing_commands_enter_only_the_user_bootstrap() {
-        let arguments = user_bootstrap_command_arguments(
-            501,
-            "/usr/bin/codesign",
-            &["--verify".to_string(), "/tmp/App.app".to_string()],
-        );
+    fn apple_signing_commands_run_directly_in_the_runner_service_session() {
+        let command = Command::new("/usr/bin/codesign");
 
         assert_eq!(
-            arguments,
-            [
-                "asuser",
-                "501",
-                "/usr/bin/codesign",
-                "--verify",
-                "/tmp/App.app",
-            ]
+            command.get_program(),
+            Path::new("/usr/bin/codesign").as_os_str()
         );
     }
 
@@ -6403,6 +6429,36 @@ mod tests {
     }
 
     #[test]
+    fn bundled_fvm_environment_is_scoped_to_the_oore_install() {
+        let install_root = temp_workspace();
+        let mut command = tokio::process::Command::new("/bin/sh");
+
+        configure_bundled_fvm_environment(&mut command, &install_root);
+
+        let environment = command
+            .as_std()
+            .get_envs()
+            .filter_map(|(key, value)| {
+                value.map(|value| format!("{}={}", key.to_string_lossy(), value.to_string_lossy()))
+            })
+            .collect::<Vec<_>>();
+        assert!(environment.contains(&format!(
+            "FVM_CACHE_PATH={}",
+            install_root.join("toolchains/flutter").display()
+        )));
+        assert!(
+            environment
+                .iter()
+                .find(|entry| entry.starts_with("PATH="))
+                .is_some_and(
+                    |entry| entry.contains(&install_root.join("bin").display().to_string())
+                )
+        );
+
+        cleanup_workspace(&install_root);
+    }
+
+    #[test]
     fn android_signing_marker_exposes_no_reusable_authority() {
         let marker =
             android_signing_prepared_marker("pipeline_profile", AndroidSigningBuildType::Release);
@@ -6786,7 +6842,7 @@ mod tests {
         let plan = resolve_execution_plan(&workspace, &snapshot).expect("resolve plan");
         assert_eq!(
             plan.stage_commands.build,
-            vec!["flutter build ios --release --no-codesign".to_string()]
+            vec!["fvm flutter build ios --release --no-codesign".to_string()]
         );
         assert_eq!(plan.artifact_patterns, vec!["*.ipa".to_string()]);
 
@@ -6821,7 +6877,7 @@ mod tests {
         let plan = resolve_execution_plan(&workspace, &snapshot).expect("resolve plan");
         assert_eq!(
             plan.stage_commands.build,
-            vec!["flutter build macos --release".to_string()]
+            vec!["fvm flutter build macos --release".to_string()]
         );
         assert_eq!(plan.artifact_patterns, vec!["*.zip".to_string()]);
 
@@ -6913,13 +6969,17 @@ mod tests {
         assert_eq!(plan.source, "ui_fallback");
         assert_eq!(
             plan.stage_commands.pre_build,
-            vec!["flutter pub get".to_string(), "echo pre".to_string()]
+            vec![
+                "fvm use stable --force --skip-pub-get".to_string(),
+                "fvm flutter pub get".to_string(),
+                "echo pre".to_string(),
+            ]
         );
         assert_eq!(
             plan.stage_commands.build,
             vec![
-                "flutter build apk --release".to_string(),
-                "flutter build macos --release".to_string(),
+                "fvm flutter build apk --release".to_string(),
+                "fvm flutter build macos --release".to_string(),
                 "echo custom".to_string(),
             ]
         );
@@ -6986,7 +7046,7 @@ mod tests {
         assert_eq!(
             plan.stage_commands.pre_build,
             vec![
-                "fvm use 3.24.0 --force".to_string(),
+                "fvm use 3.24.0 --force --skip-pub-get".to_string(),
                 "fvm flutter pub get".to_string(),
             ]
         );
@@ -7016,7 +7076,35 @@ mod tests {
         assert_eq!(
             plan.stage_commands.pre_build,
             vec![
-                "fvm use 3.22.3 --force".to_string(),
+                "fvm use 3.22.3 --force --skip-pub-get".to_string(),
+                "fvm flutter pub get".to_string(),
+            ]
+        );
+        assert_eq!(
+            plan.stage_commands.build,
+            vec!["fvm flutter build apk --release".to_string()]
+        );
+
+        cleanup_workspace(&workspace);
+    }
+
+    #[test]
+    fn unpinned_flutter_project_uses_oore_managed_stable_sdk() {
+        let workspace = temp_workspace();
+        let snapshot = serde_json::json!({
+            "config_path_explicit": false,
+            "ui_execution_config": {
+                "platforms": ["android"],
+                "commands": { "pre_build": [], "build": [], "post_build": [] },
+                "artifact_patterns": ["*.apk"]
+            }
+        });
+
+        let plan = resolve_execution_plan(&workspace, &snapshot).expect("resolve plan");
+        assert_eq!(
+            plan.stage_commands.pre_build,
+            vec![
+                "fvm use stable --force --skip-pub-get".to_string(),
                 "fvm flutter pub get".to_string(),
             ]
         );
@@ -7124,7 +7212,7 @@ mod tests {
         assert_eq!(
             plan.stage_commands.build,
             vec![
-                "flutter build ipa --release --export-method ad-hoc --target lib/main_adhoc.dart"
+                "fvm flutter build ipa --release --export-method ad-hoc --target lib/main_adhoc.dart"
                     .to_string()
             ]
         );

--- a/crates/oore/src/main.rs
+++ b/crates/oore/src/main.rs
@@ -3734,19 +3734,11 @@ fn add_signing_warnings(checks: &mut Vec<DoctorCheckResult>) {
 fn run_doctor_checks(args: DoctorArgs) -> anyhow::Result<()> {
     let mut checks: Vec<DoctorCheckResult> = Vec::new();
 
-    let base_checks: [(&str, &[&str], &str); 3] = [
-        ("git", &["--version"], "brew install git"),
-        (
-            "fvm",
-            &["--version"],
-            "brew tap leoafarias/fvm && brew install fvm",
-        ),
-        (
-            "flutter",
-            &["--version"],
-            "fvm install <version> && fvm use <version>",
-        ),
-    ];
+    let base_checks: [(&str, &[&str], &str); 1] = [(
+        "git",
+        &["--version"],
+        "install the Xcode Command Line Tools",
+    )];
 
     for (name, command_args, install_hint) in base_checks {
         if let Some(version) = command_version(name, command_args) {
@@ -3754,6 +3746,38 @@ fn run_doctor_checks(args: DoctorArgs) -> anyhow::Result<()> {
         } else {
             checks.push(doctor_check(name, "missing", None, Some(install_hint)));
         }
+    }
+
+    let fvm_available = command_version("fvm", &["--version"]);
+    if let Some(version) = &fvm_available {
+        checks.push(doctor_check("fvm", "ok", Some(version.clone()), None));
+    } else {
+        checks.push(doctor_check(
+            "fvm",
+            "missing",
+            None,
+            Some("reinstall or update Oore to restore its managed Flutter toolchain"),
+        ));
+    }
+
+    if let Some(version) = command_version("flutter", &["--version"]) {
+        checks.push(doctor_check("flutter", "ok", Some(version), None));
+    } else if fvm_available.is_some() {
+        checks.push(doctor_check(
+            "flutter",
+            "ok",
+            Some(
+                "managed by Oore through FVM; downloaded and cached on the first build".to_string(),
+            ),
+            None,
+        ));
+    } else {
+        checks.push(doctor_check(
+            "flutter",
+            "missing",
+            None,
+            Some("reinstall or update Oore to restore its managed Flutter toolchain"),
+        ));
     }
 
     add_managed_runner_service_check(&mut checks);
@@ -4893,6 +4917,8 @@ fn render_runner_launch_daemon(
         <string>{}</string>
         <key>PATH</key>
         <string>{}</string>
+        <key>FVM_CACHE_PATH</key>
+        <string>{}</string>
         <key>{}</key>
         <string>{}</string>
     </dict>
@@ -4912,6 +4938,7 @@ fn render_runner_launch_daemon(
         launchd_xml_escape(user),
         launchd_xml_escape(&home.display().to_string()),
         launchd_xml_escape(path),
+        launchd_xml_escape(&working_dir.join("toolchains/flutter").display().to_string()),
         oore_runner::RUNNER_SERVICE_ACK_PATH_ENV,
         launchd_xml_escape(&acknowledgement.display().to_string()),
         launchd_xml_escape(&working_dir.display().to_string()),
@@ -6151,6 +6178,7 @@ fn copy_release_snapshot(install_root: &Path, snapshot: &Path) -> anyhow::Result
         "bin/oore",
         "bin/oored",
         "bin/oore-web",
+        "bin/fvm",
         "VERSION",
         "WEB_VERSION",
         "CHANNEL",
@@ -6169,6 +6197,10 @@ fn copy_release_snapshot(install_root: &Path, snapshot: &Path) -> anyhow::Result
     let web = install_root.join("web-dist");
     if web.is_dir() {
         copy_dir_recursive(&web, &snapshot.join("web-dist"))?;
+    }
+    let fvm = install_root.join("libexec/fvm");
+    if fvm.is_dir() {
+        copy_dir_recursive(&fvm, &snapshot.join("libexec/fvm"))?;
     }
     Ok(())
 }
@@ -6249,6 +6281,7 @@ fn atomic_replace_directory(source: &Path, destination: &Path) -> anyhow::Result
     let parent = destination
         .parent()
         .context("release destination has no parent")?;
+    fs::create_dir_all(parent)?;
     let stem = destination
         .file_name()
         .unwrap_or_default()
@@ -6280,6 +6313,7 @@ fn restore_release_snapshot(install_root: &Path, snapshot: &Path) -> anyhow::Res
         "bin/oore",
         "bin/oored",
         "bin/oore-web",
+        "bin/fvm",
         "VERSION",
         "WEB_VERSION",
         "CHANNEL",
@@ -6303,6 +6337,13 @@ fn restore_release_snapshot(install_root: &Path, snapshot: &Path) -> anyhow::Res
     } else if destination.exists() {
         fs::remove_dir_all(destination)?;
     }
+    let source = snapshot.join("libexec/fvm");
+    let destination = install_root.join("libexec/fvm");
+    if source.is_dir() {
+        atomic_replace_directory(&source, &destination)?;
+    } else if destination.exists() {
+        fs::remove_dir_all(destination)?;
+    }
     Ok(())
 }
 
@@ -6316,6 +6357,7 @@ fn install_staged_release(
         ("bin/oore", true),
         ("bin/oored", true),
         ("bin/oore-web", true),
+        ("bin/fvm", true),
         ("VERSION", false),
     ] {
         let source = stage.join(relative);
@@ -6332,6 +6374,10 @@ fn install_staged_release(
         atomic_replace_directory(&web, &install_root.join("web-dist"))?;
         fs::write(install_root.join("WEB_CHANNEL"), channel.as_str())?;
         fs::write(install_root.join("WEB_GITHUB_REPO"), repo)?;
+    }
+    let fvm = stage.join("libexec/fvm");
+    if fvm.is_dir() {
+        atomic_replace_directory(&fvm, &install_root.join("libexec/fvm"))?;
     }
     let license = stage.join("LICENSE");
     if license.is_file() {
@@ -8298,6 +8344,8 @@ mod tests {
         assert!(plist.contains("<string>/Users/me/.oore/runner.json</string>"));
         assert!(plist.contains("<key>OORE_RUNNER_SERVICE_ACK_PATH</key>"));
         assert!(plist.contains("<string>/Users/me/.oore/run/runner-service-ack.json</string>"));
+        assert!(plist.contains("<key>FVM_CACHE_PATH</key>"));
+        assert!(plist.contains("<string>/Users/me/.oore/toolchains/flutter</string>"));
         assert!(
             plist.contains("<key>WorkingDirectory</key>\n    <string>/Users/me/.oore</string>")
         );
@@ -9731,11 +9779,16 @@ mod tests {
         for root in [&install, &stage] {
             fs::create_dir_all(root.join("bin")).unwrap();
             fs::create_dir_all(root.join("web-dist")).unwrap();
+            fs::create_dir_all(root.join("libexec/fvm")).unwrap();
         }
         fs::write(install.join("bin/oore"), "old-binary").unwrap();
+        fs::write(install.join("bin/fvm"), "old-fvm-launcher").unwrap();
+        fs::write(install.join("libexec/fvm/fvm"), "old-fvm").unwrap();
         fs::write(install.join("VERSION"), "1.0.0").unwrap();
         fs::write(install.join("web-dist/index.html"), "old-web").unwrap();
         fs::write(stage.join("bin/oore"), "new-binary").unwrap();
+        fs::write(stage.join("bin/fvm"), "new-fvm-launcher").unwrap();
+        fs::write(stage.join("libexec/fvm/fvm"), "new-fvm").unwrap();
         fs::write(stage.join("VERSION"), "2.0.0").unwrap();
         fs::write(stage.join("web-dist/index.html"), "new-web").unwrap();
 
@@ -9757,6 +9810,10 @@ mod tests {
             fs::read_to_string(install.join("WEB_GITHUB_REPO")).unwrap(),
             "oorebuild/oore"
         );
+        assert_eq!(
+            fs::read_to_string(install.join("libexec/fvm/fvm")).unwrap(),
+            "new-fvm"
+        );
 
         restore_release_snapshot(&install, &snapshot).unwrap();
         assert_eq!(
@@ -9773,6 +9830,14 @@ mod tests {
         assert_eq!(
             fs::read_to_string(install.join("web-dist/index.html")).unwrap(),
             "old-web"
+        );
+        assert_eq!(
+            fs::read_to_string(install.join("bin/fvm")).unwrap(),
+            "old-fvm-launcher"
+        );
+        assert_eq!(
+            fs::read_to_string(install.join("libexec/fvm/fvm")).unwrap(),
+            "old-fvm"
         );
     }
 

--- a/crates/oored/src/runtime_updates.rs
+++ b/crates/oored/src/runtime_updates.rs
@@ -156,6 +156,10 @@ pub fn new_state() -> RuntimeUpdateState {
     Arc::new(RwLock::new(initial_status()))
 }
 
+fn refresh_managed_service_state(status: &mut RuntimeUpdateStatus, managed_service: bool) {
+    status.managed_service = managed_service;
+}
+
 fn process_listen_address() -> anyhow::Result<SocketAddr> {
     let arguments = std::env::args().collect::<Vec<_>>();
     let from_arguments = arguments.iter().enumerate().find_map(|(index, argument)| {
@@ -272,7 +276,9 @@ pub async fn get_status(
             }
         }
     }
-    Ok(Json(state.runtime_update.read().await.clone()))
+    let mut status = state.runtime_update.write().await;
+    refresh_managed_service_state(&mut status, managed_service_installed());
+    Ok(Json(status.clone()))
 }
 
 pub async fn start_update(
@@ -467,6 +473,19 @@ mod tests {
         .map(str::to_string);
 
         assert!(!runner_program_arguments_are_update_ready(&arguments));
+    }
+
+    #[test]
+    fn status_refresh_discovers_services_installed_after_daemon_start() {
+        let mut status = RuntimeUpdateStatus {
+            phase: RuntimeUpdatePhase::Idle,
+            error: None,
+            managed_service: false,
+        };
+
+        refresh_managed_service_state(&mut status, true);
+
+        assert!(status.managed_service);
     }
 
     #[test]

--- a/scripts/install-acceptance.sh
+++ b/scripts/install-acceptance.sh
@@ -68,6 +68,30 @@ install_release_metadata "$version_file"
 
 rm -rf "$metadata_dir"
 
+fvm_transition_dir="$(mktemp -d)"
+OORE_INSTALL_ROOT="$fvm_transition_dir/install"
+BIN_DIR="$OORE_INSTALL_ROOT/bin"
+LIBEXEC_DIR="$OORE_INSTALL_ROOT/libexec"
+LOG_DIR="$OORE_INSTALL_ROOT/logs"
+WEB_BINARY="$BIN_DIR/oore-web"
+WEB_DIST_DIR="$OORE_INSTALL_ROOT/web-dist"
+mkdir -p "$fvm_transition_dir/release/bin" "$fvm_transition_dir/release/libexec/fvm/src"
+printf '#!/bin/sh\nexit 0\n' > "$fvm_transition_dir/release/bin/oored"
+printf '#!/bin/sh\nexit 0\n' > "$fvm_transition_dir/release/bin/oore"
+printf '#!/bin/sh\nexit 0\n' > "$fvm_transition_dir/release/bin/fvm"
+printf '#!/bin/sh\nexit 0\n' > "$fvm_transition_dir/release/libexec/fvm/fvm"
+printf 'snapshot\n' > "$fvm_transition_dir/release/libexec/fvm/src/fvm.snapshot"
+printf '2.0.0\n' > "$fvm_transition_dir/release/VERSION"
+chmod +x "$fvm_transition_dir/release/bin/"* "$fvm_transition_dir/release/libexec/fvm/fvm"
+OORE_INSTALL_MODE=backend
+RESOLVED_CHANNEL=alpha
+OORE_GITHUB_REPO=oore-ci/oore.build
+install_extracted_release "$fvm_transition_dir/release"
+[[ -x "$BIN_DIR/fvm" ]]
+[[ -x "$LIBEXEC_DIR/fvm/fvm" ]]
+[[ "$(< "$LIBEXEC_DIR/fvm/src/fvm.snapshot")" == "snapshot" ]]
+rm -rf "$fvm_transition_dir"
+
 transition_dir="$(mktemp -d)"
 release_dir="$transition_dir/release"
 TMP_DIR="$transition_dir/download"
@@ -284,6 +308,16 @@ grep -q -- '<string>opaque-ticket</string>' "$DAEMON_LAUNCH_DAEMON_PLIST"
 unset -f sudo id curl_quick
 rm -rf "$service_bin_dir"
 rm -f "$sudo_call" "$oored_call" "$oore_call"
+
+service_order="$(mktemp)"
+(
+  install_update_service() { printf 'updater\n' >> "$service_order"; }
+  install_daemon_service() { printf 'daemon\n' >> "$service_order"; }
+  install_runner_service() { printf 'runner\n' >> "$service_order"; }
+  install_backend_services
+)
+[[ "$(< "$service_order")" == $'updater\ndaemon\nrunner' ]]
+rm -f "$service_order"
 
 curl_args="$(mktemp)"
 OORE_CHANNEL=alpha

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,6 +45,7 @@ OORE_LOCAL_WEB_MODE="${OORE_LOCAL_WEB_MODE:-}"
 OORE_LOCAL_WEB_LISTEN="${OORE_LOCAL_WEB_LISTEN:-127.0.0.1:4173}"
 
 BIN_DIR="$OORE_INSTALL_ROOT/bin"
+LIBEXEC_DIR="$OORE_INSTALL_ROOT/libexec"
 LOG_DIR="$OORE_INSTALL_ROOT/logs"
 DAEMON_LOG="$LOG_DIR/oored.log"
 DAEMON_PID_FILE="$OORE_INSTALL_ROOT/oored.pid"
@@ -1532,6 +1533,13 @@ install_extracted_release() {
   if is_daemon_install; then
     install_executable "$extract_dir/bin/oored" "$BIN_DIR/oored"
     install_executable "$extract_dir/bin/oore" "$BIN_DIR/oore"
+    if [[ -f "$extract_dir/bin/fvm" && -d "$extract_dir/libexec/fvm" ]]; then
+      install_executable "$extract_dir/bin/fvm" "$BIN_DIR/fvm"
+      mkdir -p "$LIBEXEC_DIR"
+      rm -rf "$LIBEXEC_DIR/fvm"
+      cp -R "$extract_dir/libexec/fvm" "$LIBEXEC_DIR/fvm"
+      chmod +x "$LIBEXEC_DIR/fvm/fvm"
+    fi
   fi
   if is_web_install; then
     install_executable "$extract_dir/bin/oore-web" "$WEB_BINARY"
@@ -1881,8 +1889,8 @@ install_runner_service() {
 }
 
 install_backend_services() {
-  install_daemon_service || return 1
   install_update_service || return 1
+  install_daemon_service || return 1
   install_runner_service || return 1
 }
 
@@ -2470,6 +2478,9 @@ print_next_steps() {
       printf 'To keep the daemon running across login sessions:\n'
       printf '  oored install-service --listen %s\n\n' "$OORE_DAEMON_LISTEN"
     fi
+    if [[ -x "$BIN_DIR/fvm" ]]; then
+      printf 'Flutter toolchain: managed by Oore (SDK downloads automatically on first build)\n\n'
+    fi
     if [[ "$BACKEND_SETUP_INITIALIZED" -eq 1 ]]; then
       printf 'Setup is initialized. Sign in through your configured auth path.\n'
     elif is_default_local_install; then
@@ -2618,9 +2629,17 @@ main() {
   elif [[ "$OORE_INSTALL_MODE" == "frontend" ]]; then
     step_done "$BIN_DIR/oore-web + web-dist"
   elif [[ "$OORE_INSTALL_MODE" == "backend" ]]; then
-    step_done "$BIN_DIR/{oored,oore}"
+    if [[ -x "$BIN_DIR/fvm" ]]; then
+      step_done "$BIN_DIR/{oored,oore,fvm}"
+    else
+      step_done "$BIN_DIR/{oored,oore}"
+    fi
   elif has_local_web_bundle; then
-    step_done "$BIN_DIR/{oored,oore,oore-web}"
+    if [[ -x "$BIN_DIR/fvm" ]]; then
+      step_done "$BIN_DIR/{oored,oore,oore-web,fvm}"
+    else
+      step_done "$BIN_DIR/{oored,oore,oore-web}"
+    fi
   else
     step_done "$BIN_DIR/{oored,oore}"
   fi

--- a/tools/release-smoke.sh
+++ b/tools/release-smoke.sh
@@ -33,6 +33,9 @@ grep -q 'releases.oore.build' scripts/install.sh
 grep -Fq 'latest/$OORE_CHANNEL.json' scripts/install.sh
 grep -q 'releases.oore.build' apps/web/tools/oore-web.js
 grep -q 'releases.oore.build' crates/oore/src/main.rs
+grep -q 'tools/stage-fvm.sh arm64' .github/workflows/release.yml
+grep -q 'tools/stage-fvm.sh x86_64' .github/workflows/release.yml
+bash -n tools/stage-fvm.sh
 if grep -Eq 'make deploy-(site|docs|web)-only &' .github/workflows/release.yml; then
   echo "[release-smoke] Pages deploys must not run concurrently." >&2
   exit 1

--- a/tools/stage-fvm.sh
+++ b/tools/stage-fvm.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FVM_VERSION="4.1.2"
+FVM_REPOSITORY="conceptadev/fvm"
+FVM_ARM64_SHA256="0b2a146986c51f06331f135f0bdf2a202eb57f55d7edd420c9078e8520e4c033"
+FVM_X64_SHA256="7bbfcb6883ea67ce532163704f5625eba7ecf340084be707cde71a28fefff1d8"
+
+usage() {
+  echo "usage: $0 <arm64|x86_64> <release-stage>" >&2
+  exit 2
+}
+
+[[ $# -eq 2 ]] || usage
+
+release_arch="$1"
+stage="$2"
+case "$release_arch" in
+  arm64)
+    fvm_arch="arm64"
+    expected_sha="$FVM_ARM64_SHA256"
+    ;;
+  x86_64)
+    fvm_arch="x64"
+    expected_sha="$FVM_X64_SHA256"
+    ;;
+  *)
+    usage
+    ;;
+esac
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+archive="fvm-${FVM_VERSION}-macos-${fvm_arch}.tar.gz"
+url="https://github.com/${FVM_REPOSITORY}/releases/download/${FVM_VERSION}/${archive}"
+curl -fsSL --retry 3 --connect-timeout 10 --max-time 300 "$url" -o "$tmp/$archive"
+printf '%s  %s\n' "$expected_sha" "$tmp/$archive" | shasum -a 256 -c -
+
+if tar -tzf "$tmp/$archive" | grep -qE '^/|^\.\.$|^\.\./|/\.\.$|/\.\./'; then
+  echo "FVM archive contains an unsafe path" >&2
+  exit 1
+fi
+
+mkdir -p "$tmp/extract" "$stage/bin" "$stage/libexec"
+tar -xzf "$tmp/$archive" -C "$tmp/extract"
+[[ -f "$tmp/extract/fvm/fvm" ]] || {
+  echo "FVM archive is missing fvm/fvm" >&2
+  exit 1
+}
+
+rm -rf "$stage/libexec/fvm"
+cp -R "$tmp/extract/fvm" "$stage/libexec/fvm"
+chmod +x "$stage/libexec/fvm/fvm"
+
+cat > "$stage/bin/fvm" <<'EOF'
+#!/bin/sh
+set -eu
+root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+exec "$root/libexec/fvm/fvm" "$@"
+EOF
+chmod +x "$stage/bin/fvm"


### PR DESCRIPTION
## Summary
- bundle pinned FVM launchers in macOS release archives and manage Flutter SDKs per Oore install
- default unpinned Flutter projects to managed stable while honoring .fvmrc and pipeline overrides
- fix fresh-install managed-update discovery and install updater before daemon startup
- run Apple security and codesign directly in the canonical runner service session
- preserve bundled FVM across runtime update rollback and document the user-facing toolchain contract

## Validation
- make validate
- make release-smoke
- installer acceptance
- actual FVM 4.1.2 arm64 and x86_64 staging/version checks

## Acceptance context
Jarvis exposed the missing-Flutter failure, stale managed-service state after a fresh legacy install, and invalid launchctl-asuser use from the canonical runner. This change addresses all three; released clean-host acceptance will follow before the release is called aligned.