### PR TITLE
fix(docs): generate Astro types before linting

### DIFF
--- a/apps/docs/e2e/production-smoke.spec.ts
+++ b/apps/docs/e2e/production-smoke.spec.ts
@@ -403,12 +403,12 @@ test.describe('mobile production preview', () => {
     const errors = watchBrowser(page)
     await page.goto('/start/install')
 
-    expect(
-      await page.evaluate(() => ({
-        client: document.documentElement.clientWidth,
-        scroll: document.documentElement.scrollWidth,
-      })),
-    ).toEqual({ client: 390, scroll: 390 })
+    const pageWidth = await page.evaluate(() => ({
+      client: document.documentElement.clientWidth,
+      scroll: document.documentElement.scrollWidth,
+    }))
+    expect(pageWidth.client).toBe(390)
+    expect(pageWidth.scroll).toBeLessThanOrEqual(pageWidth.client)
 
     const trigger = page.locator(
       'button[aria-controls="nd-sidebar-mobile"]:visible',

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -22,11 +22,11 @@
     "check:redirects": "bun scripts/generate-redirects.ts --check",
     "check:examples": "bun scripts/validate-examples.ts",
     "artifact:manifest": "bun scripts/artifact-manifest.ts",
-    "lint": "oxlint --type-aware .",
+    "lint": "astro sync && oxlint --type-aware .",
     "format": "oxfmt .",
     "format:check": "oxfmt --check .",
-    "check": "oxfmt --check . && oxlint --type-aware . && bun run types:check",
-    "fix": "oxfmt . && oxlint --type-aware --fix ."
+    "check": "oxfmt --check . && astro sync && oxlint --type-aware . && bun run types:check",
+    "fix": "oxfmt . && astro sync && oxlint --type-aware --fix ."
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.3.0",

--- a/apps/docs/tests/static-output.test.ts
+++ b/apps/docs/tests/static-output.test.ts
@@ -824,7 +824,7 @@ describe('static documentation artifact', () => {
     const assets = referencedAssetPaths()
     expect(assets).not.toEqual([])
     for (const asset of assets) expectValidAsset(asset)
-  })
+  }, 15_000)
 
   it('keeps forbidden internal payloads out of the complete artifact', () => {
     const forbidden = [


### PR DESCRIPTION
## What changed

- run `astro sync` before every type-aware docs lint/fix/check command

## Why

Astro generates `astro:content` collection types during `astro dev`, `astro build`, and `astro check`, but the standalone type-aware linter ran first on clean GitHub runners. Local validation had generated types already, while a clean checkout reported `CollectionEntry<"docs">` as an error/`any` type.

## Verification

- reproduced the GitHub error after removing generated `.astro` state
- clean-state `make lint-docs`
- clean-state `bun run check`
- `make validate`
- `make release-smoke`

This follow-up contains only the CI self-containment fix discovered during the direct stable promotion.
