### PR TITLE
fix(runner): use a pipe for Linux credential fd3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,6 +2586,7 @@ dependencies = [
  "oore-contract",
  "rand 0.8.7",
  "reqwest",
+ "rustix",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ dirs = "5"
 hex = "0.4"
 humantime = "2.1"
 rand = "0.8"
+rustix = { version = "1.1.4", features = ["fs", "pipe"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"

--- a/crates/oore-runner/Cargo.toml
+++ b/crates/oore-runner/Cargo.toml
@@ -16,5 +16,6 @@ rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
-tokio = { workspace = true, features = ["fs", "io-util", "process", "sync", "time"] }
+tokio = { workspace = true, features = ["fs", "io-util", "net", "process", "sync", "time"] }
 zeroize.workspace = true
+rustix.workspace = true

--- a/crates/oore-runner/src/component_credentials.rs
+++ b/crates/oore-runner/src/component_credentials.rs
@@ -1,9 +1,9 @@
+use std::future::Future;
 use std::os::fd::{AsRawFd, OwnedFd};
 use std::time::Duration;
 
 use anyhow::Context;
 use oore_contract::ConsumeComponentCredentialGrantRequest;
-use tokio::io::AsyncWriteExt;
 use zeroize::Zeroizing;
 
 use crate::{RunnerConfig, require_safe_daemon_url};
@@ -13,6 +13,9 @@ const COMPONENT_CREDENTIAL_GRANT_HEADER: &str = "x-oore-component-credential-gra
 const COMPONENT_CREDENTIAL_CONTENT_TYPE: &str = "application/octet-stream";
 const MAX_COMPONENT_CREDENTIAL_BYTES: usize = 8 * 1024 * 1024;
 const COMPONENT_CREDENTIAL_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+const COMPONENT_CREDENTIAL_DELIVERY_TIMEOUT: Duration = Duration::from_secs(15);
+const COMPONENT_CREDENTIAL_MAGIC: &[u8; 16] = b"OORE-FD3-CRED-1\n";
+const COMPONENT_CREDENTIAL_HEADER_BYTES: usize = 16 + 32 + 8;
 
 /// A one-use broker handle held only by the trusted runner parent.
 pub struct ComponentCredentialGrantHandle(Zeroizing<String>);
@@ -31,6 +34,28 @@ impl ComponentCredentialGrantHandle {
 
     fn as_str(&self) -> &str {
         self.0.as_str()
+    }
+}
+
+/// Public SHA-256 binding for the exact credential reference sent in `Start`.
+pub struct ComponentCredentialBinding([u8; 32]);
+
+impl ComponentCredentialBinding {
+    /// Parses the fixed lowercase `sha256:` binding returned by the component protocol.
+    pub fn new(value: &str) -> anyhow::Result<Self> {
+        let value = value
+            .strip_prefix("sha256:")
+            .context("component credential binding is invalid")?;
+        anyhow::ensure!(value.len() == 64, "component credential binding is invalid");
+        let mut digest = [0_u8; 32];
+        for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
+            digest[index] = decode_hex(pair[0])
+                .context("component credential binding is invalid")?
+                .checked_mul(16)
+                .and_then(|high| decode_hex(pair[1]).map(|low| high + low))
+                .context("component credential binding is invalid")?;
+        }
+        Ok(Self(digest))
     }
 }
 
@@ -114,19 +139,72 @@ pub async fn consume_component_credential_grant(
 /// Keep this value until the component completes its verified hello handshake.
 /// Then call `deliver` once. Dropping it closes the channel without sending data.
 pub struct ComponentCredentialChannel {
-    writer: tokio::fs::File,
+    writer: tokio::io::unix::AsyncFd<OwnedFd>,
 }
 
 impl ComponentCredentialChannel {
-    pub async fn deliver(mut self, secret: Zeroizing<Vec<u8>>) -> anyhow::Result<()> {
-        self.writer
-            .write_all(secret.as_slice())
-            .await
-            .context("component credential channel closed before delivery")?;
-        self.writer
-            .shutdown()
-            .await
-            .context("component credential channel could not be closed")
+    /// Sends one reference-bound credential after the verified `Start` frame.
+    ///
+    /// The current channel version accepts exactly one credential reference.
+    /// Delivery stops on cancellation, peer closure, or the fixed timeout.
+    pub async fn deliver<C>(
+        self,
+        binding: ComponentCredentialBinding,
+        secret: Zeroizing<Vec<u8>>,
+        cancelled: C,
+    ) -> anyhow::Result<()>
+    where
+        C: Future<Output = ()>,
+    {
+        anyhow::ensure!(
+            !secret.is_empty() && secret.len() <= MAX_COMPONENT_CREDENTIAL_BYTES,
+            "component credential size is invalid"
+        );
+        let length = u64::try_from(secret.len()).context("component credential size is invalid")?;
+        let mut header = [0_u8; COMPONENT_CREDENTIAL_HEADER_BYTES];
+        header[..16].copy_from_slice(COMPONENT_CREDENTIAL_MAGIC);
+        header[16..48].copy_from_slice(&binding.0);
+        header[48..56].copy_from_slice(&length.to_be_bytes());
+        let delivery = async {
+            write_all_nonblocking(&self.writer, &header)
+                .await
+                .context("component credential channel closed before delivery")?;
+            write_all_nonblocking(&self.writer, secret.as_slice())
+                .await
+                .context("component credential channel closed before delivery")
+        };
+        tokio::select! {
+            result = tokio::time::timeout(COMPONENT_CREDENTIAL_DELIVERY_TIMEOUT, delivery) => {
+                result.context("component credential delivery timed out")?
+            }
+            () = cancelled => anyhow::bail!("component credential delivery was cancelled"),
+        }
+    }
+}
+
+async fn write_all_nonblocking(
+    writer: &tokio::io::unix::AsyncFd<OwnedFd>,
+    mut bytes: &[u8],
+) -> std::io::Result<()> {
+    while !bytes.is_empty() {
+        let mut ready = writer.writable().await?;
+        match ready.try_io(|descriptor| {
+            rustix::io::write(descriptor.get_ref(), bytes).map_err(std::io::Error::from)
+        }) {
+            Ok(Ok(0)) => return Err(std::io::ErrorKind::WriteZero.into()),
+            Ok(Ok(written)) => bytes = &bytes[written..],
+            Ok(Err(error)) => return Err(error),
+            Err(_would_block) => {}
+        }
+    }
+    Ok(())
+}
+
+const fn decode_hex(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        _ => None,
     }
 }
 
@@ -139,6 +217,8 @@ pub fn spawn_command_with_credential_channel(
     command: &mut tokio::process::Command,
 ) -> anyhow::Result<(tokio::process::Child, ComponentCredentialChannel)> {
     let (reader, writer) = credential_pipe()?;
+    let writer = tokio::io::unix::AsyncFd::new(writer)
+        .context("component credential channel could not be registered")?;
     let reader_fd = reader.as_raw_fd();
 
     // SAFETY: The closure calls only async-signal-safe descriptor operations.
@@ -151,24 +231,31 @@ pub fn spawn_command_with_credential_channel(
         .spawn()
         .context("component process could not be started")?;
     drop(reader);
-
-    let writer = std::fs::File::from(writer);
-    Ok((
-        child,
-        ComponentCredentialChannel {
-            writer: tokio::fs::File::from_std(writer),
-        },
-    ))
+    Ok((child, ComponentCredentialChannel { writer }))
 }
 
 fn credential_pipe() -> std::io::Result<(OwnedFd, OwnedFd)> {
-    use std::net::Shutdown;
-    use std::os::unix::net::UnixStream;
+    #[cfg(target_os = "linux")]
+    {
+        let (reader, writer) = rustix::pipe::pipe_with(rustix::pipe::PipeFlags::CLOEXEC)
+            .map_err(std::io::Error::from)?;
+        let flags = rustix::fs::fcntl_getfl(&writer).map_err(std::io::Error::from)?;
+        rustix::fs::fcntl_setfl(&writer, flags | rustix::fs::OFlags::NONBLOCK)
+            .map_err(std::io::Error::from)?;
+        return Ok((reader, writer));
+    }
 
-    let (reader, writer) = UnixStream::pair()?;
-    reader.shutdown(Shutdown::Write)?;
-    writer.shutdown(Shutdown::Read)?;
-    Ok((reader.into(), writer.into()))
+    #[cfg(target_os = "macos")]
+    {
+        use std::net::Shutdown;
+        use std::os::unix::net::UnixStream;
+
+        let (reader, writer) = UnixStream::pair()?;
+        reader.shutdown(Shutdown::Write)?;
+        writer.shutdown(Shutdown::Read)?;
+        writer.set_nonblocking(true)?;
+        Ok((reader.into(), writer.into()))
+    }
 }
 
 fn prepare_child_credential_fd(reader_fd: i32) -> std::io::Result<()> {

--- a/crates/oore-runner/src/lib.rs
+++ b/crates/oore-runner/src/lib.rs
@@ -29,8 +29,8 @@ use zeroize::Zeroize;
 mod component_credentials;
 
 pub use component_credentials::{
-    ComponentCredentialChannel, ComponentCredentialGrantHandle, consume_component_credential_grant,
-    spawn_command_with_credential_channel,
+    ComponentCredentialBinding, ComponentCredentialChannel, ComponentCredentialGrantHandle,
+    consume_component_credential_grant, spawn_command_with_credential_channel,
 };
 
 const AUTO_CONFIG_PATHS: [&str; 2] = [".oore.yaml", ".oore.yml"];


### PR DESCRIPTION
## What this changes

- uses an anonymous pipe for the private component credential channel on Linux
- keeps the existing private Unix socket channel on macOS
- keeps file descriptor 3 as the component contract
- sends one bounded frame with the manager-provided delivery binding and private bytes
- uses a nonblocking writer that stops after cancellation, peer closure, or a fixed 15-second timeout

## Security boundary

- the frame header contains only a SHA-256 delivery binding and a length
- the current channel version delivers exactly one credential reference
- private bytes stay outside arguments, environment variables, files, logs, and protocol JSONL
- cancellation closes the real writer and cannot leave a background write task
- failed or cancelled delivery drops the zeroizing secret buffer

## Checks

- `cargo fmt --all -- --check`
- `cargo check -p oore-runner`
- `cargo clippy -p oore-runner -- -D warnings`
- `git diff --check`

No tests were added or run under the current v0.2.0 rule.
