### PR TITLE
feat(runner): install Apple component on use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2671,8 +2671,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "tar",
  "tokio",
  "zeroize",
+ "zstd",
 ]
 
 [[package]]
@@ -5423,3 +5425,31 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ http-body-util = "0.1"
 semver = "1"
 flate2 = "1"
 tar = "0.4"
+zstd = "0.13"
 tempfile = "3"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 urlencoding = "2"

--- a/crates/oore-runner/Cargo.toml
+++ b/crates/oore-runner/Cargo.toml
@@ -21,3 +21,5 @@ sha2.workspace = true
 tokio = { workspace = true, features = ["fs", "io-util", "net", "process", "sync", "time"] }
 zeroize.workspace = true
 rustix.workspace = true
+tar.workspace = true
+zstd.workspace = true

--- a/crates/oore-runner/src/component_store.rs
+++ b/crates/oore-runner/src/component_store.rs
@@ -1,0 +1,375 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::{Cursor, Read as _, Write as _};
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use anyhow::Context as _;
+use oore_component_protocol::ComponentIdentity;
+use rand::RngCore as _;
+use sha2::{Digest as _, Sha256};
+
+const COMPONENT_ID: &str = "oore-apple-sign";
+const COMPONENT_VERSION: &str = "0.1.2";
+const RELEASE_TAG: &str = "oore-apple-sign-v0.1.2";
+const MAX_BUNDLE_BYTES: usize = 8 * 1024 * 1024;
+const MAX_MANIFEST_BYTES: u64 = 64 * 1024;
+const MAX_REDIRECTS: usize = 4;
+
+static INSTALL_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+
+#[derive(Clone, Copy)]
+struct ReleaseRecord {
+    arch: &'static str,
+    bundle_sha256: &'static str,
+    bundle_length: u64,
+    executable_sha256: &'static str,
+    executable_length: u64,
+}
+
+const ARM64_RELEASE: ReleaseRecord = ReleaseRecord {
+    arch: "arm64",
+    bundle_sha256: "5b1c8f3b94b222005143332cd01bb9ffc4b3ce286211b72d74a291686e70dc54",
+    bundle_length: 1_778_926,
+    executable_sha256: "b7f3063be59e67ab9e2ef5feb3bab2fbb7cdc7fdae9e5d2203a23edd36b3d51a",
+    executable_length: 5_087_328,
+};
+
+const X86_64_RELEASE: ReleaseRecord = ReleaseRecord {
+    arch: "x86_64",
+    bundle_sha256: "3cbc06aca157025dac9c85a2e412f4b09287971d90ccac410845fc9978c447f2",
+    bundle_length: 1_887_803,
+    executable_sha256: "48c7d3e804429a14ea0d746fcf9242b5550657521fc2a99acdc88889b2f603b0",
+    executable_length: 6_186_424,
+};
+
+/// An exact installed Apple component and its bound identity.
+pub struct InstalledAppleComponent {
+    executable: PathBuf,
+    identity: ComponentIdentity,
+}
+
+impl InstalledAppleComponent {
+    /// Returns the fixed executable path from the verified component store.
+    #[must_use]
+    pub fn executable(&self) -> &Path {
+        &self.executable
+    }
+
+    /// Returns the exact component identity for the managed protocol.
+    #[must_use]
+    pub fn identity(&self) -> &ComponentIdentity {
+        &self.identity
+    }
+}
+
+/// Installs the exact Apple component on first use and verifies every later use.
+pub async fn ensure_apple_sign_component() -> anyhow::Result<InstalledAppleComponent> {
+    let _guard = INSTALL_LOCK
+        .get_or_init(|| tokio::sync::Mutex::new(()))
+        .lock()
+        .await;
+    let executable = std::env::current_exe().context("failed to locate the Oore runner")?;
+    let install_root = super::oore_install_root_for_executable(&executable)
+        .context("the Apple component needs an installed Oore runner")?;
+    validate_owned_root(&install_root)?;
+    let release = release_for_host()?;
+    let target_root = install_root
+        .join("libexec/components")
+        .join(COMPONENT_ID)
+        .join(COMPONENT_VERSION)
+        .join(format!("macos-{}", release.arch));
+    create_private_directories(&target_root)?;
+    let component_root = target_root.join(release.bundle_sha256);
+    let component_executable = component_root.join("bin/oore-apple-sign");
+    if !verified_file(
+        &component_executable,
+        release.executable_length,
+        release.executable_sha256,
+    )? {
+        let bundle = download_bundle(release).await?;
+        install_bundle(&target_root, &component_root, release, &bundle)?;
+    }
+    anyhow::ensure!(
+        verified_file(
+            &component_executable,
+            release.executable_length,
+            release.executable_sha256,
+        )?,
+        "installed Apple component failed verification"
+    );
+    write_active_record(&target_root, release)?;
+    let identity = ComponentIdentity::new(
+        COMPONENT_ID,
+        COMPONENT_VERSION,
+        "macos",
+        release.arch,
+        format!("sha256:{}", release.bundle_sha256),
+        release.bundle_length,
+        1,
+        1,
+    )
+    .context("embedded Apple component identity is invalid")?;
+    Ok(InstalledAppleComponent {
+        executable: component_executable,
+        identity,
+    })
+}
+
+fn release_for_host() -> anyhow::Result<&'static ReleaseRecord> {
+    anyhow::ensure!(
+        std::env::consts::OS == "macos",
+        "the Apple component is available only on macOS"
+    );
+    match std::env::consts::ARCH {
+        "aarch64" => Ok(&ARM64_RELEASE),
+        "x86_64" => Ok(&X86_64_RELEASE),
+        arch => anyhow::bail!("the Apple component does not support architecture {arch}"),
+    }
+}
+
+async fn download_bundle(release: &ReleaseRecord) -> anyhow::Result<Vec<u8>> {
+    let asset = format!(
+        "{COMPONENT_ID}_{COMPONENT_VERSION}_macos_{}.tar.zst",
+        release.arch
+    );
+    let url =
+        format!("https://github.com/oore-ci/components/releases/download/{RELEASE_TAG}/{asset}");
+    let client = reqwest::Client::builder()
+        .https_only(true)
+        .redirect(reqwest::redirect::Policy::custom(|attempt| {
+            let host = attempt.url().host_str().unwrap_or_default();
+            if attempt.previous().len() >= MAX_REDIRECTS {
+                return attempt.error("too many component download redirects");
+            }
+            if matches!(
+                host,
+                "github.com"
+                    | "objects.githubusercontent.com"
+                    | "release-assets.githubusercontent.com"
+            ) {
+                attempt.follow()
+            } else {
+                attempt.error("component download redirected to an untrusted host")
+            }
+        }))
+        .build()
+        .context("failed to create the component download client")?;
+    let mut response = client
+        .get(url)
+        .send()
+        .await
+        .context("failed to download the Apple component")?
+        .error_for_status()
+        .context("Apple component download failed")?;
+    if let Some(length) = response.content_length() {
+        anyhow::ensure!(
+            length == release.bundle_length,
+            "Apple component download length changed"
+        );
+    }
+    let capacity = usize::try_from(release.bundle_length)
+        .context("Apple component bundle length is not supported")?;
+    anyhow::ensure!(
+        capacity <= MAX_BUNDLE_BYTES,
+        "Apple component bundle is too large"
+    );
+    let mut bytes = Vec::with_capacity(capacity);
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .context("failed to read the Apple component download")?
+    {
+        anyhow::ensure!(
+            bytes.len().saturating_add(chunk.len()) <= capacity,
+            "Apple component download exceeded its exact length"
+        );
+        bytes.extend_from_slice(&chunk);
+    }
+    anyhow::ensure!(
+        bytes.len() == capacity,
+        "Apple component download is incomplete"
+    );
+    anyhow::ensure!(
+        sha256(&bytes) == release.bundle_sha256,
+        "Apple component download checksum mismatch"
+    );
+    Ok(bytes)
+}
+
+fn install_bundle(
+    target_root: &Path,
+    component_root: &Path,
+    release: &ReleaseRecord,
+    bundle: &[u8],
+) -> anyhow::Result<()> {
+    use std::os::unix::fs::{DirBuilderExt as _, PermissionsExt as _};
+
+    if component_root.exists() {
+        anyhow::bail!("the existing Apple component directory is invalid");
+    }
+    let mut random = [0_u8; 12];
+    rand::thread_rng().fill_bytes(&mut random);
+    let staging = target_root.join(format!(".stage-{}", hex::encode(random)));
+    let mut builder = fs::DirBuilder::new();
+    builder.mode(0o700).create(&staging)?;
+    let result = (|| -> anyhow::Result<()> {
+        let decoder = zstd::stream::read::Decoder::new(Cursor::new(bundle))
+            .context("Apple component bundle is not valid zstd")?;
+        let mut archive = tar::Archive::new(decoder);
+        let mut entries = BTreeMap::new();
+        for item in archive
+            .entries()
+            .context("Apple component tar is invalid")?
+        {
+            let entry = item.context("Apple component tar entry is invalid")?;
+            anyhow::ensure!(
+                entry.header().entry_type().is_file(),
+                "Apple component tar contains a non-file entry"
+            );
+            let path = entry
+                .path()
+                .context("Apple component tar path is invalid")?
+                .into_owned();
+            let path = path
+                .to_str()
+                .context("Apple component tar path is not UTF-8")?
+                .to_owned();
+            let limit = match path.as_str() {
+                "component.manifest.json" => MAX_MANIFEST_BYTES,
+                "bin/oore-apple-sign" => release.executable_length,
+                _ => anyhow::bail!("Apple component tar contains an unexpected path"),
+            };
+            anyhow::ensure!(
+                !entries.contains_key(&path),
+                "Apple component tar contains a duplicate path"
+            );
+            let mut content = Vec::new();
+            entry
+                .take(limit.saturating_add(1))
+                .read_to_end(&mut content)
+                .context("failed to read the Apple component tar entry")?;
+            anyhow::ensure!(
+                content.len() as u64 <= limit,
+                "Apple component tar entry is too large"
+            );
+            entries.insert(path, content);
+        }
+        anyhow::ensure!(entries.len() == 2, "Apple component tar is incomplete");
+        let manifest = entries
+            .remove("component.manifest.json")
+            .context("Apple component manifest is missing")?;
+        anyhow::ensure!(!manifest.is_empty(), "Apple component manifest is empty");
+        let binary = entries
+            .remove("bin/oore-apple-sign")
+            .context("Apple component executable is missing")?;
+        anyhow::ensure!(
+            binary.len() as u64 == release.executable_length
+                && sha256(&binary) == release.executable_sha256,
+            "Apple component executable does not match the release record"
+        );
+        let bin = staging.join("bin");
+        let mut bin_builder = fs::DirBuilder::new();
+        bin_builder.mode(0o700).create(&bin)?;
+        write_new_file(&staging.join("component.manifest.json"), &manifest, 0o600)?;
+        let executable = bin.join("oore-apple-sign");
+        write_new_file(&executable, &binary, 0o700)?;
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755))?;
+        fs::rename(&staging, component_root).context("failed to activate the Apple component")?;
+        fs::File::open(target_root)?.sync_all()?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_dir_all(&staging);
+    }
+    result
+}
+
+fn write_active_record(target_root: &Path, release: &ReleaseRecord) -> anyhow::Result<()> {
+    let content = serde_json::to_vec(&serde_json::json!({
+        "arch": release.arch,
+        "bundle_sha256": release.bundle_sha256,
+        "component_id": COMPONENT_ID,
+        "component_version": COMPONENT_VERSION,
+    }))?;
+    let temporary = target_root.join(".active.tmp");
+    match fs::remove_file(&temporary) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
+    }
+    write_new_file(&temporary, &content, 0o600)?;
+    fs::rename(&temporary, target_root.join("active.json"))?;
+    fs::File::open(target_root)?.sync_all()?;
+    Ok(())
+}
+
+fn verified_file(path: &Path, expected_length: u64, expected_sha256: &str) -> anyhow::Result<bool> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.into()),
+    };
+    anyhow::ensure!(
+        metadata.file_type().is_file(),
+        "Apple component executable is not a regular file"
+    );
+    if metadata.len() != expected_length {
+        return Ok(false);
+    }
+    let bytes = fs::read(path)?;
+    Ok(sha256(&bytes) == expected_sha256)
+}
+
+fn validate_owned_root(path: &Path) -> anyhow::Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    anyhow::ensure!(
+        metadata.is_dir() && !metadata.file_type().is_symlink(),
+        "Oore install root is not a trusted directory"
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+        anyhow::ensure!(
+            metadata.uid() == super::current_uid()?,
+            "Oore install root has the wrong owner"
+        );
+        anyhow::ensure!(
+            metadata.permissions().mode() & 0o022 == 0,
+            "Oore install root is writable by another user"
+        );
+    }
+    Ok(())
+}
+
+fn create_private_directories(path: &Path) -> anyhow::Result<()> {
+    use std::os::unix::fs::{DirBuilderExt as _, PermissionsExt as _};
+
+    let mut builder = fs::DirBuilder::new();
+    builder.recursive(true).mode(0o700).create(path)?;
+    let metadata = fs::symlink_metadata(path)?;
+    anyhow::ensure!(
+        metadata.is_dir() && !metadata.file_type().is_symlink(),
+        "component store path is not a directory"
+    );
+    anyhow::ensure!(
+        metadata.permissions().mode() & 0o077 == 0,
+        "component store path is not private"
+    );
+    Ok(())
+}
+
+fn write_new_file(path: &Path, content: &[u8], mode: u32) -> anyhow::Result<()> {
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create_new(true).mode(mode);
+    let mut file = options.open(path)?;
+    file.write_all(content)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    hex::encode(Sha256::digest(bytes))
+}

--- a/crates/oore-runner/src/lib.rs
+++ b/crates/oore-runner/src/lib.rs
@@ -28,6 +28,7 @@ use zeroize::Zeroize;
 
 mod component_credentials;
 mod component_invoker;
+mod component_store;
 
 pub use component_credentials::{
     ComponentCredentialBinding, ComponentCredentialChannel, ComponentCredentialGrantHandle,
@@ -37,6 +38,7 @@ pub use component_invoker::{
     ComponentCancellation, ManagedComponentInvocation, component_fencing_token_digest,
     invoke_managed_component,
 };
+pub use component_store::{InstalledAppleComponent, ensure_apple_sign_component};
 
 const AUTO_CONFIG_PATHS: [&str; 2] = [".oore.yaml", ".oore.yml"];
 const OORE_ANDROID_KEYSTORE_PATH_ENV: &str = "OORE_ANDROID_KEYSTORE_PATH";


### PR DESCRIPTION
## What changed

- download oore-apple-sign only when an Apple operation needs it
- pin the immutable 0.1.2 arm64 and x86_64 macOS release files
- reject changed lengths, hashes, redirects, archive paths, links, duplicates, and executable bytes
- install under a fixed content-addressed path
- verify cached bytes before every use
- return the matching protocol identity to the runner

## Manual check

A disposable installed-runner layout downloaded the public arm64 release, extracted it, and returned the verified executable path. A second call verified the cached bytes.

## Code checks

- cargo fmt --all
- git diff --check
- cargo clippy -p oore-runner --offline -- -D warnings

No automated tests were added or run.