### PR TITLE
fix(runner): run iOS signing in the user session

### DIFF
--- a/crates/oore-runner/src/lib.rs
+++ b/crates/oore-runner/src/lib.rs
@@ -1461,40 +1461,14 @@ fn active_gui_session_process_id(uid: u32) -> anyhow::Result<u32> {
     })
 }
 
-fn ios_signing_command_arguments(
-    gui_session_process_id: Option<u32>,
-    program: &str,
-    args: &[String],
-) -> (String, Vec<String>) {
-    let Some(gui_session_process_id) = gui_session_process_id else {
-        return (program.to_string(), args.to_vec());
-    };
-
-    (
-        "/bin/launchctl".to_string(),
-        [
-            "bsexec".to_string(),
-            gui_session_process_id.to_string(),
-            program.to_string(),
-        ]
-        .into_iter()
-        .chain(args.iter().cloned())
-        .collect(),
-    )
-}
-
-fn ios_signing_command(program: &str, args: &[String]) -> anyhow::Result<Command> {
-    let gui_session_process_id = is_managed_system_runner()
-        .then(|| active_gui_session_process_id(unsafe { libc::geteuid() }))
-        .transpose()?;
-    let (program, args) = ios_signing_command_arguments(gui_session_process_id, program, args);
+fn ios_signing_command(program: &str, args: &[String]) -> Command {
     let mut command = Command::new(program);
     command.args(args);
-    Ok(command)
+    command
 }
 
 fn run_security_command_with_strings(args: &[String]) -> anyhow::Result<String> {
-    let output = ios_signing_command("/usr/bin/security", args)?
+    let output = ios_signing_command("/usr/bin/security", args)
         .output()
         .map_err(|e| anyhow::anyhow!("failed to execute security command: {e}"))?;
     if !output.status.success() {
@@ -2114,7 +2088,7 @@ fn ios_keychain_import_arguments(
 }
 
 fn run_ios_signing_tool(program: &str, args: Vec<String>, action: &str) -> anyhow::Result<String> {
-    let output = ios_signing_command(program, &args)?
+    let output = ios_signing_command(program, &args)
         .output()
         .map_err(|error| anyhow::anyhow!("failed to {action}: {error}"))?;
     if !output.status.success() {
@@ -5801,31 +5775,14 @@ mod tests {
     }
 
     #[test]
-    fn foreground_ios_signing_commands_run_directly() {
+    fn ios_signing_commands_run_directly() {
         let args = ["--verify".to_string(), "/tmp/App.app".to_string()];
-        let (program, command_args) =
-            ios_signing_command_arguments(None, "/usr/bin/codesign", &args);
+        let command = ios_signing_command("/usr/bin/codesign", &args);
 
-        assert_eq!(program, "/usr/bin/codesign");
-        assert_eq!(command_args, args);
-    }
-
-    #[test]
-    fn managed_runner_ios_signing_commands_enter_the_active_gui_bootstrap() {
-        let args = ["--verify".to_string(), "/tmp/App.app".to_string()];
-        let (program, command_args) =
-            ios_signing_command_arguments(Some(1234), "/usr/bin/codesign", &args);
-
-        assert_eq!(program, "/bin/launchctl");
+        assert_eq!(command.get_program(), "/usr/bin/codesign");
         assert_eq!(
-            command_args,
-            [
-                "bsexec",
-                "1234",
-                "/usr/bin/codesign",
-                "--verify",
-                "/tmp/App.app",
-            ]
+            command.get_args().collect::<Vec<_>>(),
+            args.iter().map(AsRef::as_ref).collect::<Vec<_>>()
         );
     }
 

--- a/crates/oore-runner/src/lib.rs
+++ b/crates/oore-runner/src/lib.rs
@@ -5782,7 +5782,7 @@ mod tests {
         assert_eq!(command.get_program(), "/usr/bin/codesign");
         assert_eq!(
             command.get_args().collect::<Vec<_>>(),
-            args.iter().map(AsRef::as_ref).collect::<Vec<_>>()
+            args.iter().map(std::ffi::OsStr::new).collect::<Vec<_>>()
         );
     }
 

--- a/crates/oore/src/main.rs
+++ b/crates/oore/src/main.rs
@@ -4848,7 +4848,7 @@ fn managed_runner_update_service(install_root: &Path) -> anyhow::Result<Option<&
 }
 
 fn managed_runner_service_requires_repair(plist: &Path) -> anyhow::Result<bool> {
-    Ok(runner_service_uses_user_bootstrap_wrapper(
+    Ok(!runner_service_uses_user_bootstrap_wrapper(
         &plist_program_arguments(plist)?,
     ))
 }
@@ -4890,8 +4890,17 @@ fn render_runner_launch_daemon(
     log_path: &Path,
     path: &str,
     user: &str,
+    uid: &str,
 ) -> String {
     let values = [
+        "/bin/launchctl".to_string(),
+        "asuser".to_string(),
+        uid.to_string(),
+        "/usr/bin/sudo".to_string(),
+        "-E".to_string(),
+        "-H".to_string(),
+        "-u".to_string(),
+        user.to_string(),
         executable.display().to_string(),
         "runner".to_string(),
         "start".to_string(),
@@ -4911,10 +4920,6 @@ fn render_runner_launch_daemon(
 <dict>
     <key>Label</key>
     <string>{RUNNER_SERVICE_LABEL}</string>
-    <key>UserName</key>
-    <string>{}</string>
-    <key>SessionCreate</key>
-    <true/>
     <key>ProgramArguments</key>
     <array>
 {arguments}
@@ -4943,7 +4948,6 @@ fn render_runner_launch_daemon(
 </dict>
 </plist>
 "#,
-        launchd_xml_escape(user),
         launchd_xml_escape(&home.display().to_string()),
         launchd_xml_escape(path),
         launchd_xml_escape(&working_dir.join("toolchains/flutter").display().to_string()),
@@ -5389,6 +5393,7 @@ async fn handle_runner_install_service_inner(
     }
 
     let user = current_user_name()?;
+    let uid = current_effective_uid().to_string();
     if args.managed_local && args.config.is_some() {
         anyhow::bail!("--managed-local cannot be combined with --config");
     }
@@ -5556,6 +5561,7 @@ async fn handle_runner_install_service_inner(
             &log_path,
             &path,
             &user,
+            &uid,
         );
         let plist = match write_system_runner_plist(&rendered) {
             Ok(plist) => plist,
@@ -8320,7 +8326,7 @@ mod tests {
     }
 
     #[test]
-    fn runner_service_is_a_boot_time_daemon_under_the_runner_account() {
+    fn runner_service_is_a_boot_time_daemon_that_starts_in_the_runner_session() {
         let plist = render_runner_launch_daemon(
             Path::new("/Users/me/.oore/bin/oore"),
             Path::new("/Users/me/.oore/runner.json"),
@@ -8330,13 +8336,16 @@ mod tests {
             Path::new("/Users/me/.oore/logs/oore-runner.log"),
             "/usr/bin:/bin",
             "me",
+            "501",
         );
 
         assert!(plist.contains("<string>build.oore.oore-runner</string>"));
-        assert!(plist.contains("<key>UserName</key>\n    <string>me</string>"));
-        assert!(plist.contains("<key>SessionCreate</key>\n    <true/>"));
-        assert!(!plist.contains("<string>/bin/launchctl</string>"));
-        assert!(!plist.contains("<string>/usr/bin/sudo</string>"));
+        assert!(plist.contains("<string>/bin/launchctl</string>"));
+        assert!(plist.contains("<string>asuser</string>\n        <string>501</string>"));
+        assert!(plist.contains("<string>/usr/bin/sudo</string>"));
+        assert!(plist.contains("<string>-u</string>\n        <string>me</string>"));
+        assert!(!plist.contains("<key>UserName</key>"));
+        assert!(!plist.contains("<key>SessionCreate</key>"));
         assert!(!plist.contains("LimitLoadToSessionType"));
         assert!(plist.contains("<string>/Users/me/.oore/bin/oore</string>"));
         assert!(plist.contains("<string>runner</string>\n        <string>start</string>"));
@@ -8420,6 +8429,7 @@ mod tests {
             Path::new("/Users/a&b/runner.log"),
             "/usr/bin:/a&b",
             "a&b",
+            "501",
         );
 
         assert!(plist.contains("/Users/a&amp;b/oore"));


### PR DESCRIPTION
## Summary
- start the managed runner through the active runner user session
- keep all iOS keychain and codesign operations in the same macOS session
- retain a boot-time system service and non-root runner process

## Validation
- cargo build --release -p oore
- production runner manual iOS build passed after service reinstall

Ready for stable release.