### PR TITLE
feat(web): add guided Apple account setup

### DIFF
--- a/apps/web/src/components/settings/settings-navigation.ts
+++ b/apps/web/src/components/settings/settings-navigation.ts
@@ -1,5 +1,6 @@
 import {
   Archive02Icon,
+  AppleIcon,
   Audit01Icon,
   CpuIcon,
   Delete02Icon,
@@ -14,6 +15,7 @@ import type { UserRole } from '@/lib/types'
 
 const ADMIN_ROLES: ReadonlyArray<UserRole> = ['owner', 'admin']
 const OPERATOR_ROLES: ReadonlyArray<UserRole> = ['owner', 'admin', 'developer']
+const OWNER_ROLES: ReadonlyArray<UserRole> = ['owner']
 
 const SETTINGS_GROUPS = [
   {
@@ -78,6 +80,13 @@ const SETTINGS_GROUPS = [
   {
     title: 'Delivery',
     items: [
+      {
+        title: 'Apple account',
+        description: 'App Store Connect access and app selection.',
+        to: '/settings/apple',
+        icon: AppleIcon,
+        roles: OWNER_ROLES,
+      },
       {
         title: 'Notifications',
         description: 'Build and system notification channels.',

--- a/apps/web/src/hooks/use-apple-account.ts
+++ b/apps/web/src/hooks/use-apple-account.ts
@@ -1,0 +1,85 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { useApiContext } from '@/hooks/use-api-context'
+import {
+  getAppleAccount,
+  getAppleAccountOperation,
+  removeAppleAccount,
+  selectAppleApp,
+} from '@/lib/api'
+import type { SelectAppleAppRequest } from '@/lib/types'
+
+function accountKey(instanceId: string | undefined) {
+  return [instanceId ?? '__none__', 'apple-account'] as const
+}
+
+export function useAppleAccount() {
+  const { baseUrl, instance, token } = useApiContext()
+
+  return useQuery({
+    queryKey: accountKey(instance?.id),
+    queryFn: ({ signal }) => getAppleAccount(baseUrl!, token!, { signal }),
+    enabled: !!baseUrl && !!token,
+  })
+}
+
+export function useAppleAccountOperation(operationId: string | null) {
+  const { baseUrl, instance, token } = useApiContext()
+
+  return useQuery({
+    queryKey: [
+      instance?.id ?? '__none__',
+      'apple-account-operation',
+      operationId,
+    ],
+    queryFn: ({ signal }) =>
+      getAppleAccountOperation(baseUrl!, token!, operationId!, { signal }),
+    enabled: !!baseUrl && !!token && !!operationId,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status
+      return status === 'succeeded' || status === 'failed' ? false : 2_000
+    },
+  })
+}
+
+export function useSelectAppleApp() {
+  const queryClient = useQueryClient()
+  const { baseUrl, instance, token } = useApiContext()
+
+  return useMutation({
+    mutationFn: (data: SelectAppleAppRequest) => {
+      if (!baseUrl || !token) {
+        return Promise.reject(new Error('Not authenticated'))
+      }
+      return selectAppleApp(baseUrl, token, data)
+    },
+    onSuccess: (account) => {
+      queryClient.setQueryData(accountKey(instance?.id), account)
+    },
+  })
+}
+
+export function useRemoveAppleAccount() {
+  const queryClient = useQueryClient()
+  const { baseUrl, instance, token } = useApiContext()
+
+  return useMutation({
+    mutationFn: () => {
+      if (!baseUrl || !token) {
+        return Promise.reject(new Error('Not authenticated'))
+      }
+      return removeAppleAccount(baseUrl, token)
+    },
+    onSuccess: (account) => {
+      queryClient.setQueryData(accountKey(instance?.id), account)
+    },
+  })
+}
+
+export function useRefreshAppleAccount() {
+  const queryClient = useQueryClient()
+  const { instance } = useApiContext()
+
+  return () =>
+    queryClient.invalidateQueries({ queryKey: accountKey(instance?.id) })
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,5 +1,7 @@
 import type {
   ApiError,
+  AppleAccountOperationResponse,
+  AppleAccountResponse,
   ArtifactDownloadLinkResponse,
   ArtifactInstallLinkResponse,
   ArtifactStorageSettingsResponse,
@@ -13,6 +15,7 @@ import type {
   BuildLogsResponse,
   CancelBuildResponse,
   ConfigureExternalAccessOidcRequest,
+  ConnectAppleAccountRequest,
   ConfigureExternalAccessOidcResponse,
   CreateApiTokenRequest,
   CreateApiTokenResponse,
@@ -86,6 +89,7 @@ import type {
   SetupTrustedProxyClaimOwnerResponse,
   SetupTrustedProxyConfigureRequest,
   SetupTrustedProxyConfigureResponse,
+  SelectAppleAppRequest,
   SyncInstallationsResponse,
   SyncPipelineIosSigningResponse,
   TestNotificationChannelResponse,
@@ -1762,6 +1766,73 @@ export function revokeApiToken(
   tokenId: string,
 ): Promise<RevokeApiTokenResponse> {
   return request<RevokeApiTokenResponse>(baseUrl, `/v1/api-tokens/${tokenId}`, {
+    method: 'DELETE',
+    headers: authHeaders(token),
+  })
+}
+
+// ── Apple account ──────────────────────────────────────────────
+
+export function getAppleAccount(
+  baseUrl: string,
+  token: string,
+  options?: RequestOptions,
+): Promise<AppleAccountResponse> {
+  return request<AppleAccountResponse>(baseUrl, '/v1/apple/account', {
+    headers: authHeaders(token),
+    signal: options?.signal,
+  })
+}
+
+export function connectAppleAccount(
+  baseUrl: string,
+  token: string,
+  data: ConnectAppleAccountRequest,
+): Promise<AppleAccountOperationResponse> {
+  return request<AppleAccountOperationResponse>(
+    baseUrl,
+    '/v1/apple/account/connect',
+    {
+      method: 'POST',
+      headers: authHeaders(token),
+      body: JSON.stringify(data),
+    },
+  )
+}
+
+export function getAppleAccountOperation(
+  baseUrl: string,
+  token: string,
+  operationId: string,
+  options?: RequestOptions,
+): Promise<AppleAccountOperationResponse> {
+  return request<AppleAccountOperationResponse>(
+    baseUrl,
+    `/v1/apple/account/operations/${encodeURIComponent(operationId)}`,
+    {
+      headers: authHeaders(token),
+      signal: options?.signal,
+    },
+  )
+}
+
+export function selectAppleApp(
+  baseUrl: string,
+  token: string,
+  data: SelectAppleAppRequest,
+): Promise<AppleAccountResponse> {
+  return request<AppleAccountResponse>(baseUrl, '/v1/apple/account/selection', {
+    method: 'PUT',
+    headers: authHeaders(token),
+    body: JSON.stringify(data),
+  })
+}
+
+export function removeAppleAccount(
+  baseUrl: string,
+  token: string,
+): Promise<AppleAccountResponse> {
+  return request<AppleAccountResponse>(baseUrl, '/v1/apple/account', {
     method: 'DELETE',
     headers: authHeaders(token),
   })

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -1242,3 +1242,45 @@ export interface ListApiTokensResponse {
 export interface RevokeApiTokenResponse {
   revoked: boolean
 }
+
+// ── Apple account ──────────────────────────────────────────────
+
+export interface AppleAppSummary {
+  id: string
+  name: string
+  bundleId: string
+  sku: string
+  primaryLocale?: string
+}
+
+export type AppleAccountOperationStatus =
+  | 'queued'
+  | 'claimed'
+  | 'running'
+  | 'succeeded'
+  | 'failed'
+
+export interface AppleAccountOperationResponse {
+  operationId: string
+  status: AppleAccountOperationStatus
+  apps: Array<AppleAppSummary>
+  errorCode?: string
+  errorMessage?: string
+}
+
+export interface AppleAccountResponse {
+  connected: boolean
+  keyId?: string
+  apps: Array<AppleAppSummary>
+  selectedAppId?: string
+}
+
+export interface ConnectAppleAccountRequest {
+  keyId: string
+  issuerId: string
+  privateKeyPem: string
+}
+
+export interface SelectAppleAppRequest {
+  appId: string
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -22,6 +22,7 @@ import { Route as ProjectsIndexRouteImport } from './routes/projects/index'
 import { Route as ProjectsProjectIdRouteRouteImport } from './routes/projects/$projectId/route'
 import { Route as SettingsIndexRouteImport } from './routes/settings/index'
 import { Route as SettingsApiTokensRouteImport } from './routes/settings/api-tokens'
+import { Route as SettingsAppleRouteImport } from './routes/settings/apple'
 import { Route as SettingsArtifactsRouteImport } from './routes/settings/artifacts'
 import { Route as SettingsAuditLogRouteImport } from './routes/settings/audit-log'
 import { Route as SettingsIntegrationsRouteRouteImport } from './routes/settings/integrations/route'
@@ -117,6 +118,11 @@ const SettingsApiTokensRoute = SettingsApiTokensRouteImport.update({
 } as any).lazy(() =>
   import('./routes/settings/api-tokens.lazy').then((d) => d.Route),
 )
+const SettingsAppleRoute = SettingsAppleRouteImport.update({
+  id: '/apple',
+  path: '/apple',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
 const SettingsArtifactsRoute = SettingsArtifactsRouteImport.update({
   id: '/artifacts',
   path: '/artifacts',
@@ -294,6 +300,7 @@ export interface FileRoutesByFullPath {
   '/auth/callback': typeof AuthCallbackRoute
   '/builds/$buildId': typeof BuildsBuildIdRoute
   '/settings/api-tokens': typeof SettingsApiTokensRoute
+  '/settings/apple': typeof SettingsAppleRoute
   '/settings/artifacts': typeof SettingsArtifactsRoute
   '/settings/audit-log': typeof SettingsAuditLogRoute
   '/settings/preferences': typeof SettingsPreferencesRoute
@@ -329,6 +336,7 @@ export interface FileRoutesByTo {
   '/auth/callback': typeof AuthCallbackRoute
   '/builds/$buildId': typeof BuildsBuildIdRoute
   '/settings/api-tokens': typeof SettingsApiTokensRoute
+  '/settings/apple': typeof SettingsAppleRoute
   '/settings/artifacts': typeof SettingsArtifactsRoute
   '/settings/audit-log': typeof SettingsAuditLogRoute
   '/settings/preferences': typeof SettingsPreferencesRoute
@@ -371,6 +379,7 @@ export interface FileRoutesById {
   '/auth/callback': typeof AuthCallbackRoute
   '/builds/$buildId': typeof BuildsBuildIdRoute
   '/settings/api-tokens': typeof SettingsApiTokensRoute
+  '/settings/apple': typeof SettingsAppleRoute
   '/settings/artifacts': typeof SettingsArtifactsRoute
   '/settings/audit-log': typeof SettingsAuditLogRoute
   '/settings/preferences': typeof SettingsPreferencesRoute
@@ -415,6 +424,7 @@ export interface FileRouteTypes {
     | '/auth/callback'
     | '/builds/$buildId'
     | '/settings/api-tokens'
+    | '/settings/apple'
     | '/settings/artifacts'
     | '/settings/audit-log'
     | '/settings/preferences'
@@ -450,6 +460,7 @@ export interface FileRouteTypes {
     | '/auth/callback'
     | '/builds/$buildId'
     | '/settings/api-tokens'
+    | '/settings/apple'
     | '/settings/artifacts'
     | '/settings/audit-log'
     | '/settings/preferences'
@@ -491,6 +502,7 @@ export interface FileRouteTypes {
     | '/auth/callback'
     | '/builds/$buildId'
     | '/settings/api-tokens'
+    | '/settings/apple'
     | '/settings/artifacts'
     | '/settings/audit-log'
     | '/settings/preferences'
@@ -622,6 +634,13 @@ declare module '@tanstack/react-router' {
       path: '/api-tokens'
       fullPath: '/settings/api-tokens'
       preLoaderRoute: typeof SettingsApiTokensRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/apple': {
+      id: '/settings/apple'
+      path: '/apple'
+      fullPath: '/settings/apple'
+      preLoaderRoute: typeof SettingsAppleRouteImport
       parentRoute: typeof SettingsRouteRoute
     }
     '/settings/artifacts': {
@@ -926,6 +945,7 @@ interface SettingsRouteRouteChildren {
   SettingsIntegrationsRouteRoute: typeof SettingsIntegrationsRouteRouteWithChildren
   SettingsNotificationsRouteRoute: typeof SettingsNotificationsRouteRouteWithChildren
   SettingsApiTokensRoute: typeof SettingsApiTokensRoute
+  SettingsAppleRoute: typeof SettingsAppleRoute
   SettingsArtifactsRoute: typeof SettingsArtifactsRoute
   SettingsAuditLogRoute: typeof SettingsAuditLogRoute
   SettingsPreferencesRoute: typeof SettingsPreferencesRoute
@@ -939,6 +959,7 @@ const SettingsRouteRouteChildren: SettingsRouteRouteChildren = {
   SettingsIntegrationsRouteRoute: SettingsIntegrationsRouteRouteWithChildren,
   SettingsNotificationsRouteRoute: SettingsNotificationsRouteRouteWithChildren,
   SettingsApiTokensRoute: SettingsApiTokensRoute,
+  SettingsAppleRoute: SettingsAppleRoute,
   SettingsArtifactsRoute: SettingsArtifactsRoute,
   SettingsAuditLogRoute: SettingsAuditLogRoute,
   SettingsPreferencesRoute: SettingsPreferencesRoute,

--- a/apps/web/src/routes/settings/apple.tsx
+++ b/apps/web/src/routes/settings/apple.tsx
@@ -1,0 +1,628 @@
+import { useEffect, useMemo, useState } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { HugeiconsIcon } from '@hugeicons/react'
+import {
+  AppleIcon,
+  CheckmarkCircle02Icon,
+  Delete02Icon,
+  Key01Icon,
+  LinkSquare02Icon,
+} from '@hugeicons/core-free-icons'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+
+import PageHeader from '@/components/page-header'
+import PageLayout from '@/components/page-layout'
+import {
+  SettingsSection,
+  SettingsSurface,
+} from '@/components/settings/settings-section'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from '@/components/ui/combobox'
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Spinner } from '@/components/ui/spinner'
+import {
+  useAppleAccount,
+  useAppleAccountOperation,
+  useRemoveAppleAccount,
+  useSelectAppleApp,
+} from '@/hooks/use-apple-account'
+import { useApiContext } from '@/hooks/use-api-context'
+import { connectAppleAccount, getApiErrorMessage } from '@/lib/api'
+import {
+  getActiveInstanceOrRedirect,
+  requireInstanceRoleOrRedirect,
+} from '@/lib/instance-context'
+import { PageMeta } from '@/lib/seo'
+import { toast } from '@/lib/toast'
+import type { AppleAppSummary } from '@/lib/types'
+
+const MAX_KEY_BYTES = 64 * 1024
+
+const appleAccountSchema = z.object({
+  keyId: z
+    .string()
+    .trim()
+    .min(1, 'Enter the key ID.')
+    .max(128, 'The key ID is too long.')
+    .regex(/^[A-Za-z0-9-]+$/, 'Enter the key ID shown by Apple.'),
+  issuerId: z
+    .string()
+    .trim()
+    .min(1, 'Enter the issuer ID.')
+    .max(128, 'The issuer ID is too long.')
+    .regex(/^[A-Za-z0-9-]+$/, 'Enter the issuer ID shown by Apple.'),
+  privateKeyFile: z
+    .custom<File>((value) => value instanceof File, 'Choose the .p8 file.')
+    .refine(
+      (file) => file instanceof File && file.size <= MAX_KEY_BYTES,
+      'The .p8 file is too large.',
+    ),
+})
+
+type AppleAccountFormValues = z.infer<typeof appleAccountSchema>
+
+export const Route = createFileRoute('/settings/apple')({
+  staticData: {
+    breadcrumb: {
+      title: 'Apple account',
+    },
+  },
+  beforeLoad: () => {
+    const instance = getActiveInstanceOrRedirect()
+    requireInstanceRoleOrRedirect(instance.id, ['owner'])
+  },
+  component: AppleAccountPage,
+})
+
+function AppleAccountPage() {
+  const { baseUrl, token } = useApiContext()
+  const accountQuery = useAppleAccount()
+  const [operationId, setOperationId] = useState<string | null>(null)
+  const operationQuery = useAppleAccountOperation(operationId)
+  const selectMutation = useSelectAppleApp()
+  const removeMutation = useRemoveAppleAccount()
+  const [connectPending, setConnectPending] = useState(false)
+  const [connectError, setConnectError] = useState<string | null>(null)
+  const [showReplaceForm, setShowReplaceForm] = useState(false)
+  const account = accountQuery.data
+  const operation = operationQuery.data
+  const refetchAccount = accountQuery.refetch
+
+  useEffect(() => {
+    if (operation?.status === 'succeeded') {
+      void refetchAccount()
+      setShowReplaceForm(false)
+    }
+  }, [operation?.status, refetchAccount])
+
+  const selectedApp = useMemo(
+    () => account?.apps.find((app) => app.id === account.selectedAppId) ?? null,
+    [account],
+  )
+
+  async function handleConnect(values: AppleAccountFormValues) {
+    if (!baseUrl || !token) {
+      setConnectError('Sign in again before you connect Apple.')
+      return false
+    }
+    setConnectPending(true)
+    setConnectError(null)
+    try {
+      const privateKeyPem = await values.privateKeyFile.text()
+      const response = await connectAppleAccount(baseUrl, token, {
+        keyId: values.keyId.trim(),
+        issuerId: values.issuerId.trim(),
+        privateKeyPem,
+      })
+      setOperationId(response.operationId)
+      toast.success('Apple account check started')
+      return true
+    } catch (error) {
+      setConnectError(
+        getApiErrorMessage(error, {
+          apple_account_invalid: 'Check the key ID and issuer ID.',
+          apple_key_invalid: 'Choose the .p8 file downloaded from Apple.',
+          apple_connection_in_progress:
+            'Another Apple account check is already running.',
+        }),
+      )
+      return false
+    } finally {
+      setConnectPending(false)
+    }
+  }
+
+  function handleSelect(app: AppleAppSummary | null) {
+    if (!app || app.id === account?.selectedAppId) return
+    selectMutation.mutate(
+      { appId: app.id },
+      {
+        onSuccess: () => toast.success(`${app.name} selected`),
+        onError: (error) =>
+          toast.error(
+            getApiErrorMessage(error, {
+              apple_app_unknown: 'Apple did not return that app.',
+            }),
+          ),
+      },
+    )
+  }
+
+  function handleRemove() {
+    removeMutation.mutate(undefined, {
+      onSuccess: () => {
+        setOperationId(null)
+        setShowReplaceForm(false)
+        toast.success('Apple account removed')
+      },
+      onError: (error) =>
+        toast.error(getApiErrorMessage(error, { store_error: 'Try again.' })),
+    })
+  }
+
+  return (
+    <PageLayout width="wide">
+      <PageMeta title="Apple account" noindex />
+      <PageHeader
+        title="Apple account"
+        description="Connect App Store Connect once, then let Oore handle Apple release work."
+      />
+
+      {accountQuery.isLoading ? (
+        <AppleAccountSkeleton />
+      ) : accountQuery.error ? (
+        <Alert variant="destructive">
+          <AlertTitle>Apple account could not load</AlertTitle>
+          <AlertDescription className="flex flex-wrap items-center justify-between gap-3">
+            <span>{accountQuery.error.message}</span>
+            <Button
+              variant="outline"
+              onClick={() => void accountQuery.refetch()}
+            >
+              Try again
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ) : account?.connected && !showReplaceForm ? (
+        <ConnectedAppleAccount
+          accountKeyId={account.keyId ?? 'Unknown'}
+          apps={account.apps}
+          removePending={removeMutation.isPending}
+          selectedApp={selectedApp}
+          selectPending={selectMutation.isPending}
+          onRemove={handleRemove}
+          onReplace={() => setShowReplaceForm(true)}
+          onSelect={handleSelect}
+        />
+      ) : (
+        <ConnectAppleAccountForm
+          error={connectError}
+          operation={operation}
+          operationLoading={operationQuery.isFetching}
+          pending={connectPending}
+          replacing={account?.connected === true}
+          onCancel={
+            account?.connected ? () => setShowReplaceForm(false) : undefined
+          }
+          onSubmit={handleConnect}
+        />
+      )}
+    </PageLayout>
+  )
+}
+
+function ConnectAppleAccountForm({
+  error,
+  onCancel,
+  onSubmit,
+  operation,
+  operationLoading,
+  pending,
+  replacing,
+}: {
+  error: string | null
+  onCancel?: () => void
+  onSubmit: (values: AppleAccountFormValues) => Promise<boolean>
+  operation:
+    | {
+        status: 'queued' | 'claimed' | 'running' | 'succeeded' | 'failed'
+        errorMessage?: string
+      }
+    | undefined
+  operationLoading: boolean
+  pending: boolean
+  replacing: boolean
+}) {
+  const form = useForm<AppleAccountFormValues>({
+    resolver: zodResolver(appleAccountSchema),
+    defaultValues: { keyId: '', issuerId: '' },
+    mode: 'onBlur',
+  })
+  const operationActive =
+    operation?.status === 'queued' ||
+    operation?.status === 'claimed' ||
+    operation?.status === 'running'
+  const statusText =
+    operation?.status === 'running'
+      ? 'Oore is checking the key with Apple.'
+      : operation?.status === 'claimed'
+        ? 'The Mac runner is preparing the Apple tool.'
+        : 'Oore is waiting for an available Mac runner.'
+
+  return (
+    <div className="space-y-7">
+      <SettingsSection
+        title={
+          replacing ? 'Replace the Apple key' : 'Connect App Store Connect'
+        }
+        description={
+          replacing
+            ? 'The current key stays active unless this check succeeds.'
+            : 'Oore checks the key before it saves the connection.'
+        }
+      >
+        <SettingsSurface className="space-y-5">
+          <div className="grid gap-4 sm:grid-cols-[auto_1fr]">
+            <div className="flex size-9 items-center justify-center rounded-lg bg-muted">
+              <HugeiconsIcon icon={AppleIcon} aria-hidden />
+            </div>
+            <div className="space-y-3 text-sm">
+              <p className="font-medium">Get these three values from Apple</p>
+              <ol className="list-decimal space-y-2 pl-4 text-muted-foreground">
+                <li>
+                  Open{' '}
+                  <a
+                    href="https://appstoreconnect.apple.com/access/integrations/api"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="font-medium text-foreground underline underline-offset-4"
+                  >
+                    App Store Connect API access
+                    <HugeiconsIcon
+                      icon={LinkSquare02Icon}
+                      className="ml-1 inline size-3.5"
+                      aria-hidden
+                    />
+                  </a>
+                  .
+                </li>
+                <li>
+                  Create a Team API key, then copy its key ID and issuer ID.
+                </li>
+                <li>
+                  Download its .p8 file. Apple only offers this download once.
+                </li>
+              </ol>
+              <p className="text-muted-foreground">
+                Do not use an Individual API key. Oore encrypts the Team key and
+                sends it only to the selected Apple tool for one job.
+              </p>
+            </div>
+          </div>
+
+          {error ? (
+            <Alert variant="destructive">
+              <AlertTitle>Apple account check could not start</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          {operationActive || operationLoading ? (
+            <Alert>
+              <Spinner />
+              <AlertTitle>Checking Apple account</AlertTitle>
+              <AlertDescription>{statusText}</AlertDescription>
+            </Alert>
+          ) : operation?.status === 'failed' ? (
+            <Alert variant="destructive">
+              <AlertTitle>Apple rejected this connection</AlertTitle>
+              <AlertDescription>
+                {operation.errorMessage ??
+                  'Check the Team key details and try again.'}
+              </AlertDescription>
+            </Alert>
+          ) : operation?.status === 'succeeded' ? (
+            <Alert>
+              <HugeiconsIcon icon={CheckmarkCircle02Icon} />
+              <AlertTitle>Apple account connected</AlertTitle>
+              <AlertDescription>
+                Oore found your apps. Choose the app that this instance will
+                use.
+              </AlertDescription>
+            </Alert>
+          ) : null}
+
+          <Form {...form}>
+            <form
+              className="space-y-5"
+              onSubmit={form.handleSubmit(async (values) => {
+                if (await onSubmit(values)) {
+                  form.reset({
+                    keyId: values.keyId,
+                    issuerId: values.issuerId,
+                  })
+                }
+              })}
+            >
+              <div className="grid gap-5 sm:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name="keyId"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Key ID</FormLabel>
+                      <FormControl>
+                        <Input
+                          autoComplete="off"
+                          placeholder="ABC123DEFG"
+                          disabled={pending || operationActive}
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        The short ID shown beside the Team key.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="issuerId"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Issuer ID</FormLabel>
+                      <FormControl>
+                        <Input
+                          autoComplete="off"
+                          placeholder="00000000-0000-0000-0000-000000000000"
+                          disabled={pending || operationActive}
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        The issuer ID above the Team keys list.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+              <FormField
+                control={form.control}
+                name="privateKeyFile"
+                render={({ field: { onChange, ref } }) => (
+                  <FormItem>
+                    <FormLabel>Private key file</FormLabel>
+                    <FormControl>
+                      <Input
+                        ref={ref}
+                        type="file"
+                        accept=".p8,application/pkcs8,text/plain"
+                        disabled={pending || operationActive}
+                        onChange={(event) => onChange(event.target.files?.[0])}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Choose the AuthKey_*.p8 file from Apple. Oore never shows
+                      its contents.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="flex flex-wrap justify-end gap-2">
+                {onCancel ? (
+                  <Button type="button" variant="outline" onClick={onCancel}>
+                    Cancel
+                  </Button>
+                ) : null}
+                <Button type="submit" disabled={pending || operationActive}>
+                  {pending || operationActive ? (
+                    <Spinner />
+                  ) : (
+                    <HugeiconsIcon icon={Key01Icon} />
+                  )}
+                  {operationActive
+                    ? 'Checking Apple'
+                    : replacing
+                      ? 'Check new key'
+                      : 'Connect Apple'}
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </SettingsSurface>
+      </SettingsSection>
+    </div>
+  )
+}
+
+function ConnectedAppleAccount({
+  accountKeyId,
+  apps,
+  onRemove,
+  onReplace,
+  onSelect,
+  removePending,
+  selectedApp,
+  selectPending,
+}: {
+  accountKeyId: string
+  apps: Array<AppleAppSummary>
+  onRemove: () => void
+  onReplace: () => void
+  onSelect: (app: AppleAppSummary | null) => void
+  removePending: boolean
+  selectedApp: AppleAppSummary | null
+  selectPending: boolean
+}) {
+  return (
+    <div className="space-y-7">
+      <SettingsSection
+        title="Connection"
+        description="This Team key passed an App Store Connect check."
+      >
+        <SettingsSurface className="flex flex-wrap items-center gap-4">
+          <div className="flex size-9 items-center justify-center rounded-lg bg-muted">
+            <HugeiconsIcon icon={AppleIcon} aria-hidden />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="font-medium">App Store Connect</p>
+              <Badge variant="success">Connected</Badge>
+            </div>
+            <p className="font-mono text-sm text-muted-foreground">
+              Key {accountKeyId}
+            </p>
+          </div>
+          <Button variant="outline" onClick={onReplace}>
+            Replace key
+          </Button>
+        </SettingsSurface>
+      </SettingsSection>
+
+      <SettingsSection
+        title="App"
+        description="Choose the Apple app that Oore will prepare and publish."
+      >
+        <SettingsSurface className="space-y-3">
+          {apps.length === 0 ? (
+            <Alert>
+              <AlertTitle>No apps found</AlertTitle>
+              <AlertDescription>
+                This Team key cannot see any apps. Replace it with a key that
+                can.
+              </AlertDescription>
+            </Alert>
+          ) : (
+            <Combobox
+              items={apps}
+              value={selectedApp}
+              onValueChange={onSelect}
+              itemToStringLabel={(app) => app.name}
+              disabled={selectPending}
+            >
+              <ComboboxInput
+                placeholder="Search apps"
+                aria-label="Choose Apple app"
+                className="w-full"
+              >
+                {selectPending ? <Spinner /> : null}
+              </ComboboxInput>
+              <ComboboxContent className="bg-popover">
+                <ComboboxEmpty>No matching apps.</ComboboxEmpty>
+                <ComboboxList>
+                  {(app) => (
+                    <ComboboxItem key={app.id} value={app}>
+                      <div className="min-w-0">
+                        <p className="truncate font-medium">{app.name}</p>
+                        <p className="truncate font-mono text-xs text-muted-foreground">
+                          {app.bundleId}
+                        </p>
+                      </div>
+                    </ComboboxItem>
+                  )}
+                </ComboboxList>
+              </ComboboxContent>
+            </Combobox>
+          )}
+          {selectedApp ? (
+            <p className="text-sm text-muted-foreground">
+              Oore will use{' '}
+              <span className="font-medium text-foreground">
+                {selectedApp.name}
+              </span>{' '}
+              for the next Apple steps.
+            </p>
+          ) : apps.length > 0 ? (
+            <p className="text-sm text-muted-foreground">
+              Choose one app to finish this setup.
+            </p>
+          ) : null}
+        </SettingsSurface>
+      </SettingsSection>
+
+      <SettingsSection
+        title="Remove Apple account"
+        description="This removes the encrypted key and stops new Apple work."
+      >
+        <SettingsSurface className="flex flex-wrap items-center justify-between gap-4">
+          <p className="max-w-[65ch] text-sm text-muted-foreground">
+            Existing build files stay unchanged. Oore removes the saved Team
+            key.
+          </p>
+          <AlertDialog>
+            <AlertDialogTrigger render={<Button variant="destructive" />}>
+              <HugeiconsIcon icon={Delete02Icon} />
+              Remove account
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Remove the Apple account?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Oore will delete the encrypted Team key and cancel any active
+                  Apple account check.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Keep account</AlertDialogCancel>
+                <AlertDialogAction
+                  variant="destructive"
+                  disabled={removePending}
+                  onClick={onRemove}
+                >
+                  {removePending ? <Spinner /> : null}
+                  Remove account
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </SettingsSurface>
+      </SettingsSection>
+    </div>
+  )
+}
+
+function AppleAccountSkeleton() {
+  return (
+    <div className="space-y-4" aria-label="Loading Apple account">
+      <Skeleton className="h-5 w-32" />
+      <Skeleton className="h-28 w-full" />
+      <Skeleton className="h-5 w-20" />
+      <Skeleton className="h-24 w-full" />
+    </div>
+  )
+}


### PR DESCRIPTION
## What changed

- adds an owner-only Apple account settings screen
- explains how to create a Team API key
- accepts the key ID, issuer ID, and one-time p8 file
- shows queue and Mac runner progress
- lists verified apps and saves the chosen app immediately
- supports safe key replacement and account removal
- clears the p8 file from form state after upload

## Checks

- bun run --cwd apps/web lint
- bun run --cwd apps/web build
- git diff --check

No automated tests were added or run. Product tests wait until the v0.2.0 milestone, as required by the repository rules.
