### PR TITLE
feat(components): add one-use credential grants

### DIFF
--- a/crates/oore-contract/src/lib.rs
+++ b/crates/oore-contract/src/lib.rs
@@ -1238,6 +1238,17 @@ pub struct ClaimJobRequest {
     pub protocol_version: u32,
 }
 
+/// Exact public binding used when a trusted runner consumes one credential grant.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ConsumeComponentCredentialGrantRequest {
+    pub operation_id: String,
+    pub component_identity_digest: String,
+    pub capability_id: String,
+    pub job_lock_digest: String,
+    pub fencing_token: i64,
+    pub secret_kind: String,
+}
+
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct UpdateRunnerRequest {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/oored/migrations/039_component_credential_grants.sql
+++ b/crates/oored/migrations/039_component_credential_grants.sql
@@ -1,7 +1,20 @@
+CREATE TABLE component_credential_authorities (
+    operation_id TEXT PRIMARY KEY NOT NULL,
+    runner_id TEXT NOT NULL REFERENCES runners(id) ON DELETE CASCADE,
+    component_identity_digest TEXT NOT NULL,
+    capability_id TEXT NOT NULL,
+    job_lock_digest TEXT NOT NULL,
+    fencing_token INTEGER NOT NULL CHECK (fencing_token > 0),
+    expires_at INTEGER NOT NULL,
+    revoked_at INTEGER,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+
 CREATE TABLE component_credential_grants (
     id TEXT PRIMARY KEY NOT NULL,
     handle_hash TEXT NOT NULL UNIQUE,
-    operation_id TEXT NOT NULL,
+    operation_id TEXT NOT NULL REFERENCES component_credential_authorities(operation_id) ON DELETE CASCADE,
     runner_id TEXT NOT NULL REFERENCES runners(id) ON DELETE CASCADE,
     component_identity_digest TEXT NOT NULL,
     capability_id TEXT NOT NULL,
@@ -16,5 +29,13 @@ CREATE TABLE component_credential_grants (
 );
 
 CREATE INDEX idx_component_credential_grants_active
-    ON component_credential_grants (handle_hash, expires_at)
+    ON component_credential_grants (operation_id, fencing_token)
     WHERE consumed_at IS NULL AND revoked_at IS NULL;
+
+CREATE INDEX idx_component_credential_grants_cleanup
+    ON component_credential_grants (expires_at)
+    WHERE secret_ciphertext <> '';
+
+CREATE INDEX idx_component_credential_authorities_expiry
+    ON component_credential_authorities (expires_at)
+    WHERE revoked_at IS NULL;

--- a/crates/oored/migrations/039_component_credential_grants.sql
+++ b/crates/oored/migrations/039_component_credential_grants.sql
@@ -1,0 +1,20 @@
+CREATE TABLE component_credential_grants (
+    id TEXT PRIMARY KEY NOT NULL,
+    handle_hash TEXT NOT NULL UNIQUE,
+    operation_id TEXT NOT NULL,
+    runner_id TEXT NOT NULL REFERENCES runners(id) ON DELETE CASCADE,
+    component_identity_digest TEXT NOT NULL,
+    capability_id TEXT NOT NULL,
+    job_lock_digest TEXT NOT NULL,
+    fencing_token INTEGER NOT NULL CHECK (fencing_token > 0),
+    secret_kind TEXT NOT NULL,
+    secret_ciphertext TEXT NOT NULL,
+    expires_at INTEGER NOT NULL,
+    consumed_at INTEGER,
+    revoked_at INTEGER,
+    created_at INTEGER NOT NULL
+);
+
+CREATE INDEX idx_component_credential_grants_active
+    ON component_credential_grants (handle_hash, expires_at)
+    WHERE consumed_at IS NULL AND revoked_at IS NULL;

--- a/crates/oored/src/background.rs
+++ b/crates/oored/src/background.rs
@@ -45,7 +45,17 @@ pub fn start_background_tasks(
         pool.clone(),
         storage.clone(),
     ));
-    tokio::spawn(expired_artifact_monitor(pool, storage));
+    tokio::spawn(expired_artifact_monitor(pool.clone(), storage));
+    tokio::spawn(component_credential_grant_monitor(pool));
+}
+
+async fn component_credential_grant_monitor(pool: SqlitePool) {
+    loop {
+        if let Err(error) = crate::credential_broker::clear_expired(&pool, now_unix()).await {
+            warn!(?error, "component credential grant cleanup failed");
+        }
+        tokio::time::sleep(Duration::from_secs(60)).await;
+    }
 }
 
 async fn stale_pending_artifact_monitor(pool: SqlitePool, storage: Arc<RwLock<StorageBackend>>) {

--- a/crates/oored/src/credential_broker.rs
+++ b/crates/oored/src/credential_broker.rs
@@ -19,12 +19,7 @@ const MAX_GRANT_LIFETIME_SECONDS: i64 = 60 * 60;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CredentialGrantBinding {
-    pub operation_id: String,
-    pub runner_id: String,
-    pub component_identity_digest: String,
-    pub capability_id: String,
-    pub job_lock_digest: String,
-    pub fencing_token: i64,
+    pub authority: CredentialAuthorityBinding,
     pub secret_kind: String,
 }
 
@@ -36,19 +31,6 @@ pub struct CredentialAuthorityBinding {
     pub capability_id: String,
     pub job_lock_digest: String,
     pub fencing_token: i64,
-}
-
-impl CredentialGrantBinding {
-    fn authority(&self) -> CredentialAuthorityBinding {
-        CredentialAuthorityBinding {
-            operation_id: self.operation_id.clone(),
-            runner_id: self.runner_id.clone(),
-            component_identity_digest: self.component_identity_digest.clone(),
-            capability_id: self.capability_id.clone(),
-            job_lock_digest: self.job_lock_digest.clone(),
-            fencing_token: self.fencing_token,
-        }
-    }
 }
 
 pub struct CredentialGrantHandle(Zeroizing<String>);
@@ -209,12 +191,12 @@ pub async fn issue(
     )
     .bind(Uuid::new_v4().to_string())
     .bind(handle_hash)
-    .bind(&binding.operation_id)
-    .bind(&binding.runner_id)
-    .bind(&binding.component_identity_digest)
-    .bind(&binding.capability_id)
-    .bind(&binding.job_lock_digest)
-    .bind(binding.fencing_token)
+    .bind(&binding.authority.operation_id)
+    .bind(&binding.authority.runner_id)
+    .bind(&binding.authority.component_identity_digest)
+    .bind(&binding.authority.capability_id)
+    .bind(&binding.authority.job_lock_digest)
+    .bind(binding.authority.fencing_token)
     .bind(&binding.secret_kind)
     .bind(encrypted)
     .bind(expires_at)
@@ -275,12 +257,12 @@ pub async fn consume(
     )
     .bind(now)
     .bind(handle_hash)
-    .bind(&binding.operation_id)
-    .bind(&binding.runner_id)
-    .bind(&binding.component_identity_digest)
-    .bind(&binding.capability_id)
-    .bind(&binding.job_lock_digest)
-    .bind(binding.fencing_token)
+    .bind(&binding.authority.operation_id)
+    .bind(&binding.authority.runner_id)
+    .bind(&binding.authority.component_identity_digest)
+    .bind(&binding.authority.capability_id)
+    .bind(&binding.authority.job_lock_digest)
+    .bind(binding.authority.fencing_token)
     .bind(&binding.secret_kind)
     .fetch_optional(pool)
     .await
@@ -346,12 +328,12 @@ pub async fn revoke(
     )
     .bind(now)
     .bind(hash_token(raw_handle))
-    .bind(&binding.operation_id)
-    .bind(&binding.runner_id)
-    .bind(&binding.component_identity_digest)
-    .bind(&binding.capability_id)
-    .bind(&binding.job_lock_digest)
-    .bind(binding.fencing_token)
+    .bind(&binding.authority.operation_id)
+    .bind(&binding.authority.runner_id)
+    .bind(&binding.authority.component_identity_digest)
+    .bind(&binding.authority.capability_id)
+    .bind(&binding.authority.job_lock_digest)
+    .bind(binding.authority.fencing_token)
     .bind(&binding.secret_kind)
     .execute(pool)
     .await
@@ -455,7 +437,7 @@ pub async fn clear_expired(pool: &SqlitePool, now: i64) -> Result<u64, Credentia
 }
 
 fn validate_binding(binding: &CredentialGrantBinding) -> Result<(), CredentialGrantError> {
-    validate_authority_binding(&binding.authority())?;
+    validate_authority_binding(&binding.authority)?;
     if !valid_id(&binding.secret_kind) {
         return Err(CredentialGrantError::InvalidRequest);
     }

--- a/crates/oored/src/credential_broker.rs
+++ b/crates/oored/src/credential_broker.rs
@@ -28,6 +28,29 @@ pub struct CredentialGrantBinding {
     pub secret_kind: String,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CredentialAuthorityBinding {
+    pub operation_id: String,
+    pub runner_id: String,
+    pub component_identity_digest: String,
+    pub capability_id: String,
+    pub job_lock_digest: String,
+    pub fencing_token: i64,
+}
+
+impl CredentialGrantBinding {
+    fn authority(&self) -> CredentialAuthorityBinding {
+        CredentialAuthorityBinding {
+            operation_id: self.operation_id.clone(),
+            runner_id: self.runner_id.clone(),
+            component_identity_digest: self.component_identity_digest.clone(),
+            capability_id: self.capability_id.clone(),
+            job_lock_digest: self.job_lock_digest.clone(),
+            fencing_token: self.fencing_token,
+        }
+    }
+}
+
 pub struct CredentialGrantHandle(Zeroizing<String>);
 
 impl CredentialGrantHandle {
@@ -50,6 +73,100 @@ pub enum CredentialGrantError {
     Crypto,
 }
 
+pub async fn activate_authority(
+    pool: &SqlitePool,
+    binding: &CredentialAuthorityBinding,
+    now: i64,
+    expires_at: i64,
+) -> Result<(), CredentialGrantError> {
+    validate_authority_binding(binding)?;
+    validate_lifetime(now, expires_at)?;
+
+    let mut transaction = pool
+        .begin()
+        .await
+        .map_err(|_| CredentialGrantError::Store)?;
+    let current_fence = sqlx::query_scalar::<_, i64>(
+        "SELECT fencing_token
+         FROM component_credential_authorities
+         WHERE operation_id = ?1",
+    )
+    .bind(&binding.operation_id)
+    .fetch_optional(&mut *transaction)
+    .await
+    .map_err(|_| CredentialGrantError::Store)?;
+
+    match current_fence {
+        None => {
+            sqlx::query(
+                "INSERT INTO component_credential_authorities (
+                    operation_id, runner_id, component_identity_digest,
+                    capability_id, job_lock_digest, fencing_token, expires_at,
+                    created_at, updated_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?8)",
+            )
+            .bind(&binding.operation_id)
+            .bind(&binding.runner_id)
+            .bind(&binding.component_identity_digest)
+            .bind(&binding.capability_id)
+            .bind(&binding.job_lock_digest)
+            .bind(binding.fencing_token)
+            .bind(expires_at)
+            .bind(now)
+            .execute(&mut *transaction)
+            .await
+            .map_err(|_| CredentialGrantError::Store)?;
+        }
+        Some(current_fence) if binding.fencing_token > current_fence => {
+            sqlx::query(
+                "UPDATE component_credential_grants
+                 SET revoked_at = ?1, secret_ciphertext = ''
+                 WHERE operation_id = ?2
+                   AND consumed_at IS NULL
+                   AND revoked_at IS NULL",
+            )
+            .bind(now)
+            .bind(&binding.operation_id)
+            .execute(&mut *transaction)
+            .await
+            .map_err(|_| CredentialGrantError::Store)?;
+            let updated = sqlx::query(
+                "UPDATE component_credential_authorities
+                 SET runner_id = ?1,
+                     component_identity_digest = ?2,
+                     capability_id = ?3,
+                     job_lock_digest = ?4,
+                     fencing_token = ?5,
+                     expires_at = ?6,
+                     revoked_at = NULL,
+                     updated_at = ?7
+                 WHERE operation_id = ?8 AND fencing_token = ?9",
+            )
+            .bind(&binding.runner_id)
+            .bind(&binding.component_identity_digest)
+            .bind(&binding.capability_id)
+            .bind(&binding.job_lock_digest)
+            .bind(binding.fencing_token)
+            .bind(expires_at)
+            .bind(now)
+            .bind(&binding.operation_id)
+            .bind(current_fence)
+            .execute(&mut *transaction)
+            .await
+            .map_err(|_| CredentialGrantError::Store)?;
+            if updated.rows_affected() != 1 {
+                return Err(CredentialGrantError::Unavailable);
+            }
+        }
+        Some(_) => return Err(CredentialGrantError::Unavailable),
+    }
+
+    transaction
+        .commit()
+        .await
+        .map_err(|_| CredentialGrantError::Store)
+}
+
 pub async fn issue(
     pool: &SqlitePool,
     encryption_key: &[u8],
@@ -59,13 +176,10 @@ pub async fn issue(
     expires_at: i64,
 ) -> Result<IssuedCredentialGrant, CredentialGrantError> {
     validate_binding(binding)?;
-    if secret.is_empty()
-        || secret.len() > MAX_SECRET_BYTES
-        || expires_at <= now
-        || expires_at > now.saturating_add(MAX_GRANT_LIFETIME_SECONDS)
-    {
+    if secret.is_empty() || secret.len() > MAX_SECRET_BYTES {
         return Err(CredentialGrantError::InvalidRequest);
     }
+    validate_lifetime(now, expires_at)?;
 
     let encoded_secret = Zeroizing::new(base64::engine::general_purpose::STANDARD.encode(secret));
     let encrypted = crypto::encrypt(encoded_secret.as_str(), encryption_key)
@@ -73,12 +187,25 @@ pub async fn issue(
     let raw_handle = Zeroizing::new(generate_token());
     let handle_hash = hash_token(raw_handle.as_str());
 
-    sqlx::query(
+    let inserted = sqlx::query(
         "INSERT INTO component_credential_grants (
             id, handle_hash, operation_id, runner_id, component_identity_digest,
             capability_id, job_lock_digest, fencing_token, secret_kind,
             secret_ciphertext, expires_at, created_at
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+         )
+         SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12
+         WHERE EXISTS (
+             SELECT 1
+             FROM component_credential_authorities
+             WHERE operation_id = ?3
+               AND runner_id = ?4
+               AND component_identity_digest = ?5
+               AND capability_id = ?6
+               AND job_lock_digest = ?7
+               AND fencing_token = ?8
+               AND expires_at >= ?11
+               AND revoked_at IS NULL
+         )",
     )
     .bind(Uuid::new_v4().to_string())
     .bind(handle_hash)
@@ -95,6 +222,9 @@ pub async fn issue(
     .execute(pool)
     .await
     .map_err(|_| CredentialGrantError::Store)?;
+    if inserted.rows_affected() != 1 {
+        return Err(CredentialGrantError::Unavailable);
+    }
 
     Ok(IssuedCredentialGrant {
         handle: CredentialGrantHandle(raw_handle),
@@ -129,6 +259,18 @@ pub async fn consume(
            AND expires_at > ?1
            AND consumed_at IS NULL
            AND revoked_at IS NULL
+           AND EXISTS (
+               SELECT 1
+               FROM component_credential_authorities authority
+               WHERE authority.operation_id = component_credential_grants.operation_id
+                 AND authority.runner_id = component_credential_grants.runner_id
+                 AND authority.component_identity_digest = component_credential_grants.component_identity_digest
+                 AND authority.capability_id = component_credential_grants.capability_id
+                 AND authority.job_lock_digest = component_credential_grants.job_lock_digest
+                 AND authority.fencing_token = component_credential_grants.fencing_token
+                 AND authority.expires_at > ?1
+                 AND authority.revoked_at IS NULL
+           )
          RETURNING id, secret_ciphertext",
     )
     .bind(now)
@@ -217,28 +359,126 @@ pub async fn revoke(
     Ok(result.rows_affected() == 1)
 }
 
-pub async fn clear_expired(pool: &SqlitePool, now: i64) -> Result<u64, CredentialGrantError> {
-    let result = sqlx::query(
-        "UPDATE component_credential_grants
-         SET revoked_at = COALESCE(revoked_at, ?1), secret_ciphertext = ''
-         WHERE expires_at <= ?1 AND secret_ciphertext <> ''",
+pub async fn revoke_authority(
+    pool: &SqlitePool,
+    binding: &CredentialAuthorityBinding,
+    now: i64,
+) -> Result<bool, CredentialGrantError> {
+    validate_authority_binding(binding)?;
+    let mut transaction = pool
+        .begin()
+        .await
+        .map_err(|_| CredentialGrantError::Store)?;
+    let revoked = sqlx::query(
+        "UPDATE component_credential_authorities
+         SET revoked_at = ?1, updated_at = ?1
+         WHERE operation_id = ?2
+           AND runner_id = ?3
+           AND component_identity_digest = ?4
+           AND capability_id = ?5
+           AND job_lock_digest = ?6
+           AND fencing_token = ?7
+           AND revoked_at IS NULL",
     )
     .bind(now)
-    .execute(pool)
+    .bind(&binding.operation_id)
+    .bind(&binding.runner_id)
+    .bind(&binding.component_identity_digest)
+    .bind(&binding.capability_id)
+    .bind(&binding.job_lock_digest)
+    .bind(binding.fencing_token)
+    .execute(&mut *transaction)
     .await
     .map_err(|_| CredentialGrantError::Store)?;
-    Ok(result.rows_affected())
+    if revoked.rows_affected() == 1 {
+        sqlx::query(
+            "UPDATE component_credential_grants
+             SET revoked_at = ?1, secret_ciphertext = ''
+             WHERE operation_id = ?2
+               AND fencing_token = ?3
+               AND consumed_at IS NULL
+               AND revoked_at IS NULL",
+        )
+        .bind(now)
+        .bind(&binding.operation_id)
+        .bind(binding.fencing_token)
+        .execute(&mut *transaction)
+        .await
+        .map_err(|_| CredentialGrantError::Store)?;
+    }
+    transaction
+        .commit()
+        .await
+        .map_err(|_| CredentialGrantError::Store)?;
+    Ok(revoked.rows_affected() == 1)
+}
+
+pub async fn clear_expired(pool: &SqlitePool, now: i64) -> Result<u64, CredentialGrantError> {
+    let mut transaction = pool
+        .begin()
+        .await
+        .map_err(|_| CredentialGrantError::Store)?;
+    let authorities = sqlx::query(
+        "UPDATE component_credential_authorities
+         SET revoked_at = ?1, updated_at = ?1
+         WHERE expires_at <= ?1 AND revoked_at IS NULL",
+    )
+    .bind(now)
+    .execute(&mut *transaction)
+    .await
+    .map_err(|_| CredentialGrantError::Store)?;
+    let grants = sqlx::query(
+        "UPDATE component_credential_grants
+         SET revoked_at = COALESCE(revoked_at, ?1), secret_ciphertext = ''
+         WHERE secret_ciphertext <> ''
+           AND (
+               expires_at <= ?1
+               OR EXISTS (
+                   SELECT 1
+                   FROM component_credential_authorities authority
+                   WHERE authority.operation_id = component_credential_grants.operation_id
+                     AND (authority.expires_at <= ?1 OR authority.revoked_at IS NOT NULL)
+               )
+           )",
+    )
+    .bind(now)
+    .execute(&mut *transaction)
+    .await
+    .map_err(|_| CredentialGrantError::Store)?;
+    transaction
+        .commit()
+        .await
+        .map_err(|_| CredentialGrantError::Store)?;
+    Ok(authorities
+        .rows_affected()
+        .saturating_add(grants.rows_affected()))
 }
 
 fn validate_binding(binding: &CredentialGrantBinding) -> Result<(), CredentialGrantError> {
+    validate_authority_binding(&binding.authority())?;
+    if !valid_id(&binding.secret_kind) {
+        return Err(CredentialGrantError::InvalidRequest);
+    }
+    Ok(())
+}
+
+fn validate_authority_binding(
+    binding: &CredentialAuthorityBinding,
+) -> Result<(), CredentialGrantError> {
     if !valid_id(&binding.operation_id)
         || !valid_id(&binding.runner_id)
         || !valid_digest(&binding.component_identity_digest)
         || !valid_id(&binding.capability_id)
         || !valid_digest(&binding.job_lock_digest)
         || binding.fencing_token <= 0
-        || !valid_id(&binding.secret_kind)
     {
+        return Err(CredentialGrantError::InvalidRequest);
+    }
+    Ok(())
+}
+
+fn validate_lifetime(now: i64, expires_at: i64) -> Result<(), CredentialGrantError> {
+    if expires_at <= now || expires_at > now.saturating_add(MAX_GRANT_LIFETIME_SECONDS) {
         return Err(CredentialGrantError::InvalidRequest);
     }
     Ok(())

--- a/crates/oored/src/credential_broker.rs
+++ b/crates/oored/src/credential_broker.rs
@@ -1,0 +1,269 @@
+//! Oore-owned, one-use credential grants for trusted runner parents.
+//!
+//! This module stores temporary secret material under Oore encryption. A grant
+//! is bound to one operation, component identity, capability, job lock, and
+//! fencing token. The raw handle is returned once and only its hash is stored.
+//! Components never receive this handle through the public component protocol.
+
+use base64::Engine as _;
+use sqlx::SqlitePool;
+use uuid::Uuid;
+use zeroize::Zeroizing;
+
+use crate::crypto;
+use crate::token::{generate_token, hash_token};
+
+const MAX_SECRET_BYTES: usize = 8 * 1024 * 1024;
+const MAX_ID_BYTES: usize = 256;
+const MAX_GRANT_LIFETIME_SECONDS: i64 = 60 * 60;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CredentialGrantBinding {
+    pub operation_id: String,
+    pub runner_id: String,
+    pub component_identity_digest: String,
+    pub capability_id: String,
+    pub job_lock_digest: String,
+    pub fencing_token: i64,
+    pub secret_kind: String,
+}
+
+pub struct CredentialGrantHandle(Zeroizing<String>);
+
+impl CredentialGrantHandle {
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+pub struct IssuedCredentialGrant {
+    pub handle: CredentialGrantHandle,
+    pub expires_at: i64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CredentialGrantError {
+    InvalidRequest,
+    Unavailable,
+    Store,
+    Crypto,
+}
+
+pub async fn issue(
+    pool: &SqlitePool,
+    encryption_key: &[u8],
+    binding: &CredentialGrantBinding,
+    secret: &[u8],
+    now: i64,
+    expires_at: i64,
+) -> Result<IssuedCredentialGrant, CredentialGrantError> {
+    validate_binding(binding)?;
+    if secret.is_empty()
+        || secret.len() > MAX_SECRET_BYTES
+        || expires_at <= now
+        || expires_at > now.saturating_add(MAX_GRANT_LIFETIME_SECONDS)
+    {
+        return Err(CredentialGrantError::InvalidRequest);
+    }
+
+    let encoded_secret = Zeroizing::new(base64::engine::general_purpose::STANDARD.encode(secret));
+    let encrypted = crypto::encrypt(encoded_secret.as_str(), encryption_key)
+        .map_err(|_| CredentialGrantError::Crypto)?;
+    let raw_handle = Zeroizing::new(generate_token());
+    let handle_hash = hash_token(raw_handle.as_str());
+
+    sqlx::query(
+        "INSERT INTO component_credential_grants (
+            id, handle_hash, operation_id, runner_id, component_identity_digest,
+            capability_id, job_lock_digest, fencing_token, secret_kind,
+            secret_ciphertext, expires_at, created_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+    )
+    .bind(Uuid::new_v4().to_string())
+    .bind(handle_hash)
+    .bind(&binding.operation_id)
+    .bind(&binding.runner_id)
+    .bind(&binding.component_identity_digest)
+    .bind(&binding.capability_id)
+    .bind(&binding.job_lock_digest)
+    .bind(binding.fencing_token)
+    .bind(&binding.secret_kind)
+    .bind(encrypted)
+    .bind(expires_at)
+    .bind(now)
+    .execute(pool)
+    .await
+    .map_err(|_| CredentialGrantError::Store)?;
+
+    Ok(IssuedCredentialGrant {
+        handle: CredentialGrantHandle(raw_handle),
+        expires_at,
+    })
+}
+
+pub async fn consume(
+    pool: &SqlitePool,
+    encryption_key: &[u8],
+    binding: &CredentialGrantBinding,
+    raw_handle: &str,
+    now: i64,
+) -> Result<Zeroizing<Vec<u8>>, CredentialGrantError> {
+    validate_binding(binding)?;
+    if !valid_handle(raw_handle) {
+        return Err(CredentialGrantError::Unavailable);
+    }
+
+    let handle_hash = hash_token(raw_handle);
+    let claimed = sqlx::query_as::<_, (String, String)>(
+        "UPDATE component_credential_grants
+         SET consumed_at = ?1
+         WHERE handle_hash = ?2
+           AND operation_id = ?3
+           AND runner_id = ?4
+           AND component_identity_digest = ?5
+           AND capability_id = ?6
+           AND job_lock_digest = ?7
+           AND fencing_token = ?8
+           AND secret_kind = ?9
+           AND expires_at > ?1
+           AND consumed_at IS NULL
+           AND revoked_at IS NULL
+         RETURNING id, secret_ciphertext",
+    )
+    .bind(now)
+    .bind(handle_hash)
+    .bind(&binding.operation_id)
+    .bind(&binding.runner_id)
+    .bind(&binding.component_identity_digest)
+    .bind(&binding.capability_id)
+    .bind(&binding.job_lock_digest)
+    .bind(binding.fencing_token)
+    .bind(&binding.secret_kind)
+    .fetch_optional(pool)
+    .await
+    .map_err(|_| CredentialGrantError::Store)?
+    .ok_or(CredentialGrantError::Unavailable)?;
+
+    let (grant_id, encrypted) = claimed;
+    let decoded = crypto::decrypt(&encrypted, encryption_key)
+        .map(Zeroizing::new)
+        .map_err(|_| CredentialGrantError::Crypto)
+        .and_then(|encoded| {
+            base64::engine::general_purpose::STANDARD
+                .decode(encoded.as_bytes())
+                .map(Zeroizing::new)
+                .map_err(|_| CredentialGrantError::Crypto)
+        });
+
+    let cleared = sqlx::query(
+        "UPDATE component_credential_grants
+         SET secret_ciphertext = ''
+         WHERE id = ?1 AND consumed_at = ?2",
+    )
+    .bind(grant_id)
+    .bind(now)
+    .execute(pool)
+    .await
+    .map_err(|_| CredentialGrantError::Store)?;
+    if cleared.rows_affected() != 1 {
+        return Err(CredentialGrantError::Store);
+    }
+
+    let secret = decoded?;
+    if secret.is_empty() || secret.len() > MAX_SECRET_BYTES {
+        return Err(CredentialGrantError::Crypto);
+    }
+    Ok(secret)
+}
+
+pub async fn revoke(
+    pool: &SqlitePool,
+    binding: &CredentialGrantBinding,
+    raw_handle: &str,
+    now: i64,
+) -> Result<bool, CredentialGrantError> {
+    validate_binding(binding)?;
+    if !valid_handle(raw_handle) {
+        return Ok(false);
+    }
+
+    let result = sqlx::query(
+        "UPDATE component_credential_grants
+         SET revoked_at = ?1, secret_ciphertext = ''
+         WHERE handle_hash = ?2
+           AND operation_id = ?3
+           AND runner_id = ?4
+           AND component_identity_digest = ?5
+           AND capability_id = ?6
+           AND job_lock_digest = ?7
+           AND fencing_token = ?8
+           AND secret_kind = ?9
+           AND consumed_at IS NULL
+           AND revoked_at IS NULL",
+    )
+    .bind(now)
+    .bind(hash_token(raw_handle))
+    .bind(&binding.operation_id)
+    .bind(&binding.runner_id)
+    .bind(&binding.component_identity_digest)
+    .bind(&binding.capability_id)
+    .bind(&binding.job_lock_digest)
+    .bind(binding.fencing_token)
+    .bind(&binding.secret_kind)
+    .execute(pool)
+    .await
+    .map_err(|_| CredentialGrantError::Store)?;
+    Ok(result.rows_affected() == 1)
+}
+
+pub async fn clear_expired(pool: &SqlitePool, now: i64) -> Result<u64, CredentialGrantError> {
+    let result = sqlx::query(
+        "UPDATE component_credential_grants
+         SET revoked_at = COALESCE(revoked_at, ?1), secret_ciphertext = ''
+         WHERE expires_at <= ?1 AND secret_ciphertext <> ''",
+    )
+    .bind(now)
+    .execute(pool)
+    .await
+    .map_err(|_| CredentialGrantError::Store)?;
+    Ok(result.rows_affected())
+}
+
+fn validate_binding(binding: &CredentialGrantBinding) -> Result<(), CredentialGrantError> {
+    if !valid_id(&binding.operation_id)
+        || !valid_id(&binding.runner_id)
+        || !valid_digest(&binding.component_identity_digest)
+        || !valid_id(&binding.capability_id)
+        || !valid_digest(&binding.job_lock_digest)
+        || binding.fencing_token <= 0
+        || !valid_id(&binding.secret_kind)
+    {
+        return Err(CredentialGrantError::InvalidRequest);
+    }
+    Ok(())
+}
+
+fn valid_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_ID_BYTES
+        && value.as_bytes()[0].is_ascii_alphanumeric()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || b"._:/-".contains(&byte))
+}
+
+fn valid_digest(value: &str) -> bool {
+    value.len() == 71
+        && value.starts_with("sha256:")
+        && value[7..]
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn valid_handle(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}

--- a/crates/oored/src/lib.rs
+++ b/crates/oored/src/lib.rs
@@ -7,6 +7,7 @@ pub mod audit_logs;
 pub mod auth;
 pub mod background;
 pub mod builds;
+pub mod credential_broker;
 pub mod crypto;
 pub mod embedded_runner;
 pub mod extractors;
@@ -2573,6 +2574,10 @@ async fn build_router_inner(
             post(runners::runner_heartbeat),
         )
         .route("/v1/runners/{runner_id}/claim", post(runners::claim_job))
+        .route(
+            "/v1/runners/{runner_id}/component-credentials/consume",
+            post(runners::consume_component_credential_grant),
+        )
         .route(
             "/v1/runners/{runner_id}/jobs/{job_id}/gitlab/{*git_path}",
             get(integrations::gitlab::proxy_git_checkout)

--- a/crates/oored/src/runners.rs
+++ b/crates/oored/src/runners.rs
@@ -3,12 +3,14 @@ use std::sync::Arc;
 use axum::Json;
 use axum::extract::{FromRequestParts, Path, State};
 use axum::http::request::Parts;
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
+use axum::response::{IntoResponse, Response};
 use oore_contract::{
     ApiError, BuildDetailResponse, BuildEvent, BuildStatus, ClaimJobRequest, ClaimJobResponse,
-    ClaimedJob, JobStatusResponse, ListRunnersResponse, RUNNER_PROTOCOL_VERSION,
-    RegisterRunnerRequest, RegisterRunnerResponse, Runner, RunnerHeartbeatRequest, RunnerStatus,
-    UpdateJobStatusRequest, UpdateRunnerRequest, UpdateRunnerResponse,
+    ClaimedJob, ConsumeComponentCredentialGrantRequest, JobStatusResponse, ListRunnersResponse,
+    RUNNER_PROTOCOL_VERSION, RegisterRunnerRequest, RegisterRunnerResponse, Runner,
+    RunnerHeartbeatRequest, RunnerStatus, UpdateJobStatusRequest, UpdateRunnerRequest,
+    UpdateRunnerResponse,
 };
 use sqlx::Row;
 use tracing::{error, info, warn};
@@ -16,6 +18,7 @@ use uuid::Uuid;
 
 use crate::AppState;
 use crate::builds::transition_build;
+use crate::credential_broker::{self, CredentialGrantBinding, CredentialGrantError};
 use crate::extractors::AuthUser;
 use crate::rbac::check_permission;
 use crate::store::write_audit_log;
@@ -23,6 +26,86 @@ use crate::token::{generate_token, hash_token};
 use crate::util::{api_err, extract_bearer, now_unix};
 
 type ApiResult<T> = Result<Json<T>, (StatusCode, Json<ApiError>)>;
+
+const COMPONENT_CREDENTIAL_GRANT_HEADER: &str = "x-oore-component-credential-grant";
+
+pub async fn consume_component_credential_grant(
+    State(state): State<Arc<AppState>>,
+    Path(runner_id): Path<String>,
+    auth: RunnerAuth,
+    headers: HeaderMap,
+    Json(request): Json<ConsumeComponentCredentialGrantRequest>,
+) -> Result<Response, (StatusCode, Json<ApiError>)> {
+    if auth.runner_id != runner_id {
+        return Err(api_err(
+            StatusCode::FORBIDDEN,
+            "runner_mismatch",
+            "The credential grant does not belong to this runner",
+        ));
+    }
+
+    let handle = headers
+        .get(COMPONENT_CREDENTIAL_GRANT_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            api_err(
+                StatusCode::UNAUTHORIZED,
+                "credential_grant_required",
+                "A component credential grant is required",
+            )
+        })?;
+    let binding = CredentialGrantBinding {
+        operation_id: request.operation_id,
+        runner_id,
+        component_identity_digest: request.component_identity_digest,
+        capability_id: request.capability_id,
+        job_lock_digest: request.job_lock_digest,
+        fencing_token: request.fencing_token,
+        secret_kind: request.secret_kind,
+    };
+    let secret = credential_broker::consume(
+        &state.db,
+        &state.encryption_key,
+        &binding,
+        handle,
+        now_unix(),
+    )
+    .await
+    .map_err(map_credential_grant_error)?;
+
+    let mut response_headers = HeaderMap::new();
+    response_headers.insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
+    response_headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/octet-stream"),
+    );
+    response_headers.insert(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    Ok((response_headers, secret.to_vec()).into_response())
+}
+
+fn map_credential_grant_error(error: CredentialGrantError) -> (StatusCode, Json<ApiError>) {
+    match error {
+        CredentialGrantError::InvalidRequest => api_err(
+            StatusCode::BAD_REQUEST,
+            "invalid_credential_grant_binding",
+            "The component credential binding is invalid",
+        ),
+        CredentialGrantError::Unavailable => api_err(
+            StatusCode::NOT_FOUND,
+            "credential_grant_unavailable",
+            "The component credential grant is unavailable",
+        ),
+        CredentialGrantError::Store | CredentialGrantError::Crypto => api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "credential_grant_error",
+            "The component credential grant could not be consumed",
+        ),
+    }
+}
 
 /// Resolve the pipeline for a currently assigned job. Signing bundles are
 /// available only while the build is assigned or running; requeue and terminal

--- a/crates/oored/src/runners.rs
+++ b/crates/oored/src/runners.rs
@@ -18,7 +18,9 @@ use uuid::Uuid;
 
 use crate::AppState;
 use crate::builds::transition_build;
-use crate::credential_broker::{self, CredentialGrantBinding, CredentialGrantError};
+use crate::credential_broker::{
+    self, CredentialAuthorityBinding, CredentialGrantBinding, CredentialGrantError,
+};
 use crate::extractors::AuthUser;
 use crate::rbac::check_permission;
 use crate::store::write_audit_log;
@@ -56,12 +58,14 @@ pub async fn consume_component_credential_grant(
             )
         })?;
     let binding = CredentialGrantBinding {
-        operation_id: request.operation_id,
-        runner_id,
-        component_identity_digest: request.component_identity_digest,
-        capability_id: request.capability_id,
-        job_lock_digest: request.job_lock_digest,
-        fencing_token: request.fencing_token,
+        authority: CredentialAuthorityBinding {
+            operation_id: request.operation_id,
+            runner_id,
+            component_identity_digest: request.component_identity_digest,
+            capability_id: request.capability_id,
+            job_lock_digest: request.job_lock_digest,
+            fencing_token: request.fencing_token,
+        },
         secret_kind: request.secret_kind,
     };
     let secret = credential_broker::consume(


### PR DESCRIPTION
## Result

Adds the first safe link needed by the Apple account flow.

- Oore encrypts temporary component credential grants at rest.
- Each grant binds one runner, operation, component, capability, job lock, fence, and secret kind.
- The runner can consume a grant once through an authenticated no-store endpoint.
- Reuse, expiry, revocation, or binding changes fail closed.
- Expired secret ciphertext is cleared by the background monitor.

This is the server half of #242. It does not invoke components or add the Apple UI yet.

## Checks

- cargo fmt --all -- --check
- cargo check -p oore-contract -p oored --locked
- git diff --check

No automated tests were added or run, per the v0.2.0 testing rule.

Supports #273 and #271.