### PR TITLE
fix(docs): prevent theme flash during navigation

### DIFF
--- a/apps/docs/src/components/layout.astro
+++ b/apps/docs/src/components/layout.astro
@@ -16,6 +16,39 @@ import '@/styles.css'
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <link rel="alternate icon" href="/favicon.ico" />
     <link rel="apple-touch-icon" href="/logo192.png" />
+    <script is:inline>
+      (() => {
+        const storageKey = 'oore-docs-theme'
+
+        const resolveTheme = () => {
+          let storedTheme
+          try {
+            storedTheme = localStorage.getItem(storageKey)
+          } catch {
+            // Storage can be unavailable in restricted browser contexts.
+          }
+
+          if (storedTheme === 'light' || storedTheme === 'dark') {
+            return storedTheme
+          }
+
+          return window.matchMedia('(prefers-color-scheme: dark)').matches
+            ? 'dark'
+            : 'light'
+        }
+
+        const applyTheme = (root) => {
+          const theme = resolveTheme()
+          root.classList.toggle('dark', theme === 'dark')
+          root.style.colorScheme = theme
+        }
+
+        applyTheme(document.documentElement)
+        document.addEventListener('astro:before-swap', (event) => {
+          applyTheme(event.newDocument.documentElement)
+        })
+      })()
+    </script>
     <ClientRouter />
     <slot name="head" />
   </head>


### PR DESCRIPTION
## What changed

Apply the persisted light, dark, or system theme to each incoming Astro document during `astro:before-swap`.

## Why

Client-side docs navigation could briefly paint the incoming document in light mode before the saved dark theme was restored, producing a bright white flash.

## Impact

Dark-mode route changes retain the correct color scheme before Astro swaps documents.

## Validation

- `make validate`
- `make release-smoke`
- No new regression test is included.