### PR TITLE
feat(apple): connect accounts through managed component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2699,6 +2699,7 @@ dependencies = [
  "libc",
  "metrics",
  "metrics-exporter-prometheus",
+ "oore-component-protocol",
  "oore-contract",
  "oore-runner",
  "openidconnect",

--- a/apps/docs/public/openapi.json
+++ b/apps/docs/public/openapi.json
@@ -486,6 +486,266 @@
         ]
       }
     },
+    "/v1/apple/account": {
+      "get": {
+        "tags": [
+          "Apple Account"
+        ],
+        "summary": "Get the connected Apple account",
+        "operationId": "get_apple_account",
+        "responses": {
+          "200": {
+            "description": "Apple account state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppleAccountResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Owner access required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Apple Account"
+        ],
+        "summary": "Remove the connected Apple account",
+        "operationId": "remove_apple_account",
+        "responses": {
+          "200": {
+            "description": "Apple account removed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppleAccountResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Owner access required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/v1/apple/account/connect": {
+      "post": {
+        "tags": [
+          "Apple Account"
+        ],
+        "summary": "Connect an App Store Connect Team API key",
+        "description": "Queues a check on a macOS runner. The private key remains encrypted until use.",
+        "operationId": "connect_apple_account",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectAppleAccountRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Apple account check queued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppleAccountOperationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid key details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Owner access required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Another check is active",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/v1/apple/account/operations/{operation_id}": {
+      "get": {
+        "tags": [
+          "Apple Account"
+        ],
+        "summary": "Get an Apple account check",
+        "operationId": "get_apple_account_operation",
+        "parameters": [
+          {
+            "name": "operation_id",
+            "in": "path",
+            "description": "Operation ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Apple account check state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppleAccountOperationResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Owner access required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Operation not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/v1/apple/account/selection": {
+      "put": {
+        "tags": [
+          "Apple Account"
+        ],
+        "summary": "Choose an app from the connected Apple account",
+        "operationId": "select_apple_app",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SelectAppleAppRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Selected Apple app",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppleAccountResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "App is not in the connected account",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Owner access required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Apple account not connected",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/v1/artifact-tokens/{token_id}": {
       "delete": {
         "tags": [
@@ -8039,6 +8299,107 @@
           }
         }
       },
+      "AppleAccountOperationResponse": {
+        "type": "object",
+        "required": [
+          "operationId",
+          "status"
+        ],
+        "properties": {
+          "apps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AppleAppSummary"
+            }
+          },
+          "errorCode": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "errorMessage": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "operationId": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/AppleAccountOperationStatus"
+          }
+        }
+      },
+      "AppleAccountOperationStatus": {
+        "type": "string",
+        "enum": [
+          "queued",
+          "claimed",
+          "running",
+          "succeeded",
+          "failed"
+        ]
+      },
+      "AppleAccountResponse": {
+        "type": "object",
+        "required": [
+          "connected"
+        ],
+        "properties": {
+          "apps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AppleAppSummary"
+            }
+          },
+          "connected": {
+            "type": "boolean"
+          },
+          "keyId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "selectedAppId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "AppleAppSummary": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "bundleId",
+          "sku"
+        ],
+        "properties": {
+          "bundleId": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "primaryLocale": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sku": {
+            "type": "string"
+          }
+        }
+      },
       "Artifact": {
         "type": "object",
         "required": [
@@ -8954,6 +9315,25 @@
           },
           "has_client_secret": {
             "type": "boolean"
+          }
+        }
+      },
+      "ConnectAppleAccountRequest": {
+        "type": "object",
+        "required": [
+          "keyId",
+          "issuerId",
+          "privateKeyPem"
+        ],
+        "properties": {
+          "issuerId": {
+            "type": "string"
+          },
+          "keyId": {
+            "type": "string"
+          },
+          "privateKeyPem": {
+            "type": "string"
           }
         }
       },
@@ -11965,6 +12345,17 @@
           "local_git"
         ]
       },
+      "SelectAppleAppRequest": {
+        "type": "object",
+        "required": [
+          "appId"
+        ],
+        "properties": {
+          "appId": {
+            "type": "string"
+          }
+        }
+      },
       "SetupCompleteResponse": {
         "type": "object",
         "required": [
@@ -13468,6 +13859,10 @@
     {
       "name": "Pipeline Signing",
       "description": "Code signing configuration — Android keystores, iOS certificates/profiles."
+    },
+    {
+      "name": "Apple Account",
+      "description": "Connect an App Store Connect Team API key and choose an app."
     },
     {
       "name": "Builds",

--- a/crates/oore-contract/src/lib.rs
+++ b/crates/oore-contract/src/lib.rs
@@ -1235,6 +1235,192 @@ pub struct RunnerHeartbeatRequest {
 
 pub const RUNNER_PROTOCOL_VERSION: u32 = 4;
 
+pub const APPLE_COMPONENT_ID: &str = "oore-apple-sign";
+pub const APPLE_COMPONENT_VERSION: &str = "0.1.2";
+pub const APPLE_COMPONENT_CAPABILITY: &str = "apple.apps.read";
+pub const APPLE_COMPONENT_INPUT_SCHEMA: &str = "oore.apple.apps.read:1";
+pub const APPLE_COMPONENT_SECRET_KIND: &str = "apple_team_api_private_key";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AppleComponentReleaseRecord {
+    pub rust_arch: &'static str,
+    pub target_arch: &'static str,
+    pub bundle_sha256: &'static str,
+    pub bundle_length: u64,
+    pub executable_sha256: &'static str,
+    pub executable_length: u64,
+}
+
+pub const APPLE_COMPONENT_ARM64: AppleComponentReleaseRecord = AppleComponentReleaseRecord {
+    rust_arch: "aarch64",
+    target_arch: "arm64",
+    bundle_sha256: "5b1c8f3b94b222005143332cd01bb9ffc4b3ce286211b72d74a291686e70dc54",
+    bundle_length: 1_778_926,
+    executable_sha256: "b7f3063be59e67ab9e2ef5feb3bab2fbb7cdc7fdae9e5d2203a23edd36b3d51a",
+    executable_length: 5_087_328,
+};
+
+pub const APPLE_COMPONENT_X86_64: AppleComponentReleaseRecord = AppleComponentReleaseRecord {
+    rust_arch: "x86_64",
+    target_arch: "x86_64",
+    bundle_sha256: "3cbc06aca157025dac9c85a2e412f4b09287971d90ccac410845fc9978c447f2",
+    bundle_length: 1_887_803,
+    executable_sha256: "48c7d3e804429a14ea0d746fcf9242b5550657521fc2a99acdc88889b2f603b0",
+    executable_length: 6_186_424,
+};
+
+#[must_use]
+pub fn apple_component_release_for_rust_arch(
+    arch: &str,
+) -> Option<&'static AppleComponentReleaseRecord> {
+    match arch {
+        "aarch64" => Some(&APPLE_COMPONENT_ARM64),
+        "x86_64" => Some(&APPLE_COMPONENT_X86_64),
+        _ => None,
+    }
+}
+
+#[must_use]
+pub fn apple_component_release_for_target_arch(
+    arch: &str,
+) -> Option<&'static AppleComponentReleaseRecord> {
+    match arch {
+        "arm64" => Some(&APPLE_COMPONENT_ARM64),
+        "x86_64" => Some(&APPLE_COMPONENT_X86_64),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AppleAppSummary {
+    pub id: String,
+    pub name: String,
+    pub bundle_id: String,
+    pub sku: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub primary_locale: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ConnectAppleAccountRequest {
+    pub key_id: String,
+    pub issuer_id: String,
+    pub private_key_pem: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AppleAccountOperationStatus {
+    Queued,
+    Claimed,
+    Running,
+    Succeeded,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AppleAccountOperationResponse {
+    pub operation_id: String,
+    pub status: AppleAccountOperationStatus,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub apps: Vec<AppleAppSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AppleAccountResponse {
+    pub connected: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub apps: Vec<AppleAppSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_app_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SelectAppleAppRequest {
+    pub app_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ClaimComponentOperationRequest {
+    pub protocol_version: u32,
+    pub target_os: String,
+    pub target_arch: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ClaimComponentOperationResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operation: Option<ClaimedAppleComponentOperation>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimedAppleComponentOperation {
+    pub operation_id: String,
+    pub key_id: String,
+    pub issuer_id: String,
+    pub job_lock_digest: String,
+    pub lease_id: String,
+    pub receipt_id: String,
+    pub fencing_token: i64,
+    pub lease_expires_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ComponentIdentityClaim {
+    pub component_id: String,
+    pub component_version: String,
+    pub target_os: String,
+    pub target_arch: String,
+    pub protocol_major: u16,
+    pub bundle_digest: String,
+    pub bundle_length: u64,
+    pub catalog_revision: u64,
+    pub release_counter: u64,
+    pub identity_digest: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivateComponentOperationRequest {
+    pub component: ComponentIdentityClaim,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivateComponentOperationResponse {
+    pub credential_grant: String,
+    pub credential_expires_at: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CompleteComponentOperationRequest {
+    pub component_identity_digest: String,
+    pub job_lock_digest: String,
+    pub lease_id: String,
+    pub receipt_id: String,
+    pub fencing_token: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+}
+
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct ClaimJobRequest {
     pub protocol_version: u32,

--- a/crates/oore-runner/src/component_store.rs
+++ b/crates/oore-runner/src/component_store.rs
@@ -6,42 +6,19 @@ use std::sync::OnceLock;
 
 use anyhow::Context as _;
 use oore_component_protocol::ComponentIdentity;
+use oore_contract::{
+    APPLE_COMPONENT_ID, APPLE_COMPONENT_VERSION, AppleComponentReleaseRecord,
+    apple_component_release_for_rust_arch,
+};
 use rand::RngCore as _;
 use sha2::{Digest as _, Sha256};
 
-const COMPONENT_ID: &str = "oore-apple-sign";
-const COMPONENT_VERSION: &str = "0.1.2";
 const RELEASE_TAG: &str = "oore-apple-sign-v0.1.2";
 const MAX_BUNDLE_BYTES: usize = 8 * 1024 * 1024;
 const MAX_MANIFEST_BYTES: u64 = 64 * 1024;
 const MAX_REDIRECTS: usize = 4;
 
 static INSTALL_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
-
-#[derive(Clone, Copy)]
-struct ReleaseRecord {
-    arch: &'static str,
-    bundle_sha256: &'static str,
-    bundle_length: u64,
-    executable_sha256: &'static str,
-    executable_length: u64,
-}
-
-const ARM64_RELEASE: ReleaseRecord = ReleaseRecord {
-    arch: "arm64",
-    bundle_sha256: "5b1c8f3b94b222005143332cd01bb9ffc4b3ce286211b72d74a291686e70dc54",
-    bundle_length: 1_778_926,
-    executable_sha256: "b7f3063be59e67ab9e2ef5feb3bab2fbb7cdc7fdae9e5d2203a23edd36b3d51a",
-    executable_length: 5_087_328,
-};
-
-const X86_64_RELEASE: ReleaseRecord = ReleaseRecord {
-    arch: "x86_64",
-    bundle_sha256: "3cbc06aca157025dac9c85a2e412f4b09287971d90ccac410845fc9978c447f2",
-    bundle_length: 1_887_803,
-    executable_sha256: "48c7d3e804429a14ea0d746fcf9242b5550657521fc2a99acdc88889b2f603b0",
-    executable_length: 6_186_424,
-};
 
 /// An exact installed Apple component and its bound identity.
 pub struct InstalledAppleComponent {
@@ -76,9 +53,9 @@ pub async fn ensure_apple_sign_component() -> anyhow::Result<InstalledAppleCompo
     let release = release_for_host()?;
     let target_root = install_root
         .join("libexec/components")
-        .join(COMPONENT_ID)
-        .join(COMPONENT_VERSION)
-        .join(format!("macos-{}", release.arch));
+        .join(APPLE_COMPONENT_ID)
+        .join(APPLE_COMPONENT_VERSION)
+        .join(format!("macos-{}", release.target_arch));
     create_private_directories(&target_root)?;
     let component_root = target_root.join(release.bundle_sha256);
     let component_executable = component_root.join("bin/oore-apple-sign");
@@ -100,10 +77,10 @@ pub async fn ensure_apple_sign_component() -> anyhow::Result<InstalledAppleCompo
     );
     write_active_record(&target_root, release)?;
     let identity = ComponentIdentity::new(
-        COMPONENT_ID,
-        COMPONENT_VERSION,
+        APPLE_COMPONENT_ID,
+        APPLE_COMPONENT_VERSION,
         "macos",
-        release.arch,
+        release.target_arch,
         format!("sha256:{}", release.bundle_sha256),
         release.bundle_length,
         1,
@@ -116,22 +93,23 @@ pub async fn ensure_apple_sign_component() -> anyhow::Result<InstalledAppleCompo
     })
 }
 
-fn release_for_host() -> anyhow::Result<&'static ReleaseRecord> {
+fn release_for_host() -> anyhow::Result<&'static AppleComponentReleaseRecord> {
     anyhow::ensure!(
         std::env::consts::OS == "macos",
         "the Apple component is available only on macOS"
     );
-    match std::env::consts::ARCH {
-        "aarch64" => Ok(&ARM64_RELEASE),
-        "x86_64" => Ok(&X86_64_RELEASE),
-        arch => anyhow::bail!("the Apple component does not support architecture {arch}"),
-    }
+    apple_component_release_for_rust_arch(std::env::consts::ARCH).ok_or_else(|| {
+        anyhow::anyhow!(
+            "the Apple component does not support architecture {}",
+            std::env::consts::ARCH
+        )
+    })
 }
 
-async fn download_bundle(release: &ReleaseRecord) -> anyhow::Result<Vec<u8>> {
+async fn download_bundle(release: &AppleComponentReleaseRecord) -> anyhow::Result<Vec<u8>> {
     let asset = format!(
-        "{COMPONENT_ID}_{COMPONENT_VERSION}_macos_{}.tar.zst",
-        release.arch
+        "{APPLE_COMPONENT_ID}_{APPLE_COMPONENT_VERSION}_macos_{}.tar.zst",
+        release.target_arch
     );
     let url =
         format!("https://github.com/oore-ci/components/releases/download/{RELEASE_TAG}/{asset}");
@@ -200,7 +178,7 @@ async fn download_bundle(release: &ReleaseRecord) -> anyhow::Result<Vec<u8>> {
 fn install_bundle(
     target_root: &Path,
     component_root: &Path,
-    release: &ReleaseRecord,
+    release: &AppleComponentReleaseRecord,
     bundle: &[u8],
 ) -> anyhow::Result<()> {
     use std::os::unix::fs::{DirBuilderExt as _, PermissionsExt as _};
@@ -285,12 +263,15 @@ fn install_bundle(
     result
 }
 
-fn write_active_record(target_root: &Path, release: &ReleaseRecord) -> anyhow::Result<()> {
+fn write_active_record(
+    target_root: &Path,
+    release: &AppleComponentReleaseRecord,
+) -> anyhow::Result<()> {
     let content = serde_json::to_vec(&serde_json::json!({
-        "arch": release.arch,
+        "arch": release.target_arch,
         "bundle_sha256": release.bundle_sha256,
-        "component_id": COMPONENT_ID,
-        "component_version": COMPONENT_VERSION,
+        "component_id": APPLE_COMPONENT_ID,
+        "component_version": APPLE_COMPONENT_VERSION,
     }))?;
     let temporary = target_root.join(".active.tmp");
     match fs::remove_file(&temporary) {

--- a/crates/oore-runner/src/lib.rs
+++ b/crates/oore-runner/src/lib.rs
@@ -12,14 +12,18 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::Context;
 use base64::Engine as _;
+use oore_component_protocol::JobBinding;
 use oore_contract::{
-    AndroidSigningBuildType, BuildPlatform, BuildStatus, ClaimJobRequest, ClaimJobResponse,
-    ClaimedJob, CompleteArtifactRequest, CompleteArtifactResponse, JobStatusResponse,
-    PipelineCommandStages, PipelineEnvVar, PipelineExecutionConfig, PlatformBuildArgs,
-    PlatformBuildCommands, RUNNER_PROTOCOL_VERSION, RunnerAndroidSigningProfile,
-    RunnerAndroidSigningResponse, RunnerIosSigningBundle, RunnerIosSigningResponse, StepResult,
-    artifact_pattern_matches, parse_repository_pipeline_yaml, validate_artifact_pattern,
-    validate_repository_config_path,
+    APPLE_COMPONENT_CAPABILITY, APPLE_COMPONENT_INPUT_SCHEMA, APPLE_COMPONENT_SECRET_KIND,
+    ActivateComponentOperationRequest, ActivateComponentOperationResponse, AndroidSigningBuildType,
+    BuildPlatform, BuildStatus, ClaimComponentOperationRequest, ClaimComponentOperationResponse,
+    ClaimJobRequest, ClaimJobResponse, ClaimedJob, CompleteArtifactRequest,
+    CompleteArtifactResponse, CompleteComponentOperationRequest, ComponentIdentityClaim,
+    ConsumeComponentCredentialGrantRequest, JobStatusResponse, PipelineCommandStages,
+    PipelineEnvVar, PipelineExecutionConfig, PlatformBuildArgs, PlatformBuildCommands,
+    RUNNER_PROTOCOL_VERSION, RunnerAndroidSigningProfile, RunnerAndroidSigningResponse,
+    RunnerIosSigningBundle, RunnerIosSigningResponse, StepResult, artifact_pattern_matches,
+    parse_repository_pipeline_yaml, validate_artifact_pattern, validate_repository_config_path,
 };
 use rand::RngCore;
 use sha2::{Digest, Sha256};
@@ -3194,6 +3198,16 @@ pub async fn run_runner_forever(
             tokio::time::sleep(Duration::from_secs(10)).await;
             continue;
         }
+        match claim_and_execute_component(&client, &daemon_url, &config).await {
+            Ok(true) => continue,
+            Ok(false) => {}
+            Err(error) if terminal_runner_error(&error) => return Err(error),
+            Err(error) => {
+                eprintln!("Apple component operation failed: {error:#}");
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                continue;
+            }
+        }
         match claim_and_execute(&client, &daemon_url, &config).await {
             Ok(_executed) => {}
             Err(error) if terminal_runner_error(&error) => return Err(error),
@@ -3203,6 +3217,177 @@ pub async fn run_runner_forever(
             }
         }
     }
+}
+
+async fn claim_and_execute_component(
+    client: &reqwest::Client,
+    daemon_url: &str,
+    config: &RunnerConfig,
+) -> anyhow::Result<bool> {
+    let target_arch = match std::env::consts::ARCH {
+        "aarch64" => "arm64",
+        "x86_64" => "x86_64",
+        _ => return Ok(false),
+    };
+    let response = client
+        .post(format!(
+            "{}/v1/runners/{}/component-operations/claim",
+            daemon_url, config.runner_id
+        ))
+        .bearer_auth(&config.runner_token)
+        .json(&ClaimComponentOperationRequest {
+            protocol_version: RUNNER_PROTOCOL_VERSION,
+            target_os: std::env::consts::OS.into(),
+            target_arch: target_arch.into(),
+        })
+        .send()
+        .await?;
+    if !response.status().is_success() {
+        let status = response.status();
+        if runner_response_is_terminal(status) {
+            return Err(anyhow::Error::new(RunnerControlPlaneRejected {
+                operation: "component claim",
+                status,
+            }));
+        }
+        anyhow::bail!("Component claim request failed: {status}");
+    }
+    let claim: ClaimComponentOperationResponse = response.json().await?;
+    let Some(operation) = claim.operation else {
+        return Ok(false);
+    };
+    let component = ensure_apple_sign_component().await?;
+    let identity = component.identity().clone();
+    let activation = client
+        .post(format!(
+            "{}/v1/runners/{}/component-operations/{}/activate",
+            daemon_url, config.runner_id, operation.operation_id
+        ))
+        .bearer_auth(&config.runner_token)
+        .json(&ActivateComponentOperationRequest {
+            component: ComponentIdentityClaim {
+                component_id: identity.component_id.clone(),
+                component_version: identity.component_version.clone(),
+                target_os: identity.target_os.clone(),
+                target_arch: identity.target_arch.clone(),
+                protocol_major: identity.protocol_major,
+                bundle_digest: identity.bundle_digest.clone(),
+                bundle_length: identity.bundle_length,
+                catalog_revision: identity.catalog_revision,
+                release_counter: identity.release_counter,
+                identity_digest: identity.identity_digest.clone(),
+            },
+        })
+        .send()
+        .await?;
+    anyhow::ensure!(
+        activation.status().is_success(),
+        "Apple component activation failed ({})",
+        activation.status()
+    );
+    let activation: ActivateComponentOperationResponse = activation.json().await?;
+    let grant_handle = ComponentCredentialGrantHandle::new(activation.credential_grant)?;
+    let fencing_token_digest = component_fencing_token_digest(operation.fencing_token)
+        .context("Apple component fencing token is invalid")?;
+    let job = JobBinding {
+        job_id: operation.operation_id.clone(),
+        job_lock_digest: operation.job_lock_digest.clone(),
+        lease_id: operation.lease_id.clone(),
+        fencing_token_digest,
+        receipt_id: operation.receipt_id.clone(),
+        plan_hash: None,
+    };
+    let grant_request = ConsumeComponentCredentialGrantRequest {
+        operation_id: operation.operation_id.clone(),
+        component_identity_digest: identity.identity_digest.clone(),
+        capability_id: APPLE_COMPONENT_CAPABILITY.into(),
+        job_lock_digest: operation.job_lock_digest.clone(),
+        fencing_token: operation.fencing_token,
+        secret_kind: APPLE_COMPONENT_SECRET_KIND.into(),
+    };
+    let public_input = serde_json::to_vec(&serde_json::json!({
+        "issuer_id": operation.issuer_id,
+        "key_id": operation.key_id,
+    }))?;
+    let workspace_root = prepare_runner_workspace_root()?;
+    let workspace = create_private_workspace_in(&workspace_root, &config.runner_id)?;
+    let invocation = ManagedComponentInvocation::new(
+        component.executable().to_path_buf(),
+        workspace.clone(),
+        identity,
+        job,
+        operation.operation_id.clone(),
+        APPLE_COMPONENT_CAPABILITY.into(),
+        APPLE_COMPONENT_INPUT_SCHEMA.into(),
+        public_input,
+        random_component_reference(),
+        u64::try_from(activation.credential_expires_at)
+            .context("Apple credential expiry is invalid")?,
+        grant_request,
+        grant_handle,
+    )?;
+    let result =
+        invoke_managed_component(config, invocation, ComponentCancellation::default()).await;
+    let completion = match result {
+        Ok(bytes) => match serde_json::from_slice(&bytes) {
+            Ok(value) => CompleteComponentOperationRequest {
+                component_identity_digest: component.identity().identity_digest.clone(),
+                job_lock_digest: operation.job_lock_digest.clone(),
+                lease_id: operation.lease_id.clone(),
+                receipt_id: operation.receipt_id.clone(),
+                fencing_token: operation.fencing_token,
+                result: Some(value),
+                error_code: None,
+                error_message: None,
+            },
+            Err(_) => CompleteComponentOperationRequest {
+                component_identity_digest: component.identity().identity_digest.clone(),
+                job_lock_digest: operation.job_lock_digest.clone(),
+                lease_id: operation.lease_id.clone(),
+                receipt_id: operation.receipt_id.clone(),
+                fencing_token: operation.fencing_token,
+                result: None,
+                error_code: Some("component_result_invalid".into()),
+                error_message: Some("The Apple check returned an invalid result".into()),
+            },
+        },
+        Err(error) => {
+            eprintln!("Apple component execution failed: {error:#}");
+            CompleteComponentOperationRequest {
+                component_identity_digest: component.identity().identity_digest.clone(),
+                job_lock_digest: operation.job_lock_digest.clone(),
+                lease_id: operation.lease_id.clone(),
+                receipt_id: operation.receipt_id.clone(),
+                fencing_token: operation.fencing_token,
+                result: None,
+                error_code: Some("component_failed".into()),
+                error_message: Some("The Apple check failed on the runner".into()),
+            }
+        }
+    };
+    let cleanup = fs::remove_dir_all(&workspace);
+    let response = client
+        .post(format!(
+            "{}/v1/runners/{}/component-operations/{}/complete",
+            daemon_url, config.runner_id, operation.operation_id
+        ))
+        .bearer_auth(&config.runner_token)
+        .json(&completion)
+        .send()
+        .await?;
+    anyhow::ensure!(
+        response.status().is_success(),
+        "Apple component completion failed ({})",
+        response.status()
+    );
+    cleanup.context("failed to remove the Apple component workspace")?;
+    Ok(true)
+}
+
+fn random_component_reference() -> String {
+    let mut random = [0_u8; 16];
+    rand::thread_rng().fill_bytes(&mut random);
+    format!("apple-key-{}", hex::encode(random))
 }
 
 async fn claim_and_execute(

--- a/crates/oored/Cargo.toml
+++ b/crates/oored/Cargo.toml
@@ -19,6 +19,7 @@ jsonwebtoken.workspace = true
 lettre.workspace = true
 libc.workspace = true
 oore-contract = { path = "../oore-contract" }
+oore-component-protocol.workspace = true
 oore-runner = { path = "../oore-runner" }
 openidconnect.workspace = true
 rand.workspace = true

--- a/crates/oored/migrations/040_apple_account_component_operations.sql
+++ b/crates/oored/migrations/040_apple_account_component_operations.sql
@@ -1,0 +1,45 @@
+CREATE TABLE apple_account (
+    id INTEGER PRIMARY KEY NOT NULL CHECK (id = 1),
+    key_id TEXT NOT NULL,
+    issuer_id TEXT NOT NULL,
+    private_key_encrypted TEXT NOT NULL,
+    apps_json TEXT NOT NULL,
+    selected_app_id TEXT,
+    connected_by TEXT NOT NULL REFERENCES users(id),
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE apple_account_operations (
+    id TEXT PRIMARY KEY NOT NULL,
+    requested_by TEXT NOT NULL REFERENCES users(id),
+    key_id TEXT NOT NULL,
+    issuer_id TEXT NOT NULL,
+    private_key_encrypted TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('queued', 'claimed', 'running', 'succeeded', 'failed')),
+    runner_id TEXT REFERENCES runners(id) ON DELETE SET NULL,
+    job_lock_digest TEXT,
+    lease_id TEXT,
+    receipt_id TEXT,
+    component_identity_digest TEXT,
+    component_target_arch TEXT,
+    fencing_token INTEGER NOT NULL DEFAULT 0,
+    lease_expires_at INTEGER,
+    result_json TEXT,
+    error_code TEXT,
+    error_message TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX idx_apple_account_operations_queue
+    ON apple_account_operations (created_at, id)
+    WHERE status = 'queued';
+
+CREATE UNIQUE INDEX idx_apple_account_operations_one_active
+    ON apple_account_operations ((1))
+    WHERE status IN ('queued', 'claimed', 'running');
+
+CREATE INDEX idx_apple_account_operations_lease
+    ON apple_account_operations (lease_expires_at)
+    WHERE status IN ('claimed', 'running');

--- a/crates/oored/src/apple_accounts.rs
+++ b/crates/oored/src/apple_accounts.rs
@@ -1,0 +1,837 @@
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use oore_component_protocol::ComponentIdentity;
+use oore_contract::{
+    APPLE_COMPONENT_CAPABILITY, APPLE_COMPONENT_ID, APPLE_COMPONENT_SECRET_KIND,
+    APPLE_COMPONENT_VERSION, ActivateComponentOperationRequest, ActivateComponentOperationResponse,
+    AppleAccountOperationResponse, AppleAccountOperationStatus, AppleAccountResponse,
+    AppleAppSummary, ClaimComponentOperationRequest, ClaimComponentOperationResponse,
+    ClaimedAppleComponentOperation, CompleteComponentOperationRequest, ConnectAppleAccountRequest,
+    RUNNER_PROTOCOL_VERSION, SelectAppleAppRequest, apple_component_release_for_target_arch,
+};
+use serde::Deserialize;
+use sha2::{Digest as _, Sha256};
+use sqlx::Row as _;
+use uuid::Uuid;
+use zeroize::Zeroizing;
+
+use crate::AppState;
+use crate::credential_broker::{
+    self, CredentialAuthorityBinding, CredentialGrantBinding, CredentialGrantError,
+};
+use crate::extractors::AuthUser;
+use crate::runners::RunnerAuth;
+use crate::store::write_audit_log;
+use crate::util::{api_err, now_unix};
+
+type ApiResult<T> = Result<Json<T>, (StatusCode, Json<oore_contract::ApiError>)>;
+
+const MAX_KEY_ID_BYTES: usize = 128;
+const MAX_ISSUER_ID_BYTES: usize = 128;
+const MAX_PRIVATE_KEY_BYTES: usize = 64 * 1024;
+const MAX_APPS: usize = 10_000;
+const MAX_APP_FIELD_BYTES: usize = 512;
+const OPERATION_LEASE_SECONDS: i64 = 10 * 60;
+const CREDENTIAL_LEASE_SECONDS: i64 = 8 * 60;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AppleAppsResult {
+    apps: Vec<AppleAppSummary>,
+    rate_limit: Option<serde_json::Value>,
+}
+
+pub async fn connect_account(
+    State(state): State<Arc<AppState>>,
+    auth: AuthUser,
+    Json(request): Json<ConnectAppleAccountRequest>,
+) -> ApiResult<AppleAccountOperationResponse> {
+    auth.require_owner()?;
+    let key_id = bounded_trimmed(&request.key_id, MAX_KEY_ID_BYTES, "key_id")?;
+    let issuer_id = bounded_trimmed(&request.issuer_id, MAX_ISSUER_ID_BYTES, "issuer_id")?;
+    let private_key = Zeroizing::new(request.private_key_pem);
+    validate_private_key(private_key.as_str())?;
+    let now = now_unix();
+    let active = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM apple_account_operations WHERE status IN ('queued', 'claimed', 'running')",
+    )
+    .fetch_one(&state.db)
+    .await
+    .map_err(store_error)?;
+    if active > 0 {
+        return Err(api_err(
+            StatusCode::CONFLICT,
+            "apple_connection_in_progress",
+            "An Apple connection check is already running",
+        ));
+    }
+    let encrypted =
+        crate::crypto::encrypt(private_key.as_str(), &state.encryption_key).map_err(|_| {
+            internal_error(
+                "apple_key_encrypt_failed",
+                "The Apple key could not be protected",
+            )
+        })?;
+    let operation_id = format!("apple-connect-{}", Uuid::new_v4());
+    sqlx::query(
+        "INSERT INTO apple_account_operations (
+            id, requested_by, key_id, issuer_id, private_key_encrypted,
+            status, created_at, updated_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, 'queued', ?6, ?6)",
+    )
+    .bind(&operation_id)
+    .bind(&auth.0.user_id)
+    .bind(&key_id)
+    .bind(&issuer_id)
+    .bind(encrypted)
+    .bind(now)
+    .execute(&state.db)
+    .await
+    .map_err(store_error)?;
+    let details = serde_json::json!({
+        "key_id": key_id,
+    })
+    .to_string();
+    let _ = write_audit_log(
+        &state.db,
+        Some(&auth.0.user_id),
+        "apple_account_connection_started",
+        "apple_account_operation",
+        Some(&operation_id),
+        Some(&details),
+    )
+    .await;
+    Ok(Json(AppleAccountOperationResponse {
+        operation_id,
+        status: AppleAccountOperationStatus::Queued,
+        apps: Vec::new(),
+        error_code: None,
+        error_message: None,
+    }))
+}
+
+pub async fn get_operation(
+    State(state): State<Arc<AppState>>,
+    Path(operation_id): Path<String>,
+    auth: AuthUser,
+) -> ApiResult<AppleAccountOperationResponse> {
+    auth.require_owner()?;
+    let row = sqlx::query(
+        "SELECT status, result_json, error_code, error_message
+         FROM apple_account_operations
+         WHERE id = ?1 AND requested_by = ?2",
+    )
+    .bind(&operation_id)
+    .bind(&auth.0.user_id)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(store_error)?
+    .ok_or_else(|| {
+        api_err(
+            StatusCode::NOT_FOUND,
+            "not_found",
+            "Apple operation not found",
+        )
+    })?;
+    Ok(Json(operation_response(&operation_id, &row)?))
+}
+
+pub async fn get_account(
+    State(state): State<Arc<AppState>>,
+    auth: AuthUser,
+) -> ApiResult<AppleAccountResponse> {
+    auth.require_owner()?;
+    let row =
+        sqlx::query("SELECT key_id, apps_json, selected_app_id FROM apple_account WHERE id = 1")
+            .fetch_optional(&state.db)
+            .await
+            .map_err(store_error)?;
+    let Some(row) = row else {
+        return Ok(Json(AppleAccountResponse {
+            connected: false,
+            key_id: None,
+            apps: Vec::new(),
+            selected_app_id: None,
+        }));
+    };
+    let apps = parse_apps(&row.get::<String, _>("apps_json"))?;
+    Ok(Json(AppleAccountResponse {
+        connected: true,
+        key_id: Some(row.get("key_id")),
+        apps,
+        selected_app_id: row.get("selected_app_id"),
+    }))
+}
+
+pub async fn select_app(
+    State(state): State<Arc<AppState>>,
+    auth: AuthUser,
+    Json(request): Json<SelectAppleAppRequest>,
+) -> ApiResult<AppleAccountResponse> {
+    auth.require_owner()?;
+    let app_id = bounded_trimmed(&request.app_id, MAX_APP_FIELD_BYTES, "app_id")?;
+    let row = sqlx::query("SELECT apps_json FROM apple_account WHERE id = 1")
+        .fetch_optional(&state.db)
+        .await
+        .map_err(store_error)?
+        .ok_or_else(|| {
+            api_err(
+                StatusCode::NOT_FOUND,
+                "apple_account_missing",
+                "No Apple account is connected",
+            )
+        })?;
+    let apps = parse_apps(&row.get::<String, _>("apps_json"))?;
+    if !apps.iter().any(|app| app.id == app_id) {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "apple_app_unknown",
+            "Choose an app returned by the connected Apple account",
+        ));
+    }
+    sqlx::query("UPDATE apple_account SET selected_app_id = ?1, updated_at = ?2 WHERE id = 1")
+        .bind(&app_id)
+        .bind(now_unix())
+        .execute(&state.db)
+        .await
+        .map_err(store_error)?;
+    let details = serde_json::json!({
+        "app_id": app_id,
+    })
+    .to_string();
+    let _ = write_audit_log(
+        &state.db,
+        Some(&auth.0.user_id),
+        "apple_app_selected",
+        "apple_account",
+        Some("1"),
+        Some(&details),
+    )
+    .await;
+    get_account(State(state), auth).await
+}
+
+pub async fn remove_account(
+    State(state): State<Arc<AppState>>,
+    auth: AuthUser,
+) -> ApiResult<AppleAccountResponse> {
+    auth.require_owner()?;
+    let mut transaction = state.db.begin().await.map_err(store_error)?;
+    sqlx::query("DELETE FROM apple_account WHERE id = 1")
+        .execute(&mut *transaction)
+        .await
+        .map_err(store_error)?;
+    sqlx::query(
+        "UPDATE apple_account_operations
+         SET private_key_encrypted = '', status = 'failed',
+             error_code = 'account_removed', error_message = 'The Apple account was removed',
+             updated_at = ?1
+         WHERE status IN ('queued', 'claimed', 'running')",
+    )
+    .bind(now_unix())
+    .execute(&mut *transaction)
+    .await
+    .map_err(store_error)?;
+    transaction.commit().await.map_err(store_error)?;
+    let _ = write_audit_log(
+        &state.db,
+        Some(&auth.0.user_id),
+        "apple_account_removed",
+        "apple_account",
+        Some("1"),
+        None,
+    )
+    .await;
+    Ok(Json(AppleAccountResponse {
+        connected: false,
+        key_id: None,
+        apps: Vec::new(),
+        selected_app_id: None,
+    }))
+}
+
+pub async fn claim_operation(
+    State(state): State<Arc<AppState>>,
+    Path(runner_id): Path<String>,
+    auth: RunnerAuth,
+    Json(request): Json<ClaimComponentOperationRequest>,
+) -> ApiResult<ClaimComponentOperationResponse> {
+    require_runner(&auth, &runner_id)?;
+    if request.protocol_version != RUNNER_PROTOCOL_VERSION {
+        return Err(api_err(
+            StatusCode::CONFLICT,
+            "runner_protocol_mismatch",
+            "The runner protocol is not supported",
+        ));
+    }
+    if request.target_os != "macos"
+        || apple_component_release_for_target_arch(&request.target_arch).is_none()
+    {
+        return Ok(Json(ClaimComponentOperationResponse { operation: None }));
+    }
+    let now = now_unix();
+    let mut transaction = state.db.begin().await.map_err(store_error)?;
+    sqlx::query(
+        "UPDATE apple_account_operations
+         SET status = 'queued', runner_id = NULL, job_lock_digest = NULL,
+             lease_id = NULL, receipt_id = NULL, lease_expires_at = NULL,
+             updated_at = ?1
+         WHERE status IN ('claimed', 'running') AND lease_expires_at <= ?1",
+    )
+    .bind(now)
+    .execute(&mut *transaction)
+    .await
+    .map_err(store_error)?;
+    let row = sqlx::query(
+        "SELECT id, key_id, issuer_id, fencing_token
+         FROM apple_account_operations
+         WHERE status = 'queued'
+         ORDER BY created_at, id LIMIT 1",
+    )
+    .fetch_optional(&mut *transaction)
+    .await
+    .map_err(store_error)?;
+    let Some(row) = row else {
+        transaction.commit().await.map_err(store_error)?;
+        return Ok(Json(ClaimComponentOperationResponse { operation: None }));
+    };
+    let operation_id: String = row.get("id");
+    let fencing_token = row.get::<i64, _>("fencing_token").saturating_add(1);
+    let lease_id = format!("apple-lease-{}", Uuid::new_v4());
+    let receipt_id = format!("apple-receipt-{}", Uuid::new_v4());
+    let lease_expires_at = now.saturating_add(OPERATION_LEASE_SECONDS);
+    let job_lock_digest = digest_fields(&[
+        operation_id.as_bytes(),
+        runner_id.as_bytes(),
+        lease_id.as_bytes(),
+        &fencing_token.to_be_bytes(),
+    ]);
+    let updated = sqlx::query(
+        "UPDATE apple_account_operations
+         SET status = 'claimed', runner_id = ?1, job_lock_digest = ?2,
+             lease_id = ?3, receipt_id = ?4, fencing_token = ?5,
+             lease_expires_at = ?6, updated_at = ?7
+         WHERE id = ?8 AND status = 'queued'",
+    )
+    .bind(&runner_id)
+    .bind(&job_lock_digest)
+    .bind(&lease_id)
+    .bind(&receipt_id)
+    .bind(fencing_token)
+    .bind(lease_expires_at)
+    .bind(now)
+    .bind(&operation_id)
+    .execute(&mut *transaction)
+    .await
+    .map_err(store_error)?;
+    if updated.rows_affected() != 1 {
+        transaction.rollback().await.map_err(store_error)?;
+        return Ok(Json(ClaimComponentOperationResponse { operation: None }));
+    }
+    transaction.commit().await.map_err(store_error)?;
+    Ok(Json(ClaimComponentOperationResponse {
+        operation: Some(ClaimedAppleComponentOperation {
+            operation_id,
+            key_id: row.get("key_id"),
+            issuer_id: row.get("issuer_id"),
+            job_lock_digest,
+            lease_id,
+            receipt_id,
+            fencing_token,
+            lease_expires_at,
+        }),
+    }))
+}
+
+pub async fn activate_operation(
+    State(state): State<Arc<AppState>>,
+    Path((runner_id, operation_id)): Path<(String, String)>,
+    auth: RunnerAuth,
+    Json(request): Json<ActivateComponentOperationRequest>,
+) -> ApiResult<ActivateComponentOperationResponse> {
+    require_runner(&auth, &runner_id)?;
+    let component = validate_component_identity(&request.component)?;
+    let now = now_unix();
+    let row = sqlx::query(
+        "SELECT private_key_encrypted, job_lock_digest, fencing_token, lease_expires_at
+         FROM apple_account_operations
+         WHERE id = ?1 AND runner_id = ?2 AND status = 'claimed' AND lease_expires_at > ?3",
+    )
+    .bind(&operation_id)
+    .bind(&runner_id)
+    .bind(now)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(store_error)?
+    .ok_or_else(|| {
+        api_err(
+            StatusCode::NOT_FOUND,
+            "component_operation_unavailable",
+            "The Apple operation is unavailable",
+        )
+    })?;
+    let job_lock_digest: String = row.get("job_lock_digest");
+    let fencing_token: i64 = row.get("fencing_token");
+    let operation_expires_at: i64 = row.get("lease_expires_at");
+    let credential_expires_at =
+        operation_expires_at.min(now.saturating_add(CREDENTIAL_LEASE_SECONDS));
+    let authority = CredentialAuthorityBinding {
+        operation_id: operation_id.clone(),
+        runner_id: runner_id.clone(),
+        component_identity_digest: component.identity_digest.clone(),
+        capability_id: APPLE_COMPONENT_CAPABILITY.into(),
+        job_lock_digest,
+        fencing_token,
+    };
+    credential_broker::activate_authority(&state.db, &authority, now, operation_expires_at)
+        .await
+        .map_err(map_grant_error)?;
+    let private_key = Zeroizing::new(
+        crate::crypto::decrypt(
+            &row.get::<String, _>("private_key_encrypted"),
+            &state.encryption_key,
+        )
+        .map_err(|_| internal_error("apple_key_unavailable", "The Apple key is unavailable"))?,
+    );
+    let grant = credential_broker::issue(
+        &state.db,
+        &state.encryption_key,
+        &CredentialGrantBinding {
+            authority,
+            secret_kind: APPLE_COMPONENT_SECRET_KIND.into(),
+        },
+        private_key.as_bytes(),
+        now,
+        credential_expires_at,
+    )
+    .await
+    .map_err(map_grant_error)?;
+    let updated = sqlx::query(
+        "UPDATE apple_account_operations
+         SET status = 'running', component_identity_digest = ?1,
+             component_target_arch = ?2, updated_at = ?3
+         WHERE id = ?4 AND runner_id = ?5 AND status = 'claimed'",
+    )
+    .bind(&component.identity_digest)
+    .bind(&component.target_arch)
+    .bind(now)
+    .bind(&operation_id)
+    .bind(&runner_id)
+    .execute(&state.db)
+    .await
+    .map_err(store_error)?;
+    if updated.rows_affected() != 1 {
+        return Err(api_err(
+            StatusCode::CONFLICT,
+            "component_operation_changed",
+            "The Apple operation changed",
+        ));
+    }
+    Ok(Json(ActivateComponentOperationResponse {
+        credential_grant: grant.handle.as_str().to_owned(),
+        credential_expires_at: grant.expires_at,
+    }))
+}
+
+pub async fn complete_operation(
+    State(state): State<Arc<AppState>>,
+    Path((runner_id, operation_id)): Path<(String, String)>,
+    auth: RunnerAuth,
+    Json(request): Json<CompleteComponentOperationRequest>,
+) -> ApiResult<AppleAccountOperationResponse> {
+    require_runner(&auth, &runner_id)?;
+    let now = now_unix();
+    let row = sqlx::query(
+        "SELECT requested_by, key_id, issuer_id, private_key_encrypted,
+                job_lock_digest, lease_id, receipt_id, fencing_token,
+                component_identity_digest
+         FROM apple_account_operations
+         WHERE id = ?1 AND runner_id = ?2 AND status = 'running'
+           AND lease_expires_at > ?3",
+    )
+    .bind(&operation_id)
+    .bind(&runner_id)
+    .bind(now)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(store_error)?
+    .ok_or_else(|| {
+        api_err(
+            StatusCode::NOT_FOUND,
+            "component_operation_unavailable",
+            "The Apple operation is unavailable",
+        )
+    })?;
+    let CompleteComponentOperationRequest {
+        component_identity_digest,
+        job_lock_digest,
+        lease_id,
+        receipt_id,
+        fencing_token,
+        result,
+        error_code,
+        error_message,
+    } = request;
+    if component_identity_digest != row.get::<String, _>("component_identity_digest")
+        || job_lock_digest != row.get::<String, _>("job_lock_digest")
+        || lease_id != row.get::<String, _>("lease_id")
+        || receipt_id != row.get::<String, _>("receipt_id")
+        || fencing_token != row.get::<i64, _>("fencing_token")
+    {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "component_completion_binding_invalid",
+            "The Apple component completion binding is invalid",
+        ));
+    }
+    let success = result.is_some() && error_code.is_none();
+    let apps = if success {
+        let result: AppleAppsResult =
+            serde_json::from_value(result.unwrap_or_default()).map_err(|_| {
+                api_err(
+                    StatusCode::BAD_REQUEST,
+                    "component_result_invalid",
+                    "The Apple component result is invalid",
+                )
+            })?;
+        let _ = result.rate_limit;
+        validate_apps(result.apps)?
+    } else {
+        Vec::new()
+    };
+    let mut transaction = state.db.begin().await.map_err(store_error)?;
+    if success {
+        let apps_json = serde_json::to_string(&apps).map_err(|_| {
+            internal_error(
+                "apple_apps_encode_failed",
+                "The Apple apps could not be saved",
+            )
+        })?;
+        let completed = sqlx::query(
+            "UPDATE apple_account_operations
+             SET status = 'succeeded', private_key_encrypted = '', result_json = ?1,
+                 error_code = NULL, error_message = NULL, updated_at = ?2
+             WHERE id = ?3 AND runner_id = ?4 AND status = 'running'",
+        )
+        .bind(&apps_json)
+        .bind(now)
+        .bind(&operation_id)
+        .bind(&runner_id)
+        .execute(&mut *transaction)
+        .await
+        .map_err(store_error)?;
+        if completed.rows_affected() != 1 {
+            transaction.rollback().await.map_err(store_error)?;
+            return Err(api_err(
+                StatusCode::CONFLICT,
+                "component_operation_changed",
+                "The Apple operation changed",
+            ));
+        }
+        sqlx::query(
+            "INSERT INTO apple_account (
+                id, key_id, issuer_id, private_key_encrypted, apps_json,
+                selected_app_id, connected_by, created_at, updated_at
+             ) VALUES (1, ?1, ?2, ?3, ?4, NULL, ?5, ?6, ?6)
+             ON CONFLICT(id) DO UPDATE SET
+                key_id = excluded.key_id,
+                issuer_id = excluded.issuer_id,
+                private_key_encrypted = excluded.private_key_encrypted,
+                apps_json = excluded.apps_json,
+                selected_app_id = NULL,
+                connected_by = excluded.connected_by,
+                updated_at = excluded.updated_at",
+        )
+        .bind(row.get::<String, _>("key_id"))
+        .bind(row.get::<String, _>("issuer_id"))
+        .bind(row.get::<String, _>("private_key_encrypted"))
+        .bind(&apps_json)
+        .bind(row.get::<String, _>("requested_by"))
+        .bind(now)
+        .execute(&mut *transaction)
+        .await
+        .map_err(store_error)?;
+    } else {
+        let error_code = safe_error(error_code.as_deref(), "apple_check_failed");
+        let error_message = safe_error(error_message.as_deref(), "Apple could not verify this key");
+        let completed = sqlx::query(
+            "UPDATE apple_account_operations
+             SET status = 'failed', private_key_encrypted = '', result_json = NULL,
+                 error_code = ?1, error_message = ?2, updated_at = ?3
+             WHERE id = ?4 AND runner_id = ?5 AND status = 'running'",
+        )
+        .bind(&error_code)
+        .bind(&error_message)
+        .bind(now)
+        .bind(&operation_id)
+        .bind(&runner_id)
+        .execute(&mut *transaction)
+        .await
+        .map_err(store_error)?;
+        if completed.rows_affected() != 1 {
+            transaction.rollback().await.map_err(store_error)?;
+            return Err(api_err(
+                StatusCode::CONFLICT,
+                "component_operation_changed",
+                "The Apple operation changed",
+            ));
+        }
+    }
+    transaction.commit().await.map_err(store_error)?;
+    let authority = CredentialAuthorityBinding {
+        operation_id: operation_id.clone(),
+        runner_id,
+        component_identity_digest,
+        capability_id: APPLE_COMPONENT_CAPABILITY.into(),
+        job_lock_digest,
+        fencing_token,
+    };
+    let _ = credential_broker::revoke_authority(&state.db, &authority, now).await;
+    Ok(Json(AppleAccountOperationResponse {
+        operation_id,
+        status: if success {
+            AppleAccountOperationStatus::Succeeded
+        } else {
+            AppleAccountOperationStatus::Failed
+        },
+        apps,
+        error_code: if success {
+            None
+        } else {
+            Some(safe_error(error_code.as_deref(), "apple_check_failed"))
+        },
+        error_message: if success {
+            None
+        } else {
+            Some(safe_error(
+                error_message.as_deref(),
+                "Apple could not verify this key",
+            ))
+        },
+    }))
+}
+
+fn validate_component_identity(
+    claim: &oore_contract::ComponentIdentityClaim,
+) -> Result<ComponentIdentity, (StatusCode, Json<oore_contract::ApiError>)> {
+    let expected = expected_identity(&claim.target_arch)?;
+    if claim.component_id != expected.component_id
+        || claim.component_version != expected.component_version
+        || claim.target_os != expected.target_os
+        || claim.target_arch != expected.target_arch
+        || claim.protocol_major != expected.protocol_major
+        || claim.bundle_digest != expected.bundle_digest
+        || claim.bundle_length != expected.bundle_length
+        || claim.catalog_revision != expected.catalog_revision
+        || claim.release_counter != expected.release_counter
+        || claim.identity_digest != expected.identity_digest
+    {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "component_identity_invalid",
+            "The Apple component identity is invalid",
+        ));
+    }
+    Ok(expected)
+}
+
+fn expected_identity(
+    target_arch: &str,
+) -> Result<ComponentIdentity, (StatusCode, Json<oore_contract::ApiError>)> {
+    let release = apple_component_release_for_target_arch(target_arch).ok_or_else(|| {
+        api_err(
+            StatusCode::BAD_REQUEST,
+            "component_target_invalid",
+            "The Apple component target is invalid",
+        )
+    })?;
+    ComponentIdentity::new(
+        APPLE_COMPONENT_ID,
+        APPLE_COMPONENT_VERSION,
+        "macos",
+        release.target_arch,
+        format!("sha256:{}", release.bundle_sha256),
+        release.bundle_length,
+        1,
+        1,
+    )
+    .map_err(|_| {
+        internal_error(
+            "component_identity_invalid",
+            "The Apple component identity is invalid",
+        )
+    })
+}
+
+fn operation_response(
+    operation_id: &str,
+    row: &sqlx::sqlite::SqliteRow,
+) -> Result<AppleAccountOperationResponse, (StatusCode, Json<oore_contract::ApiError>)> {
+    let status = match row.get::<String, _>("status").as_str() {
+        "queued" => AppleAccountOperationStatus::Queued,
+        "claimed" => AppleAccountOperationStatus::Claimed,
+        "running" => AppleAccountOperationStatus::Running,
+        "succeeded" => AppleAccountOperationStatus::Succeeded,
+        "failed" => AppleAccountOperationStatus::Failed,
+        _ => {
+            return Err(internal_error(
+                "apple_operation_invalid",
+                "The Apple operation has an invalid state",
+            ));
+        }
+    };
+    let result_json: Option<String> = row.get("result_json");
+    Ok(AppleAccountOperationResponse {
+        operation_id: operation_id.into(),
+        status,
+        apps: result_json
+            .as_deref()
+            .map(parse_apps)
+            .transpose()?
+            .unwrap_or_default(),
+        error_code: row.get("error_code"),
+        error_message: row.get("error_message"),
+    })
+}
+
+fn parse_apps(
+    value: &str,
+) -> Result<Vec<AppleAppSummary>, (StatusCode, Json<oore_contract::ApiError>)> {
+    let apps = serde_json::from_str(value)
+        .map_err(|_| internal_error("apple_apps_invalid", "The stored Apple apps are invalid"))?;
+    validate_apps(apps)
+}
+
+fn validate_apps(
+    apps: Vec<AppleAppSummary>,
+) -> Result<Vec<AppleAppSummary>, (StatusCode, Json<oore_contract::ApiError>)> {
+    if apps.len() > MAX_APPS {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "apple_apps_invalid",
+            "The Apple app list is too large",
+        ));
+    }
+    let mut ids = BTreeSet::new();
+    for app in &apps {
+        if !ids.insert(app.id.as_str())
+            || [&app.id, &app.name, &app.bundle_id, &app.sku]
+                .into_iter()
+                .any(|value| value.is_empty() || value.len() > MAX_APP_FIELD_BYTES)
+            || app
+                .primary_locale
+                .as_ref()
+                .is_some_and(|value| value.len() > MAX_APP_FIELD_BYTES)
+        {
+            return Err(api_err(
+                StatusCode::BAD_REQUEST,
+                "apple_apps_invalid",
+                "The Apple app list is invalid",
+            ));
+        }
+    }
+    Ok(apps)
+}
+
+fn validate_private_key(value: &str) -> Result<(), (StatusCode, Json<oore_contract::ApiError>)> {
+    if value.is_empty()
+        || value.len() > MAX_PRIVATE_KEY_BYTES
+        || !value.starts_with("-----BEGIN PRIVATE KEY-----")
+        || !value.trim_end().ends_with("-----END PRIVATE KEY-----")
+    {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "apple_key_invalid",
+            "Choose the p8 key downloaded from App Store Connect",
+        ));
+    }
+    Ok(())
+}
+
+fn bounded_trimmed(
+    value: &str,
+    maximum: usize,
+    field: &str,
+) -> Result<String, (StatusCode, Json<oore_contract::ApiError>)> {
+    let value = value.trim();
+    if value.is_empty()
+        || value.len() > maximum
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+    {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "apple_account_invalid",
+            format!("The Apple {field} is invalid"),
+        ));
+    }
+    Ok(value.into())
+}
+
+fn require_runner(
+    auth: &RunnerAuth,
+    runner_id: &str,
+) -> Result<(), (StatusCode, Json<oore_contract::ApiError>)> {
+    if auth.runner_id != runner_id {
+        return Err(api_err(
+            StatusCode::FORBIDDEN,
+            "runner_mismatch",
+            "The runner token does not match",
+        ));
+    }
+    Ok(())
+}
+
+fn digest_fields(fields: &[&[u8]]) -> String {
+    let mut hasher = Sha256::new();
+    for field in fields {
+        hasher.update((field.len() as u64).to_be_bytes());
+        hasher.update(field);
+    }
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+fn safe_error(value: Option<&str>, fallback: &str) -> String {
+    value
+        .filter(|value| {
+            !value.is_empty() && value.len() <= 512 && !value.chars().any(char::is_control)
+        })
+        .unwrap_or(fallback)
+        .to_owned()
+}
+
+fn map_grant_error(error: CredentialGrantError) -> (StatusCode, Json<oore_contract::ApiError>) {
+    match error {
+        CredentialGrantError::InvalidRequest => api_err(
+            StatusCode::BAD_REQUEST,
+            "credential_grant_invalid",
+            "The Apple credential grant is invalid",
+        ),
+        CredentialGrantError::Unavailable => api_err(
+            StatusCode::CONFLICT,
+            "credential_grant_unavailable",
+            "The Apple credential grant is unavailable",
+        ),
+        CredentialGrantError::Store | CredentialGrantError::Crypto => internal_error(
+            "credential_grant_failed",
+            "The Apple credential grant could not be created",
+        ),
+    }
+}
+
+fn store_error(error: sqlx::Error) -> (StatusCode, Json<oore_contract::ApiError>) {
+    tracing::error!(error = %error, "Apple account store operation failed");
+    internal_error("store_error", "The Apple account could not be updated")
+}
+
+fn internal_error(
+    code: &'static str,
+    message: impl Into<String>,
+) -> (StatusCode, Json<oore_contract::ApiError>) {
+    api_err(StatusCode::INTERNAL_SERVER_ERROR, code, message)
+}

--- a/crates/oored/src/bin/openapi_export.rs
+++ b/crates/oored/src/bin/openapi_export.rs
@@ -134,6 +134,12 @@ use utoipa::{
         paths::sync_pipeline_ios_signing,
         paths::list_pipeline_ios_devices,
         paths::register_pipeline_ios_device,
+        // ── Apple Account ──
+        paths::get_apple_account,
+        paths::connect_apple_account,
+        paths::get_apple_account_operation,
+        paths::select_apple_app,
+        paths::remove_apple_account,
         // ── Builds ──
         paths::create_build,
         paths::preview_build_changelog,
@@ -326,6 +332,13 @@ use utoipa::{
         oore_contract::RegisterIosDeviceRequest,
         oore_contract::RegisterIosDeviceResponse,
         oore_contract::SyncPipelineIosSigningResponse,
+        // Apple Account
+        oore_contract::AppleAppSummary,
+        oore_contract::ConnectAppleAccountRequest,
+        oore_contract::AppleAccountOperationStatus,
+        oore_contract::AppleAccountOperationResponse,
+        oore_contract::AppleAccountResponse,
+        oore_contract::SelectAppleAppRequest,
         // Builds
         oore_contract::BuildStatus,
         oore_contract::RunnerPolicyBlockReason,
@@ -460,6 +473,7 @@ use utoipa::{
         (name = "Project Members", description = "Per-project role assignments for granular RBAC."),
         (name = "Pipelines", description = "Pipeline configuration — build platforms, commands, triggers, concurrency."),
         (name = "Pipeline Signing", description = "Code signing configuration — Android keystores, iOS certificates/profiles."),
+        (name = "Apple Account", description = "Connect an App Store Connect Team API key and choose an app."),
         (name = "Builds", description = "Build lifecycle — queue, list, detail, cancel."),
         (name = "Runners", description = "Build runner management — register, heartbeat, job claim/status."),
         (name = "Build Logs", description = "Build log ingestion and retrieval — append, paginated fetch, SSE streaming."),
@@ -1788,6 +1802,68 @@ mod paths {
         )
     )]
     pub(super) async fn register_pipeline_ios_device() {}
+
+    // ── Apple Account ──
+
+    /// Get the connected Apple account
+    #[utoipa::path(get, path = "/v1/apple/account", tag = "Apple Account",
+        security(("bearer_auth" = [])),
+        responses(
+            (status = 200, description = "Apple account state", body = AppleAccountResponse),
+            (status = 403, description = "Owner access required", body = ApiError),
+        )
+    )]
+    pub(super) async fn get_apple_account() {}
+
+    /// Connect an App Store Connect Team API key
+    ///
+    /// Queues a check on a macOS runner. The private key remains encrypted until use.
+    #[utoipa::path(post, path = "/v1/apple/account/connect", tag = "Apple Account",
+        request_body = ConnectAppleAccountRequest,
+        security(("bearer_auth" = [])),
+        responses(
+            (status = 200, description = "Apple account check queued", body = AppleAccountOperationResponse),
+            (status = 400, description = "Invalid key details", body = ApiError),
+            (status = 403, description = "Owner access required", body = ApiError),
+            (status = 409, description = "Another check is active", body = ApiError),
+        )
+    )]
+    pub(super) async fn connect_apple_account() {}
+
+    /// Get an Apple account check
+    #[utoipa::path(get, path = "/v1/apple/account/operations/{operation_id}", tag = "Apple Account",
+        params(("operation_id" = String, Path, description = "Operation ID")),
+        security(("bearer_auth" = [])),
+        responses(
+            (status = 200, description = "Apple account check state", body = AppleAccountOperationResponse),
+            (status = 403, description = "Owner access required", body = ApiError),
+            (status = 404, description = "Operation not found", body = ApiError),
+        )
+    )]
+    pub(super) async fn get_apple_account_operation() {}
+
+    /// Choose an app from the connected Apple account
+    #[utoipa::path(put, path = "/v1/apple/account/selection", tag = "Apple Account",
+        request_body = SelectAppleAppRequest,
+        security(("bearer_auth" = [])),
+        responses(
+            (status = 200, description = "Selected Apple app", body = AppleAccountResponse),
+            (status = 400, description = "App is not in the connected account", body = ApiError),
+            (status = 403, description = "Owner access required", body = ApiError),
+            (status = 404, description = "Apple account not connected", body = ApiError),
+        )
+    )]
+    pub(super) async fn select_apple_app() {}
+
+    /// Remove the connected Apple account
+    #[utoipa::path(delete, path = "/v1/apple/account", tag = "Apple Account",
+        security(("bearer_auth" = [])),
+        responses(
+            (status = 200, description = "Apple account removed", body = AppleAccountResponse),
+            (status = 403, description = "Owner access required", body = ApiError),
+        )
+    )]
+    pub(super) async fn remove_apple_account() {}
 
     // ── Builds ──
 

--- a/crates/oored/src/lib.rs
+++ b/crates/oored/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api_tokens;
+pub mod apple_accounts;
 pub mod apple_api;
 pub mod artifact_install;
 pub mod artifact_tokens;
@@ -2563,6 +2564,23 @@ async fn build_router_inner(
             "/v1/api-tokens/{token_id}",
             axum::routing::delete(api_tokens::revoke_api_token_handler),
         )
+        // Apple account endpoints
+        .route(
+            "/v1/apple/account",
+            get(apple_accounts::get_account).delete(apple_accounts::remove_account),
+        )
+        .route(
+            "/v1/apple/account/connect",
+            post(apple_accounts::connect_account).layer(DefaultBodyLimit::max(96 * 1024)),
+        )
+        .route(
+            "/v1/apple/account/operations/{operation_id}",
+            get(apple_accounts::get_operation),
+        )
+        .route(
+            "/v1/apple/account/selection",
+            axum::routing::put(apple_accounts::select_app),
+        )
         // Runner endpoints
         .route("/v1/runners/register", post(runners::register_runner))
         .route(
@@ -2574,6 +2592,18 @@ async fn build_router_inner(
             post(runners::runner_heartbeat),
         )
         .route("/v1/runners/{runner_id}/claim", post(runners::claim_job))
+        .route(
+            "/v1/runners/{runner_id}/component-operations/claim",
+            post(apple_accounts::claim_operation),
+        )
+        .route(
+            "/v1/runners/{runner_id}/component-operations/{operation_id}/activate",
+            post(apple_accounts::activate_operation),
+        )
+        .route(
+            "/v1/runners/{runner_id}/component-operations/{operation_id}/complete",
+            post(apple_accounts::complete_operation),
+        )
         .route(
             "/v1/runners/{runner_id}/component-credentials/consume",
             post(runners::consume_component_credential_grant),


### PR DESCRIPTION
## What changed

- adds the owner-only Apple account API
- encrypts the App Store Connect private key at rest
- queues app discovery on a macOS runner
- installs the pinned Apple component only when needed
- binds each credential use to one runner operation and exact component identity
- stores verified apps and lets the owner choose one
- adds audit records and OpenAPI documentation

## Checks

- cargo fmt --all -- --check
- git diff --check
- cargo clippy -p oore-contract -p oore-runner -p oored --offline -- -D warnings
- make gen-openapi
- disposable SQLite migration smoke

No automated tests were added or run. Product tests wait until the v0.2.0 milestone, as required by the repository rules.
