### PR TITLE
feat(runner): invoke managed components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,18 +130,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -458,7 +458,7 @@ checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -827,7 +827,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1073,7 +1073,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1096,7 +1096,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1107,7 +1107,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1196,7 +1196,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1495,7 +1495,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2327,6 +2327,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "metrics"
 version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2401,6 +2410,19 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -2565,6 +2587,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "oore-component-protocol"
+version = "0.1.0"
+source = "git+https://github.com/oore-ci/components.git?rev=30a6f8a00a97742e5d5bdcf45c57af3655791005#30a6f8a00a97742e5d5bdcf45c57af3655791005"
+dependencies = [
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "oore-component-runtime"
+version = "0.1.0"
+source = "git+https://github.com/oore-ci/components.git?rev=30a6f8a00a97742e5d5bdcf45c57af3655791005#30a6f8a00a97742e5d5bdcf45c57af3655791005"
+dependencies = [
+ "getrandom 0.3.4",
+ "nix",
+ "oore-component-protocol",
+ "oore-credential-lease",
+ "oore-operation-contract",
+ "rustix",
+ "thiserror 2.0.18",
+ "zeroize",
+]
+
+[[package]]
 name = "oore-contract"
 version = "0.1.10"
 dependencies = [
@@ -2572,6 +2621,36 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "utoipa",
+]
+
+[[package]]
+name = "oore-credential-lease"
+version = "0.1.0"
+source = "git+https://github.com/oore-ci/components.git?rev=30a6f8a00a97742e5d5bdcf45c57af3655791005#30a6f8a00a97742e5d5bdcf45c57af3655791005"
+dependencies = [
+ "async-trait",
+ "getrandom 0.3.4",
+ "oore-operation-contract",
+ "rustix",
+ "schemars 1.2.1",
+ "security-framework",
+ "security-framework-sys",
+ "serde",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "zeroize",
+]
+
+[[package]]
+name = "oore-operation-contract"
+version = "0.1.0"
+source = "git+https://github.com/oore-ci/components.git?rev=30a6f8a00a97742e5d5bdcf45c57af3655791005#30a6f8a00a97742e5d5bdcf45c57af3655791005"
+dependencies = [
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2583,6 +2662,8 @@ dependencies = [
  "base64 0.22.1",
  "hex",
  "libc",
+ "oore-component-protocol",
+ "oore-component-runtime",
  "oore-contract",
  "rand 0.8.7",
  "reqwest",
@@ -2874,7 +2955,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2990,7 +3071,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3249,7 +3330,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3365,7 +3446,7 @@ checksum = "3cd3a7535e50bf36857e7be7bec276d334e8c2dfa469c2201226fd01638ea5ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3552,8 +3633,21 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3652,7 +3746,18 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3729,7 +3834,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3989,7 +4094,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4010,7 +4115,7 @@ dependencies = [
  "sha2 0.10.9",
  "sqlx-core",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.118",
  "tokio",
  "url",
 ]
@@ -4164,6 +4269,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4180,7 +4296,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4242,7 +4358,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4253,7 +4369,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4353,7 +4469,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4516,7 +4632,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4685,7 +4801,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4806,7 +4922,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -4849,7 +4965,7 @@ checksum = "94eb68555b95bcea5e8cf4abe280b529049479fa995bfc23734af96a6aedc120"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4962,7 +5078,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4973,7 +5089,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5204,7 +5320,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -5225,7 +5341,7 @@ checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5245,7 +5361,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -5266,7 +5382,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5299,7 +5415,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,8 @@ opentelemetry-otlp = { version = "0.28", default-features = false, features = ["
 tracing-opentelemetry = "0.29"
 metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.16", default-features = false }
+oore-component-protocol = { git = "https://github.com/oore-ci/components.git", rev = "30a6f8a00a97742e5d5bdcf45c57af3655791005" }
+oore-component-runtime = { git = "https://github.com/oore-ci/components.git", rev = "30a6f8a00a97742e5d5bdcf45c57af3655791005" }
 
 # OpenAPI documentation
 utoipa = { version = "5", features = ["axum_extras"] }

--- a/crates/oore-runner/Cargo.toml
+++ b/crates/oore-runner/Cargo.toml
@@ -11,6 +11,8 @@ base64.workspace = true
 hex.workspace = true
 libc = "0.2"
 oore-contract = { path = "../oore-contract" }
+oore-component-protocol.workspace = true
+oore-component-runtime.workspace = true
 reqwest.workspace = true
 rand.workspace = true
 serde.workspace = true

--- a/crates/oore-runner/src/component_invoker.rs
+++ b/crates/oore-runner/src/component_invoker.rs
@@ -1,0 +1,575 @@
+use std::collections::VecDeque;
+use std::path::{Component, Path, PathBuf};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::Context as _;
+use oore_component_protocol::{
+    Body, Correlation, CredentialChannel, CredentialReference, Direction, ExitClass, Frame,
+    FrameType, HARD_MAX_STDERR_BYTES, JobBinding, JsonlDecoder, PROTOCOL_WIRE, ProtocolLimits,
+    ProtocolStateMachine, SessionConfig, SessionPhase, build_machine_argv, encode_line,
+};
+use oore_contract::ConsumeComponentCredentialGrantRequest;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+use crate::{
+    ComponentCredentialBinding, ComponentCredentialGrantHandle, RunnerConfig,
+    consume_component_credential_grant, spawn_command_with_credential_channel,
+};
+
+const COMPONENT_EXIT_TIMEOUT: Duration = Duration::from_secs(15);
+const COMPONENT_FRAME_TIMEOUT: Duration = Duration::from_secs(120);
+const COMPONENT_CANCEL_GRACE: Duration = Duration::from_secs(5);
+const READ_CHUNK_BYTES: usize = 8 * 1024;
+
+/// A reusable cancellation signal for one managed component invocation.
+#[derive(Clone, Default)]
+pub struct ComponentCancellation {
+    inner: Arc<ComponentCancellationInner>,
+}
+
+#[derive(Default)]
+struct ComponentCancellationInner {
+    cancelled: AtomicBool,
+    notify: tokio::sync::Notify,
+}
+
+#[derive(Clone, Default)]
+struct ComponentStderrMonitor {
+    inner: Arc<ComponentStderrMonitorInner>,
+}
+
+#[derive(Default)]
+struct ComponentStderrMonitorInner {
+    exceeded: AtomicBool,
+    notify: tokio::sync::Notify,
+}
+
+impl ComponentStderrMonitor {
+    fn mark_exceeded(&self) {
+        if !self.inner.exceeded.swap(true, Ordering::AcqRel) {
+            self.inner.notify.notify_waiters();
+        }
+    }
+
+    async fn exceeded(&self) {
+        loop {
+            let notified = self.inner.notify.notified();
+            if self.inner.exceeded.load(Ordering::Acquire) {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+impl ComponentCancellation {
+    /// Requests cancellation. Repeated calls have no extra effect.
+    pub fn cancel(&self) {
+        if !self.inner.cancelled.swap(true, Ordering::AcqRel) {
+            self.inner.notify.notify_waiters();
+        }
+    }
+
+    /// Waits until cancellation is requested.
+    pub async fn cancelled(&self) {
+        loop {
+            let notified = self.inner.notify.notified();
+            if self.inner.cancelled.load(Ordering::Acquire) {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+/// Exact public facts needed to start one already verified component binary.
+pub struct ManagedComponentInvocation {
+    executable: PathBuf,
+    workspace: PathBuf,
+    identity: oore_component_protocol::ComponentIdentity,
+    job: JobBinding,
+    operation_id: String,
+    capability_id: String,
+    payload_schema: String,
+    public_input: Vec<u8>,
+    credential_ref_id: String,
+    credential_expires_at: u64,
+    grant_request: ConsumeComponentCredentialGrantRequest,
+    grant_handle: ComponentCredentialGrantHandle,
+}
+
+impl ManagedComponentInvocation {
+    /// Creates one launch request from catalog-verified public facts.
+    ///
+    /// This constructor validates bindings. Catalog and executable signature
+    /// verification remain the caller's responsibility until the component
+    /// store lands.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        executable: PathBuf,
+        workspace: PathBuf,
+        identity: oore_component_protocol::ComponentIdentity,
+        job: JobBinding,
+        operation_id: String,
+        capability_id: String,
+        payload_schema: String,
+        public_input: Vec<u8>,
+        credential_ref_id: String,
+        credential_expires_at: u64,
+        grant_request: ConsumeComponentCredentialGrantRequest,
+        grant_handle: ComponentCredentialGrantHandle,
+    ) -> anyhow::Result<Self> {
+        identity
+            .validate()
+            .context("component identity is invalid")?;
+        job.validate().context("component job binding is invalid")?;
+        anyhow::ensure!(
+            valid_absolute_path(&executable),
+            "component executable path is invalid"
+        );
+        anyhow::ensure!(
+            valid_absolute_path(&workspace),
+            "component workspace path is invalid"
+        );
+        anyhow::ensure!(!public_input.is_empty(), "component input is empty");
+        anyhow::ensure!(
+            grant_request.operation_id == operation_id
+                && grant_request.component_identity_digest == identity.identity_digest
+                && grant_request.capability_id == capability_id
+                && grant_request.job_lock_digest == job.job_lock_digest,
+            "component credential grant binding is invalid"
+        );
+        anyhow::ensure!(
+            credential_expires_at > now_unix_seconds(),
+            "component credential reference is expired"
+        );
+        Ok(Self {
+            executable,
+            workspace,
+            identity,
+            job,
+            operation_id,
+            capability_id,
+            payload_schema,
+            public_input,
+            credential_ref_id,
+            credential_expires_at,
+            grant_request,
+            grant_handle,
+        })
+    }
+}
+
+/// Runs one managed, one-shot component and returns its verified public result.
+pub async fn invoke_managed_component(
+    runner: &RunnerConfig,
+    invocation: ManagedComponentInvocation,
+    cancellation: ComponentCancellation,
+) -> anyhow::Result<Vec<u8>> {
+    let session_id = random_public_id("component-session");
+    let request_id = random_public_id("component-request");
+    let correlation = Correlation::managed(
+        &session_id,
+        &request_id,
+        invocation.operation_id.clone(),
+        invocation.identity.clone(),
+        invocation.job.clone(),
+    )
+    .context("component correlation is invalid")?;
+    let config = SessionConfig::one_shot(invocation.identity.clone(), correlation.clone())
+        .with_credential_channel(CredentialChannel::BrokerFd3)
+        .with_broker_fd3(true);
+    let mut state = ProtocolStateMachine::new_bound(config, &session_id, &request_id)
+        .context("component session binding is invalid")?;
+    state.expect_capabilities([invocation.capability_id.clone()]);
+
+    let input = oore_component_runtime::write_input_artifact(
+        &invocation.workspace,
+        &invocation.public_input,
+    )
+    .context("component input could not be prepared")?;
+    let argv = build_machine_argv(&invocation.executable, false)
+        .context("component command is invalid")?;
+    let mut command = tokio::process::Command::new(&invocation.executable);
+    command
+        .args(&argv[1..])
+        .current_dir(&invocation.workspace)
+        .env_clear()
+        .env("LANG", "C")
+        .env("LC_ALL", "C")
+        .env("TZ", "UTC")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true);
+    let (mut child, credential_channel) = spawn_command_with_credential_channel(&mut command)?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .context("component stdin is unavailable")?;
+    let stdout = child
+        .stdout
+        .take()
+        .context("component stdout is unavailable")?;
+    let stderr = child
+        .stderr
+        .take()
+        .context("component stderr is unavailable")?;
+    let stderr_monitor = ComponentStderrMonitor::default();
+    let stderr_task = tokio::spawn(drain_component_stderr(stderr, stderr_monitor.clone()));
+    let mut reader = ComponentFrameReader::new(stdout);
+
+    let result = run_session(
+        runner,
+        &invocation,
+        &cancellation,
+        &stderr_monitor,
+        &mut state,
+        &correlation,
+        &session_id,
+        &request_id,
+        input.digest(),
+        &mut stdin,
+        &mut reader,
+        credential_channel,
+    )
+    .await;
+
+    if result.is_err() && state.phase() != SessionPhase::Terminal {
+        let _ = child.kill().await;
+    }
+    let status = tokio::time::timeout(COMPONENT_EXIT_TIMEOUT, child.wait())
+        .await
+        .context("component exit timed out")?
+        .context("component exit could not be observed")?;
+    let stderr_bytes = stderr_task
+        .await
+        .context("component stderr drain failed")??;
+    anyhow::ensure!(
+        stderr_bytes <= HARD_MAX_STDERR_BYTES,
+        "component stderr exceeded the size limit"
+    );
+    let (result_digest, exit_class) = result?;
+    state
+        .verify_process_exit(exit_class, status.code())
+        .context("component exit did not match its result")?;
+    state
+        .clean_eof()
+        .context("component ended without a result")?;
+    oore_component_runtime::read_result_artifact(&invocation.workspace, &result_digest)
+        .context("component result could not be verified")
+}
+
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+async fn run_session(
+    runner: &RunnerConfig,
+    invocation: &ManagedComponentInvocation,
+    cancellation: &ComponentCancellation,
+    stderr_monitor: &ComponentStderrMonitor,
+    state: &mut ProtocolStateMachine,
+    correlation: &Correlation,
+    session_id: &str,
+    request_id: &str,
+    input_digest: &str,
+    stdin: &mut tokio::process::ChildStdin,
+    reader: &mut ComponentFrameReader,
+    credential_channel: crate::ComponentCredentialChannel,
+) -> anyhow::Result<(String, ExitClass)> {
+    let hello = Frame {
+        wire: PROTOCOL_WIRE.into(),
+        frame_type: FrameType::Request,
+        schema_version: 1,
+        message_id: "manager-hello-0".into(),
+        session_id: session_id.into(),
+        request_id: request_id.into(),
+        seq: 0,
+        reply_to: None,
+        correlation: correlation.clone(),
+        body: Body::Hello {
+            supported_protocols: vec![oore_component_protocol::ProtocolRange::current()],
+            expected_identity_digest: invocation.identity.identity_digest.clone(),
+            limits: ProtocolLimits::default(),
+            service: false,
+            credential_channel: CredentialChannel::BrokerFd3,
+        },
+    };
+    send_manager_frame(state, stdin, &hello).await?;
+    let hello_ack = next_frame(reader, cancellation, stderr_monitor).await?;
+    state
+        .accept(Direction::ComponentToManager, &hello_ack)
+        .context("component hello response was rejected")?;
+    let capability = state
+        .capability(&invocation.capability_id)
+        .context("component capability is unavailable")?;
+    anyhow::ensure!(
+        capability.gate_ids.is_empty(),
+        "component capability requires a gate"
+    );
+    anyhow::ensure!(
+        capability.credential_requirements.len() == 1,
+        "component credential contract is unsupported"
+    );
+    let requirement = capability.credential_requirements[0].clone();
+    let selected_correlation = correlation
+        .with_capability(session_id, request_id, invocation.capability_id.clone())
+        .context("component capability binding is invalid")?;
+    let start = Frame {
+        wire: PROTOCOL_WIRE.into(),
+        frame_type: FrameType::Request,
+        schema_version: 1,
+        message_id: "manager-start-1".into(),
+        session_id: session_id.into(),
+        request_id: request_id.into(),
+        seq: 1,
+        reply_to: None,
+        correlation: selected_correlation,
+        body: Body::Start {
+            capability_id: invocation.capability_id.clone(),
+            payload_schema: invocation.payload_schema.clone(),
+            payload_inline: None,
+            payload_ref: Some(input_digest.into()),
+            plan_hash: invocation.job.plan_hash.clone(),
+            gate_outcomes: Vec::new(),
+            credential_refs: vec![CredentialReference {
+                ref_id: invocation.credential_ref_id.clone(),
+                purpose: requirement.purpose,
+                capability_id: Some(invocation.capability_id.clone()),
+                request_binding: requirement.request_binding,
+                one_use: true,
+                expires_at: invocation.credential_expires_at,
+            }],
+        },
+    };
+    send_manager_frame(state, stdin, &start).await?;
+
+    let secret = tokio::select! {
+        biased;
+        () = cancellation.cancelled() => {
+            return cancel_session(state, stdin, reader, &start).await;
+        }
+        () = stderr_monitor.exceeded() => anyhow::bail!("component stderr exceeded the size limit"),
+        result = consume_component_credential_grant(
+            runner,
+            &invocation.grant_request,
+            &invocation.grant_handle,
+        ) => result?,
+    };
+    let delivery_digest = oore_component_runtime::broker_credential_delivery_digest(&start)
+        .context("component credential delivery binding is invalid")?;
+    if credential_channel
+        .deliver(
+            ComponentCredentialBinding::new(&delivery_digest)?,
+            secret,
+            async {
+                tokio::select! {
+                    () = cancellation.cancelled() => {}
+                    () = stderr_monitor.exceeded() => {}
+                }
+            },
+        )
+        .await
+        .is_err()
+    {
+        if cancellation.inner.cancelled.load(Ordering::Acquire) {
+            return cancel_session(state, stdin, reader, &start).await;
+        }
+        if stderr_monitor.inner.exceeded.load(Ordering::Acquire) {
+            anyhow::bail!("component stderr exceeded the size limit");
+        }
+        anyhow::bail!("component credential delivery failed");
+    }
+
+    loop {
+        let frame = tokio::select! {
+            () = cancellation.cancelled() => {
+                return cancel_session(state, stdin, reader, &start).await;
+            }
+            () = stderr_monitor.exceeded() => anyhow::bail!("component stderr exceeded the size limit"),
+            result = tokio::time::timeout(COMPONENT_FRAME_TIMEOUT, reader.next()) => {
+                result.context("component response timed out")??
+                    .context("component ended before a result")?
+            }
+        };
+        state
+            .accept(Direction::ComponentToManager, &frame)
+            .context("component response was rejected")?;
+        match frame.body {
+            Body::Completed {
+                output_digest: Some(output_digest),
+                exit_class,
+                ..
+            } => return Ok((output_digest, exit_class)),
+            Body::Completed { .. } => anyhow::bail!("component completed without a result"),
+            Body::Stopped { .. } | Body::Error { .. } => {
+                anyhow::bail!("component did not complete the operation")
+            }
+            _ => {}
+        }
+    }
+}
+
+async fn cancel_session(
+    state: &mut ProtocolStateMachine,
+    stdin: &mut tokio::process::ChildStdin,
+    reader: &mut ComponentFrameReader,
+    start: &Frame,
+) -> anyhow::Result<(String, ExitClass)> {
+    let cancel_id = "manager-cancel-2";
+    let cancel = Frame {
+        wire: PROTOCOL_WIRE.into(),
+        frame_type: FrameType::Cancel,
+        schema_version: 1,
+        message_id: cancel_id.into(),
+        session_id: start.session_id.clone(),
+        request_id: start.request_id.clone(),
+        seq: 2,
+        reply_to: None,
+        correlation: start.correlation.clone(),
+        body: Body::Cancel {
+            cancel_id: cancel_id.into(),
+            reason: oore_component_protocol::CancelReason::Operator,
+            grace_ms: u32::try_from(COMPONENT_CANCEL_GRACE.as_millis())
+                .expect("fixed cancellation grace fits u32"),
+        },
+    };
+    send_manager_frame(state, stdin, &cancel).await?;
+    let deadline = tokio::time::Instant::now() + COMPONENT_CANCEL_GRACE;
+    loop {
+        let frame = tokio::time::timeout_at(deadline, reader.next())
+            .await
+            .context("component cancellation grace expired")??
+            .context("component ended before cancellation completed")?;
+        state
+            .accept(Direction::ComponentToManager, &frame)
+            .context("component cancellation response was rejected")?;
+        if frame.body.is_terminal() {
+            anyhow::bail!("component invocation was cancelled");
+        }
+    }
+}
+
+async fn send_manager_frame(
+    state: &mut ProtocolStateMachine,
+    stdin: &mut tokio::process::ChildStdin,
+    frame: &Frame,
+) -> anyhow::Result<()> {
+    state
+        .accept(Direction::ManagerToComponent, frame)
+        .context("component request was rejected")?;
+    let line = encode_line(frame).context("component request could not be encoded")?;
+    stdin
+        .write_all(&line)
+        .await
+        .context("component request could not be written")?;
+    stdin
+        .flush()
+        .await
+        .context("component request could not be flushed")
+}
+
+async fn next_frame(
+    reader: &mut ComponentFrameReader,
+    cancellation: &ComponentCancellation,
+    stderr_monitor: &ComponentStderrMonitor,
+) -> anyhow::Result<Frame> {
+    tokio::select! {
+        biased;
+        () = cancellation.cancelled() => anyhow::bail!("component invocation was cancelled"),
+        () = stderr_monitor.exceeded() => anyhow::bail!("component stderr exceeded the size limit"),
+        result = tokio::time::timeout(COMPONENT_FRAME_TIMEOUT, reader.next()) => {
+            result.context("component response timed out")??
+                .context("component ended before a result")
+        }
+    }
+}
+
+struct ComponentFrameReader {
+    stdout: tokio::process::ChildStdout,
+    decoder: JsonlDecoder,
+    pending: VecDeque<Frame>,
+}
+
+impl ComponentFrameReader {
+    fn new(stdout: tokio::process::ChildStdout) -> Self {
+        Self {
+            stdout,
+            decoder: JsonlDecoder::new(),
+            pending: VecDeque::new(),
+        }
+    }
+
+    async fn next(&mut self) -> anyhow::Result<Option<Frame>> {
+        if let Some(frame) = self.pending.pop_front() {
+            return Ok(Some(frame));
+        }
+        let mut chunk = [0_u8; READ_CHUNK_BYTES];
+        loop {
+            let read = self
+                .stdout
+                .read(&mut chunk)
+                .await
+                .context("component output could not be read")?;
+            if read == 0 {
+                self.decoder
+                    .finish()
+                    .context("component output ended with a partial frame")?;
+                return Ok(None);
+            }
+            self.pending.extend(
+                self.decoder
+                    .push(&chunk[..read])
+                    .context("component output was invalid")?,
+            );
+            if let Some(frame) = self.pending.pop_front() {
+                return Ok(Some(frame));
+            }
+        }
+    }
+}
+
+async fn drain_component_stderr(
+    mut stderr: tokio::process::ChildStderr,
+    monitor: ComponentStderrMonitor,
+) -> anyhow::Result<u64> {
+    let mut total = 0_u64;
+    let mut chunk = [0_u8; READ_CHUNK_BYTES];
+    loop {
+        let read = stderr
+            .read(&mut chunk)
+            .await
+            .context("component stderr could not be drained")?;
+        if read == 0 {
+            return Ok(total);
+        }
+        total = total.saturating_add(u64::try_from(read).unwrap_or(u64::MAX));
+        if total > HARD_MAX_STDERR_BYTES {
+            monitor.mark_exceeded();
+        }
+    }
+}
+
+fn random_public_id(prefix: &str) -> String {
+    use rand::RngCore as _;
+
+    let mut random = [0_u8; 16];
+    rand::thread_rng().fill_bytes(&mut random);
+    format!("{prefix}-{}", hex::encode(random))
+}
+
+fn valid_absolute_path(path: &Path) -> bool {
+    path.is_absolute()
+        && !path
+            .components()
+            .any(|part| matches!(part, Component::CurDir | Component::ParentDir))
+}
+
+fn now_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}

--- a/crates/oore-runner/src/component_invoker.rs
+++ b/crates/oore-runner/src/component_invoker.rs
@@ -194,6 +194,7 @@ pub async fn invoke_managed_component(
         &invocation.public_input,
     )
     .context("component input could not be prepared")?;
+    let component_tmp = create_private_component_tmp(&invocation.workspace)?;
     let argv = build_machine_argv(&invocation.executable, false)
         .context("component command is invalid")?;
     let mut command = tokio::process::Command::new(&invocation.executable);
@@ -204,6 +205,7 @@ pub async fn invoke_managed_component(
         .env("LANG", "C")
         .env("LC_ALL", "C")
         .env("TZ", "UTC")
+        .env("TMPDIR", &component_tmp)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
@@ -242,16 +244,19 @@ pub async fn invoke_managed_component(
     .await;
 
     if result.is_err() && state.phase() != SessionPhase::Terminal {
-        let _ = child.kill().await;
+        let _ = child.start_kill();
     }
     drop(stdin);
     let stdout_task = tokio::spawn(async move { reader.finish_after_terminal().await });
     let status = match tokio::time::timeout(COMPONENT_EXIT_TIMEOUT, child.wait()).await {
         Ok(status) => status.context("component exit could not be observed"),
         Err(_) => {
-            let _ = child.kill().await;
-            let _ = child.wait().await;
-            Err(anyhow::anyhow!("component exit timed out"))
+            let _ = child.start_kill();
+            match tokio::time::timeout(COMPONENT_EXIT_TIMEOUT, child.wait()).await {
+                Ok(Ok(_)) => Err(anyhow::anyhow!("component exit timed out")),
+                Ok(Err(_)) => Err(anyhow::anyhow!("component exit could not be observed")),
+                Err(_) => Err(anyhow::anyhow!("component could not be reaped")),
+            }
         }
     };
     let stdout_result = join_component_task(stdout_task, "component stdout drain").await;
@@ -617,6 +622,27 @@ fn valid_absolute_path(path: &Path) -> bool {
         && !path
             .components()
             .any(|part| matches!(part, Component::CurDir | Component::ParentDir))
+}
+
+fn create_private_component_tmp(workspace: &Path) -> anyhow::Result<PathBuf> {
+    use std::os::unix::fs::{DirBuilderExt as _, MetadataExt as _};
+
+    let path = workspace.join("tmp");
+    let mut builder = std::fs::DirBuilder::new();
+    builder.mode(0o700);
+    builder
+        .create(&path)
+        .context("component temporary directory could not be created")?;
+    let metadata = path
+        .symlink_metadata()
+        .context("component temporary directory could not be inspected")?;
+    anyhow::ensure!(
+        metadata.file_type().is_dir()
+            && metadata.mode() & 0o077 == 0
+            && metadata.uid() == rustix::process::getuid().as_raw(),
+        "component temporary directory is invalid"
+    );
+    Ok(path)
 }
 
 fn now_unix_seconds() -> u64 {

--- a/crates/oore-runner/src/component_invoker.rs
+++ b/crates/oore-runner/src/component_invoker.rs
@@ -140,7 +140,9 @@ impl ManagedComponentInvocation {
             grant_request.operation_id == operation_id
                 && grant_request.component_identity_digest == identity.identity_digest
                 && grant_request.capability_id == capability_id
-                && grant_request.job_lock_digest == job.job_lock_digest,
+                && grant_request.job_lock_digest == job.job_lock_digest
+                && component_fencing_token_digest(grant_request.fencing_token).as_deref()
+                    == Some(job.fencing_token_digest.as_str()),
             "component credential grant binding is invalid"
         );
         anyhow::ensure!(
@@ -242,13 +244,21 @@ pub async fn invoke_managed_component(
     if result.is_err() && state.phase() != SessionPhase::Terminal {
         let _ = child.kill().await;
     }
-    let status = tokio::time::timeout(COMPONENT_EXIT_TIMEOUT, child.wait())
-        .await
-        .context("component exit timed out")?
-        .context("component exit could not be observed")?;
-    let stderr_bytes = stderr_task
-        .await
-        .context("component stderr drain failed")??;
+    drop(stdin);
+    let stdout_task = tokio::spawn(async move { reader.finish_after_terminal().await });
+    let status = match tokio::time::timeout(COMPONENT_EXIT_TIMEOUT, child.wait()).await {
+        Ok(status) => status.context("component exit could not be observed"),
+        Err(_) => {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            Err(anyhow::anyhow!("component exit timed out"))
+        }
+    };
+    let stdout_result = join_component_task(stdout_task, "component stdout drain").await;
+    let stderr_result = join_component_task(stderr_task, "component stderr drain").await;
+    let status = status?;
+    stdout_result?;
+    let stderr_bytes = stderr_result?;
     anyhow::ensure!(
         stderr_bytes <= HARD_MAX_STDERR_BYTES,
         "component stderr exceeded the size limit"
@@ -529,6 +539,48 @@ impl ComponentFrameReader {
             }
         }
     }
+
+    async fn finish_after_terminal(&mut self) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self.pending.is_empty(),
+            "component wrote a frame after its terminal result"
+        );
+        let mut chunk = [0_u8; READ_CHUNK_BYTES];
+        loop {
+            let read = self
+                .stdout
+                .read(&mut chunk)
+                .await
+                .context("component output could not be drained")?;
+            if read == 0 {
+                return self
+                    .decoder
+                    .finish()
+                    .context("component output ended with a partial frame");
+            }
+            anyhow::ensure!(
+                self.decoder
+                    .push(&chunk[..read])
+                    .context("component trailing output was invalid")?
+                    .is_empty(),
+                "component wrote a frame after its terminal result"
+            );
+        }
+    }
+}
+
+async fn join_component_task<T>(
+    mut task: tokio::task::JoinHandle<anyhow::Result<T>>,
+    label: &'static str,
+) -> anyhow::Result<T> {
+    match tokio::time::timeout(COMPONENT_EXIT_TIMEOUT, &mut task).await {
+        Ok(result) => result.context(format!("{label} task failed"))?,
+        Err(_) => {
+            task.abort();
+            let _ = task.await;
+            anyhow::bail!("{label} timed out");
+        }
+    }
 }
 
 async fn drain_component_stderr(
@@ -572,4 +624,10 @@ fn now_unix_seconds() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
+}
+
+/// Returns the public commitment used for one positive D03 fencing token.
+#[must_use]
+pub fn component_fencing_token_digest(fencing_token: i64) -> Option<String> {
+    (fencing_token > 0).then(|| oore_component_protocol::digest_bytes(&fencing_token.to_be_bytes()))
 }

--- a/crates/oore-runner/src/lib.rs
+++ b/crates/oore-runner/src/lib.rs
@@ -27,10 +27,14 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt};
 use zeroize::Zeroize;
 
 mod component_credentials;
+mod component_invoker;
 
 pub use component_credentials::{
     ComponentCredentialBinding, ComponentCredentialChannel, ComponentCredentialGrantHandle,
     consume_component_credential_grant, spawn_command_with_credential_channel,
+};
+pub use component_invoker::{
+    ComponentCancellation, ManagedComponentInvocation, invoke_managed_component,
 };
 
 const AUTO_CONFIG_PATHS: [&str; 2] = [".oore.yaml", ".oore.yml"];

--- a/crates/oore-runner/src/lib.rs
+++ b/crates/oore-runner/src/lib.rs
@@ -34,7 +34,8 @@ pub use component_credentials::{
     consume_component_credential_grant, spawn_command_with_credential_channel,
 };
 pub use component_invoker::{
-    ComponentCancellation, ManagedComponentInvocation, invoke_managed_component,
+    ComponentCancellation, ManagedComponentInvocation, component_fencing_token_digest,
+    invoke_managed_component,
 };
 
 const AUTO_CONFIG_PATHS: [&str; 2] = [".oore.yaml", ".oore.yml"];


### PR DESCRIPTION
## What this adds

- starts an exact component executable without a shell or inherited environment
- completes the managed protocol hello and start handshake
- copies the component-advertised credential request binding into the start request
- binds the credential grant fence to the protocol job fence commitment
- redeems one broker grant only after the handshake succeeds
- delivers the secret through private fd 3
- bounds protocol output, stderr, child exit, and drain task lifetimes
- rejects every frame or partial line after the terminal result
- sends protocol cancellation before forced process termination
- verifies the terminal result, process exit, and fixed result artifact
- pins the shared Components protocol and runtime to accepted commit 30a6f8a00a97742e5d5bdcf45c57af3655791005

## Scope

This is the first managed one-shot invoker seam for issue #243. It does not close #243. Service mode, gate handling, and runner protocol v4 result mapping remain later parts of that issue. Catalog download and executable signature verification remain owned by the future component store. The constructor states that boundary and accepts already verified launch facts.

## Checks

- cargo fmt --all -- --check
- cargo check -p oore-runner
- cargo clippy -p oore-runner -- -D warnings
- git diff --check

No automated tests were added or run under the v0.2.0 test rule.