### PR TITLE
chore(release): set version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2556,7 +2556,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oore"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2615,7 +2615,7 @@ dependencies = [
 
 [[package]]
 name = "oore-contract"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "oore-runner"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2679,7 +2679,7 @@ dependencies = [
 
 [[package]]
 name = "oored"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/oore", "crates/oore-runner", "crates/oored", "crates/oore-con
 resolver = "2"
 
 [workspace.package]
-version = "0.1.10"
+version = "0.2.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/oore-ci/oore.build"


### PR DESCRIPTION
## What changed

- sets the Rust workspace version to 0.2.0
- updates the locked local package versions
- makes the next alpha branch release v0.2.0-alpha.1

## Check

- cargo check -p oore-contract --offline
- git diff --check

No automated tests were added or run.
