### PR TITLE
fix(docs): satisfy release formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Oore CI lets you run your own mobile CI server. V1 targets Android, iOS, and mac
 
 ## Screenshots
 
-| Dashboards                                                                             | Builds                                                                                |
-| -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Dashboards                                                                    | Builds                                                                       |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | ![Oore CI demo dashboard screenshot](shared/media/product/demo-dashboard.png) | ![Oore CI demo builds list screenshot](shared/media/product/demo-builds.png) |
 
 Try the live demo first: [demo.oore.build](https://demo.oore.build)


### PR DESCRIPTION
## Fix

Formats the README table with the checked-in formatter so the alpha release check can continue.

## Check

- make format-oxc-check
