### PR TITLE
fix(storage): default new instances to local artifacts

### DIFF
--- a/apps/docs-site/docs/guides/artifacts/configure-storage.md
+++ b/apps/docs-site/docs/guides/artifacts/configure-storage.md
@@ -7,6 +7,10 @@ description: 'Configure artifact storage backends for Oore CI including local, S
 
 Build artifacts (APKs, IPAs, etc.) need a storage location. Oore CI supports local filesystem storage, Amazon S3, and Cloudflare R2.
 
+New instances use local filesystem storage automatically. You only need to
+change these settings when you want to disable artifacts or move them to S3 or
+R2.
+
 ## What you need
 
 - **Role**: owner or admin
@@ -30,7 +34,9 @@ Build artifacts (APKs, IPAs, etc.) need a storage location. Oore CI supports loc
 
 ### Local storage
 
-No additional configuration needed. Artifacts are stored on the daemon's filesystem and served via signed token URLs.
+This is the default for a new instance and needs no additional configuration.
+Artifacts are stored on the daemon's filesystem and served via signed token
+URLs.
 
 ### S3 storage
 

--- a/crates/oored/src/storage.rs
+++ b/crates/oored/src/storage.rs
@@ -715,7 +715,7 @@ pub async fn load_effective_config(
     }
 
     Ok(EffectiveStorageConfig {
-        provider: ArtifactStorageProvider::Disabled,
+        provider: ArtifactStorageProvider::Local,
         source: ArtifactStorageSource::Default,
         local_base_dir: Some(default_local_artifacts_dir().to_string_lossy().to_string()),
         s3_bucket: None,
@@ -750,6 +750,46 @@ pub async fn load_backend(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn unconfigured_storage_defaults_to_local() {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("sqlite pool");
+        sqlx::query(
+            "CREATE TABLE artifact_storage_settings (
+                id INTEGER PRIMARY KEY,
+                provider TEXT NOT NULL,
+                local_base_dir TEXT,
+                s3_bucket TEXT,
+                s3_region TEXT,
+                s3_endpoint TEXT,
+                s3_access_key_encrypted TEXT,
+                s3_secret_key_encrypted TEXT,
+                updated_at INTEGER
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("artifact storage table");
+
+        let config = load_effective_config(&pool, b"unused")
+            .await
+            .expect("default storage config");
+
+        assert_eq!(config.provider, ArtifactStorageProvider::Local);
+        assert_eq!(config.source, ArtifactStorageSource::Default);
+        assert!(
+            config
+                .local_base_dir
+                .as_deref()
+                .is_some_and(|path| path.ends_with("oore/artifacts"))
+        );
+        assert!(matches!(
+            build_backend_from_config(&config, None).expect("local backend"),
+            StorageBackend::Local(_)
+        ));
+    }
 
     #[tokio::test]
     async fn local_download_can_use_artifact_delivery_origin() {


### PR DESCRIPTION
## Summary
- make local filesystem artifact storage the effective default when a new instance has no saved storage settings
- preserve explicit Disabled, Local, S3, and R2 choices
- document that new instances need no artifact-storage setup

## Why
Fresh Jarvis acceptance reached a successful Oore-managed Flutter build, then failed publication with `artifact storage is not configured`. The clean setup had no storage row, so the backend's default-disabled fallback contradicted the no-configuration local storage contract.

## Verification
- `cargo test -p oored --lib` (73 passed)
- `make test-docs`
- `make build-docs`
- `git diff --check`