### PR TITLE
fix(runner): restore iOS signing user bootstrap

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -179,8 +179,8 @@ jobs:
       - name: Test
         run: make test-web
 
-      - name: Build, check bundle, and validate standalone server
-        run: make bundle-check validate-web-launcher
+      - name: Build and validate standalone server
+        run: make validate-web-launcher
 
       - name: Install Chromium
         run: cd apps/web && bunx playwright install --with-deps chromium

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   changes:
     name: Detect changes
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ${{ vars.RUNNER_LINUX || 'ubuntu-latest' }}
     outputs:
       frontend: ${{ steps.filter.outputs.frontend }}
@@ -114,6 +115,7 @@ jobs:
   tooling:
     name: Validation tooling
     needs: changes
+    if: needs.changes.result == 'success'
     runs-on: ${{ vars.RUNNER_LINUX || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
@@ -159,7 +161,7 @@ jobs:
   frontend:
     name: Frontend
     needs: changes
-    if: needs.changes.outputs.frontend == 'true'
+    if: needs.changes.result == 'success' && needs.changes.outputs.frontend == 'true'
     runs-on: ${{ vars.RUNNER_LINUX || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
@@ -191,7 +193,7 @@ jobs:
   docs:
     name: Docs
     needs: changes
-    if: needs.changes.outputs.docs == 'true'
+    if: needs.changes.result == 'success' && needs.changes.outputs.docs == 'true'
     runs-on: ${{ vars.RUNNER_LINUX || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
@@ -235,7 +237,7 @@ jobs:
   rust:
     name: Rust
     needs: changes
-    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.scheduled_rust == 'true'
+    if: needs.changes.result == 'success' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.scheduled_rust == 'true')
     runs-on: ${{ vars.RUNNER_MACOS || 'macos-latest' }}
     steps:
       - uses: actions/checkout@v6
@@ -261,7 +263,7 @@ jobs:
 
   required:
     name: Required validation
-    if: ${{ always() }}
+    if: ${{ always() && !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     needs: [changes, tooling, frontend, docs, rust]
     runs-on: ${{ vars.RUNNER_LINUX || 'ubuntu-latest' }}
     env:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,9 +30,10 @@ jobs:
       - uses: dorny/paths-filter@v4
         id: filter
         with:
-          # Pull requests use the GitHub API comparison against their base
-          # branch. Other events compare against the prior branch commit.
-          base: ${{ github.event_name != 'pull_request' && github.ref || '' }}
+          # On a PR update, compare only the new commit range. On PR open or
+          # reopen, compare the PR base. Branch events use the prior commit.
+          token: ''
+          base: ${{ github.event.action == 'synchronize' && github.event.before || github.event.pull_request.base.sha || github.ref }}
           filters: |
             frontend:
               - 'apps/web/**'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,10 +30,9 @@ jobs:
       - uses: dorny/paths-filter@v4
         id: filter
         with:
-          # Pull requests use the API comparison against their base branch, so
-          # this value is ignored there. Pushes compare each long-lived branch
-          # with its own previous commit instead of the repository default.
-          base: ${{ github.ref }}
+          # Pull requests use the GitHub API comparison against their base
+          # branch. Other events compare against the prior branch commit.
+          base: ${{ github.event_name != 'pull_request' && github.ref || '' }}
           filters: |
             frontend:
               - 'apps/web/**'

--- a/apps/docs/editorial-review.json
+++ b/apps/docs/editorial-review.json
@@ -1112,7 +1112,7 @@
     }
   ],
   "result": "pass",
-  "reviewedCommit": "cd47868ccdbdc4ed1fa04967f7e7710686c0f7e2",
+  "reviewedCommit": "8fa537321e8880d300cf932b510c26e7ed80df25",
   "reviewerCoverage": [
     "The integration owner reviewed every authored destination page by page against the accepted truth, deployment, voice, hierarchy, and URL contracts.",
     "An independent full-corpus content review covered all 81 pages and every source-sensitive claim, then rechecked each applied finding at the fixed commit.",

--- a/apps/docs/public/openapi.json
+++ b/apps/docs/public/openapi.json
@@ -8636,12 +8636,6 @@
               "null"
             ]
           },
-          "repository_id": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "repository_full_name": {
             "type": [
               "string",
@@ -8649,6 +8643,12 @@
             ]
           },
           "repository_host_url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "repository_id": {
             "type": [
               "string",
               "null"

--- a/apps/docs/public/openapi.json
+++ b/apps/docs/public/openapi.json
@@ -8636,6 +8636,12 @@
               "null"
             ]
           },
+          "repository_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "repository_full_name": {
             "type": [
               "string",

--- a/apps/web/src/components/build-item.tsx
+++ b/apps/web/src/components/build-item.tsx
@@ -93,6 +93,8 @@ export function BuildItem({
         <RepositoryAvatar
           fullName={build.context?.repository_full_name ?? projectName}
           avatarUrl={build.context?.project_avatar_url}
+          repositoryId={build.context?.repository_id}
+          provider={build.context?.repository_provider}
           size="sm"
         />
       </ItemMedia>

--- a/apps/web/src/demo/handlers/builds.ts
+++ b/apps/web/src/demo/handlers/builds.ts
@@ -32,6 +32,7 @@ function withBuildContext(build: (typeof demoState.builds)[number]) {
           },
     context: {
       project_name: project?.name,
+      repository_id: project?.repository_id,
       project_avatar_url: project?.repository_avatar_url,
       repository_full_name: project?.repository_full_name,
       repository_provider: integration?.provider,

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -419,6 +419,7 @@ export type RunnerPolicyBlockReason =
 
 export interface BuildContext {
   project_name?: string
+  repository_id?: string
   project_avatar_url?: string
   repository_full_name?: string
   repository_provider?: ScmProvider

--- a/apps/web/src/routes/settings/-import-users-dialog.tsx
+++ b/apps/web/src/routes/settings/-import-users-dialog.tsx
@@ -80,7 +80,8 @@ export default function ImportUsersDialog({
         row.role !== 'owner' && !existingEmails.has(row.email.toLowerCase()),
     )
     const ownerRows = parsed.rows.filter(
-      (row) => row.role === 'owner' && !existingEmails.has(row.email.toLowerCase()),
+      (row) =>
+        row.role === 'owner' && !existingEmails.has(row.email.toLowerCase()),
     )
     const outcomes = await Promise.allSettled(
       importRows.map((row) =>

--- a/apps/web/src/routes/settings/-import-users-dialog.tsx
+++ b/apps/web/src/routes/settings/-import-users-dialog.tsx
@@ -1,0 +1,216 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { Spinner } from '@/components/ui/spinner'
+import { useInviteUser } from '@/hooks/use-auth'
+import { toast } from '@/lib/toast'
+import { parseUserCsv } from './-user-csv'
+
+const importUsersSchema = z.object({
+  file: z.instanceof(File, { message: 'Choose a CSV file.' }),
+})
+
+type ImportUsersForm = z.infer<typeof importUsersSchema>
+
+interface ImportResult {
+  failed: Array<{ email: string; message: string; row: number }>
+  imported: number
+  skipped: number
+}
+
+export default function ImportUsersDialog({
+  existingEmails,
+  onOpenChange,
+  open,
+}: {
+  existingEmails: Set<string>
+  onOpenChange: (open: boolean) => void
+  open: boolean
+}) {
+  const inviteMutation = useInviteUser()
+  const [result, setResult] = useState<ImportResult | null>(null)
+  const form = useForm<ImportUsersForm>({
+    resolver: zodResolver(importUsersSchema),
+    defaultValues: { file: undefined },
+  })
+
+  async function submit({ file }: ImportUsersForm) {
+    setResult(null)
+    const parsed = parseUserCsv(await file.text())
+    if (parsed.errors.length > 0) {
+      form.setError('root', {
+        message: parsed.errors
+          .map((error) =>
+            error.row ? `Row ${error.row}: ${error.message}` : error.message,
+          )
+          .join(' '),
+      })
+      return
+    }
+    if (parsed.rows.length === 0) {
+      form.setError('root', { message: 'The CSV file has no users to import.' })
+      return
+    }
+
+    const skipped = parsed.rows.filter((row) =>
+      existingEmails.has(row.email.toLowerCase()),
+    )
+    const importRows = parsed.rows.filter(
+      (row) =>
+        row.role !== 'owner' && !existingEmails.has(row.email.toLowerCase()),
+    )
+    const ownerRows = parsed.rows.filter(
+      (row) => row.role === 'owner' && !existingEmails.has(row.email.toLowerCase()),
+    )
+    const outcomes = await Promise.allSettled(
+      importRows.map((row) =>
+        inviteMutation.mutateAsync({ email: row.email, role: row.role }),
+      ),
+    )
+    const failed = outcomes.flatMap((outcome, index) => {
+      if (outcome.status === 'fulfilled') return []
+      const row = importRows[index]
+      return [
+        {
+          email: row.email,
+          message:
+            outcome.reason instanceof Error
+              ? outcome.reason.message
+              : 'The invite failed.',
+          row: row.row,
+        },
+      ]
+    })
+    const imported = importRows.length - failed.length
+    const ownerFailures = ownerRows.map((row) => ({
+      email: row.email,
+      message: 'Only the existing owner can have the owner role.',
+      row: row.row,
+    }))
+    setResult({
+      imported,
+      skipped: skipped.length,
+      failed: [...failed, ...ownerFailures],
+    })
+
+    if (failed.length === 0 && ownerFailures.length === 0) {
+      toast.success(
+        imported > 0
+          ? `${imported} user${imported === 1 ? '' : 's'} imported`
+          : `${skipped.length} existing user${skipped.length === 1 ? '' : 's'} skipped`,
+      )
+      form.reset()
+      onOpenChange(false)
+    }
+  }
+
+  function resetDialog() {
+    setResult(null)
+    form.clearErrors()
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        onOpenChange(nextOpen)
+        if (!nextOpen) resetDialog()
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Import users</DialogTitle>
+          <DialogDescription>CSV format: email,role</DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form className="space-y-4" onSubmit={form.handleSubmit(submit)}>
+            <FormField
+              control={form.control}
+              name="file"
+              render={({ field }) => (
+                <FormItem>
+                  <FormControl>
+                    <Input
+                      accept=".csv,text/csv"
+                      type="file"
+                      onChange={(event) => {
+                        field.onChange(event.target.files?.[0])
+                        form.clearErrors()
+                        setResult(null)
+                      }}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {form.formState.errors.root?.message ? (
+              <Alert variant="destructive">
+                <AlertDescription>
+                  {form.formState.errors.root.message}
+                </AlertDescription>
+              </Alert>
+            ) : null}
+
+            {result && result.failed.length > 0 ? (
+              <Alert variant="destructive">
+                <AlertDescription>
+                  Imported {result.imported}. Failed {result.failed.length}.{' '}
+                  Skipped {result.skipped}.{' '}
+                  {result.failed
+                    .map(
+                      (failure) =>
+                        `Row ${failure.row} (${failure.email}): ${failure.message}`,
+                    )
+                    .join(' ')}
+                </AlertDescription>
+              </Alert>
+            ) : null}
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={inviteMutation.isPending}>
+                {inviteMutation.isPending ? (
+                  <>
+                    <Spinner className="size-4" />
+                    Importing...
+                  </>
+                ) : (
+                  'Import users'
+                )}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/routes/settings/-user-csv-actions.tsx
+++ b/apps/web/src/routes/settings/-user-csv-actions.tsx
@@ -20,7 +20,11 @@ export function UserCsvActions({ users }: { users: Array<User> }) {
         onFocus={() => void loadImportUsersDialog()}
         onClick={() => setOpen(true)}
       >
-        <HugeiconsIcon icon={Upload04Icon} data-icon="inline-start" aria-hidden />
+        <HugeiconsIcon
+          icon={Upload04Icon}
+          data-icon="inline-start"
+          aria-hidden
+        />
         Import
       </Button>
       <Button variant="outline" onClick={() => downloadUsersCsv(users)}>
@@ -34,7 +38,9 @@ export function UserCsvActions({ users }: { users: Array<User> }) {
       {open ? (
         <Suspense fallback={null}>
           <ImportUsersDialog
-            existingEmails={new Set(users.map((user) => user.email.toLowerCase()))}
+            existingEmails={
+              new Set(users.map((user) => user.email.toLowerCase()))
+            }
             open
             onOpenChange={setOpen}
           />

--- a/apps/web/src/routes/settings/-user-csv-actions.tsx
+++ b/apps/web/src/routes/settings/-user-csv-actions.tsx
@@ -1,0 +1,45 @@
+import { Download04Icon, Upload04Icon } from '@hugeicons/core-free-icons'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { lazy, Suspense, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import type { User } from '@/lib/types'
+import { downloadUsersCsv } from './-user-csv'
+
+const loadImportUsersDialog = () => import('./-import-users-dialog')
+const ImportUsersDialog = lazy(loadImportUsersDialog)
+
+export function UserCsvActions({ users }: { users: Array<User> }) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        onMouseEnter={() => void loadImportUsersDialog()}
+        onFocus={() => void loadImportUsersDialog()}
+        onClick={() => setOpen(true)}
+      >
+        <HugeiconsIcon icon={Upload04Icon} data-icon="inline-start" aria-hidden />
+        Import
+      </Button>
+      <Button variant="outline" onClick={() => downloadUsersCsv(users)}>
+        <HugeiconsIcon
+          icon={Download04Icon}
+          data-icon="inline-start"
+          aria-hidden
+        />
+        Export
+      </Button>
+      {open ? (
+        <Suspense fallback={null}>
+          <ImportUsersDialog
+            existingEmails={new Set(users.map((user) => user.email.toLowerCase()))}
+            open
+            onOpenChange={setOpen}
+          />
+        </Suspense>
+      ) : null}
+    </>
+  )
+}

--- a/apps/web/src/routes/settings/-user-csv.ts
+++ b/apps/web/src/routes/settings/-user-csv.ts
@@ -74,8 +74,8 @@ function escapeCsvField(value: string): string {
 }
 
 export function parseUserCsv(source: string): CsvUserImportResult {
-  const records = parseCsvRecords(source.replace(/^\uFEFF/, '')).filter((record) =>
-    record.some((field) => field.trim()),
+  const records = parseCsvRecords(source.replace(/^\uFEFF/, '')).filter(
+    (record) => record.some((field) => field.trim()),
   )
   const header = records.shift()?.map((field) => field.trim().toLowerCase())
 
@@ -88,14 +88,20 @@ export function parseUserCsv(source: string): CsvUserImportResult {
   if (emailIndex === -1 || roleIndex === -1) {
     return {
       rows: [],
-      errors: [{ message: 'The CSV header must contain email and role columns.' }],
+      errors: [
+        { message: 'The CSV header must contain email and role columns.' },
+      ],
     }
   }
 
   if (records.length > MAX_IMPORT_ROWS) {
     return {
       rows: [],
-      errors: [{ message: `A CSV import can contain at most ${MAX_IMPORT_ROWS} users.` }],
+      errors: [
+        {
+          message: `A CSV import can contain at most ${MAX_IMPORT_ROWS} users.`,
+        },
+      ],
     }
   }
 
@@ -121,7 +127,10 @@ export function parseUserCsv(source: string): CsvUserImportResult {
       continue
     }
     if (seenEmails.has(normalizedEmail)) {
-      errors.push({ row, message: 'The email address is repeated in this file.' })
+      errors.push({
+        row,
+        message: 'The email address is repeated in this file.',
+      })
       continue
     }
 

--- a/apps/web/src/routes/settings/-user-csv.ts
+++ b/apps/web/src/routes/settings/-user-csv.ts
@@ -1,0 +1,150 @@
+import { z } from 'zod'
+
+import type { User, UserRole } from '@/lib/types'
+
+const IMPORT_ROLES = new Set<UserRole>([
+  'owner',
+  'admin',
+  'developer',
+  'qa_viewer',
+])
+const EMAIL_SCHEMA = z.email()
+const MAX_IMPORT_ROWS = 200
+
+export interface CsvUserImportRow {
+  email: string
+  role: UserRole
+  row: number
+}
+
+export interface CsvUserImportError {
+  message: string
+  row?: number
+}
+
+export interface CsvUserImportResult {
+  errors: Array<CsvUserImportError>
+  rows: Array<CsvUserImportRow>
+}
+
+function parseCsvRecords(source: string): Array<Array<string>> {
+  const records: Array<Array<string>> = []
+  let field = ''
+  let record: Array<string> = []
+  let quoted = false
+
+  for (let index = 0; index < source.length; index += 1) {
+    const character = source[index]
+    const nextCharacter = source[index + 1]
+
+    if (quoted) {
+      if (character === '"' && nextCharacter === '"') {
+        field += '"'
+        index += 1
+      } else if (character === '"') {
+        quoted = false
+      } else {
+        field += character
+      }
+      continue
+    }
+
+    if (character === '"') {
+      quoted = true
+    } else if (character === ',') {
+      record.push(field)
+      field = ''
+    } else if (character === '\n') {
+      record.push(field)
+      records.push(record)
+      field = ''
+      record = []
+    } else if (character !== '\r') {
+      field += character
+    }
+  }
+
+  record.push(field)
+  records.push(record)
+  return records
+}
+
+function escapeCsvField(value: string): string {
+  return /[",\n\r]/.test(value) ? `"${value.replaceAll('"', '""')}"` : value
+}
+
+export function parseUserCsv(source: string): CsvUserImportResult {
+  const records = parseCsvRecords(source.replace(/^\uFEFF/, '')).filter((record) =>
+    record.some((field) => field.trim()),
+  )
+  const header = records.shift()?.map((field) => field.trim().toLowerCase())
+
+  if (!header) {
+    return { rows: [], errors: [{ message: 'The CSV file is empty.' }] }
+  }
+
+  const emailIndex = header.indexOf('email')
+  const roleIndex = header.indexOf('role')
+  if (emailIndex === -1 || roleIndex === -1) {
+    return {
+      rows: [],
+      errors: [{ message: 'The CSV header must contain email and role columns.' }],
+    }
+  }
+
+  if (records.length > MAX_IMPORT_ROWS) {
+    return {
+      rows: [],
+      errors: [{ message: `A CSV import can contain at most ${MAX_IMPORT_ROWS} users.` }],
+    }
+  }
+
+  const seenEmails = new Set<string>()
+  const rows: Array<CsvUserImportRow> = []
+  const errors: Array<CsvUserImportError> = []
+
+  for (const [index, record] of records.entries()) {
+    const row = index + 2
+    const email = (record[emailIndex] ?? '').trim()
+    const role = (record[roleIndex] ?? '').trim().toLowerCase()
+    const normalizedEmail = email.toLowerCase()
+
+    if (!EMAIL_SCHEMA.safeParse(email).success) {
+      errors.push({ row, message: 'Enter a valid email address.' })
+      continue
+    }
+    if (!IMPORT_ROLES.has(role as UserRole)) {
+      errors.push({
+        row,
+        message: 'Use admin, developer, or qa_viewer as the role.',
+      })
+      continue
+    }
+    if (seenEmails.has(normalizedEmail)) {
+      errors.push({ row, message: 'The email address is repeated in this file.' })
+      continue
+    }
+
+    seenEmails.add(normalizedEmail)
+    rows.push({ email, role: role as UserRole, row })
+  }
+
+  return { rows, errors }
+}
+
+export function usersCsv(users: Array<User>): string {
+  const lines = users.map((user) =>
+    [user.email, user.role, user.status].map(escapeCsvField).join(','),
+  )
+  return ['email,role,status', ...lines].join('\n')
+}
+
+export function downloadUsersCsv(users: Array<User>) {
+  const blob = new Blob([usersCsv(users)], { type: 'text/csv;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = 'oore-users.csv'
+  anchor.click()
+  URL.revokeObjectURL(url)
+}

--- a/apps/web/src/routes/settings/users.tsx
+++ b/apps/web/src/routes/settings/users.tsx
@@ -32,6 +32,7 @@ import PageLayout from '@/components/page-layout'
 import PageHeader from '@/components/page-header'
 import { PageMeta } from '@/lib/seo'
 import { InviteUserAction } from './-invite-user-action'
+import { UserCsvActions } from './-user-csv-actions'
 import { UsersEmptyState } from './-users-empty-state'
 import { UsersCollection } from './-users-collection'
 
@@ -280,7 +281,12 @@ function UsersSettingsPage() {
       <PageHeader
         title="Users"
         description="Instance access, roles, and account status."
-        actions={<InviteUserAction />}
+        actions={
+          <div className="flex flex-wrap gap-2">
+            <UserCsvActions users={users} />
+            <InviteUserAction />
+          </div>
+        }
       />
 
       {!usersQuery.error ? (

--- a/crates/oore-contract/src/lib.rs
+++ b/crates/oore-contract/src/lib.rs
@@ -1076,6 +1076,8 @@ pub struct BuildContext {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub project_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub repository_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub project_avatar_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repository_full_name: Option<String>,

--- a/crates/oore-runner/src/lib.rs
+++ b/crates/oore-runner/src/lib.rs
@@ -54,6 +54,7 @@ pub const RUNNER_SERVICE_ACK_FILE: &str = "runner-service-ack.json";
 pub const RUNNER_SERVICE_ACK_PATH_ENV: &str = "OORE_RUNNER_SERVICE_ACK_PATH";
 pub const RUNNER_SERVICE_ACK_MAX_AGE_SECS: u64 = 75;
 const RUNNER_SERVICE_ACK_SCHEMA_VERSION: u32 = 1;
+const MANAGED_RUNNER_SERVICE_LABEL: &str = "build.oore.oore-runner";
 // ponytail: fixed three-check grace; move it into the runner protocol if deployments need tuning.
 const MAX_CONSECUTIVE_AUTHORITY_FAILURES: u8 = 3;
 const MANAGED_FVM_VERSION: &str = "4.1.2";
@@ -1437,9 +1438,41 @@ fn require_ios_signing_user_session() -> anyhow::Result<()> {
     Ok(())
 }
 
+fn ios_signing_command_arguments(
+    is_managed_system_service: bool,
+    uid: u32,
+    program: &str,
+    args: &[String],
+) -> (String, Vec<String>) {
+    if !is_managed_system_service {
+        return (program.to_string(), args.to_vec());
+    }
+
+    (
+        "/bin/launchctl".to_string(),
+        ["asuser".to_string(), uid.to_string(), program.to_string()]
+            .into_iter()
+            .chain(args.iter().cloned())
+            .collect(),
+    )
+}
+
+fn ios_signing_command(program: &str, args: &[String]) -> Command {
+    let is_managed_system_service = std::env::var_os("XPC_SERVICE_NAME")
+        .is_some_and(|name| name == MANAGED_RUNNER_SERVICE_LABEL);
+    let (program, args) = ios_signing_command_arguments(
+        is_managed_system_service,
+        unsafe { libc::geteuid() },
+        program,
+        args,
+    );
+    let mut command = Command::new(program);
+    command.args(args);
+    command
+}
+
 fn run_security_command_with_strings(args: &[String]) -> anyhow::Result<String> {
-    let output = Command::new("/usr/bin/security")
-        .args(args)
+    let output = ios_signing_command("/usr/bin/security", args)
         .output()
         .map_err(|e| anyhow::anyhow!("failed to execute security command: {e}"))?;
     if !output.status.success() {
@@ -2059,8 +2092,7 @@ fn ios_keychain_import_arguments(
 }
 
 fn run_ios_signing_tool(program: &str, args: Vec<String>, action: &str) -> anyhow::Result<String> {
-    let output = Command::new(program)
-        .args(&args)
+    let output = ios_signing_command(program, &args)
         .output()
         .map_err(|error| anyhow::anyhow!("failed to {action}: {error}"))?;
     if !output.status.success() {
@@ -5747,12 +5779,31 @@ mod tests {
     }
 
     #[test]
-    fn apple_signing_commands_run_directly_in_the_runner_service_session() {
-        let command = Command::new("/usr/bin/codesign");
+    fn foreground_ios_signing_commands_run_directly() {
+        let args = ["--verify".to_string(), "/tmp/App.app".to_string()];
+        let (program, command_args) =
+            ios_signing_command_arguments(false, 501, "/usr/bin/codesign", &args);
 
+        assert_eq!(program, "/usr/bin/codesign");
+        assert_eq!(command_args, args);
+    }
+
+    #[test]
+    fn managed_runner_ios_signing_commands_enter_the_active_user_bootstrap() {
+        let args = ["--verify".to_string(), "/tmp/App.app".to_string()];
+        let (program, command_args) =
+            ios_signing_command_arguments(true, 501, "/usr/bin/codesign", &args);
+
+        assert_eq!(program, "/bin/launchctl");
         assert_eq!(
-            command.get_program(),
-            Path::new("/usr/bin/codesign").as_os_str()
+            command_args,
+            [
+                "asuser",
+                "501",
+                "/usr/bin/codesign",
+                "--verify",
+                "/tmp/App.app",
+            ]
         );
     }
 

--- a/crates/oored/src/builds.rs
+++ b/crates/oored/src/builds.rs
@@ -36,6 +36,7 @@ fn row_to_build(row: &sqlx::sqlite::SqliteRow) -> Build {
     let step_results = step_results_str.and_then(|s| serde_json::from_str(&s).ok());
     let context = BuildContext {
         project_name: row.try_get("project_name").ok(),
+        repository_id: row.try_get("repository_id").ok(),
         project_avatar_url: row.try_get("project_avatar_url").ok(),
         repository_full_name: row.try_get("repository_full_name").ok(),
         repository_provider: row.try_get("repository_provider").ok(),
@@ -44,6 +45,7 @@ fn row_to_build(row: &sqlx::sqlite::SqliteRow) -> Build {
         runner_name: row.try_get("runner_name").ok(),
     };
     let context = (context.project_name.is_some()
+        || context.repository_id.is_some()
         || context.project_avatar_url.is_some()
         || context.repository_full_name.is_some()
         || context.repository_provider.is_some()
@@ -1127,7 +1129,7 @@ pub async fn list_builds(
 
     let count_query = format!("SELECT COUNT(*) FROM builds {where_clause}");
     let list_query = format!(
-        "SELECT builds.*, projects.name AS project_name, integration_repositories.avatar_url AS project_avatar_url, \
+        "SELECT builds.*, projects.name AS project_name, integration_repositories.id AS repository_id, integration_repositories.avatar_url AS project_avatar_url, \
          integration_repositories.full_name AS repository_full_name, integrations.provider AS repository_provider, \
          integrations.host_url AS repository_host_url, pipelines.name AS pipeline_name, runners.name AS runner_name, \
          CASE \
@@ -1189,7 +1191,7 @@ pub async fn get_build(
     let pool = &state.db;
 
     let build_row = sqlx::query(
-        "SELECT builds.*, projects.name AS project_name, integration_repositories.avatar_url AS project_avatar_url, \
+        "SELECT builds.*, projects.name AS project_name, integration_repositories.id AS repository_id, integration_repositories.avatar_url AS project_avatar_url, \
          integration_repositories.full_name AS repository_full_name, integrations.provider AS repository_provider, \
          integrations.host_url AS repository_host_url, pipelines.name AS pipeline_name, runners.name AS runner_name, \
          CASE \


### PR DESCRIPTION
Closes #279

The managed system runner now invokes iOS keychain and signing tools through the active runner-user bootstrap. Foreground runners remain direct. This preserves the job-scoped temporary keychain flow and restores non-interactive codesign authorization for a LaunchDaemon-managed runner.

Validation:
- cargo test -p oore-runner --lib -- --nocapture
- make validate
- make release-smoke