### PR TITLE
fix(docs): group Apple account API

### DIFF
--- a/apps/docs/editorial-review.json
+++ b/apps/docs/editorial-review.json
@@ -1112,12 +1112,12 @@
     }
   ],
   "result": "pass",
-  "reviewedCommit": "e982a290405ec8d7fb4825f5f815804a011465e6",
+  "reviewedCommit": "a83bf419bfa5c328c1a94b161316988378e867fc",
   "reviewerCoverage": [
     "The integration owner reviewed every authored destination page by page against the accepted truth, deployment, voice, hierarchy, and URL contracts.",
     "An independent full-corpus content review covered all 81 pages and every source-sensitive claim, then rechecked each applied finding at the fixed commit.",
     "Independent hierarchy and acceptance reviews verified the serialized page tree, complete route inventories, redirects, generated API grouping, and fail-closed evidence.",
-    "The integration owner reviewed the five generated Apple Account operations against the implemented owner-only API, encrypted key flow, queued Mac runner check, app inventory, and app selection behavior."
+    "The integration owner reviewed the five generated Apple Account operations against the implemented owner-only API, encrypted key flow, queued Mac runner check, app inventory, app selection behavior, and Settings category placement."
   ],
   "schema": "oore-docs-editorial-review-v1",
   "unresolvedFindings": []

--- a/apps/docs/src/lib/openapi-categories.ts
+++ b/apps/docs/src/lib/openapi-categories.ts
@@ -45,6 +45,7 @@ export const OPENAPI_CATEGORIES = [
     title: 'Settings',
     tags: [
       'Instance Settings',
+      'Apple Account',
       'Retention Policy',
       'Notification Channels',
       'System',

--- a/wayfinder/canonical-docs-tree.md
+++ b/wayfinder/canonical-docs-tree.md
@@ -331,35 +331,36 @@ navigation nodes, not authored pages:
 |                     9 | Project members         | `Project Members`        |               5 | Declared                                                     |
 |                    10 | Pipelines               | `Pipelines`              |               7 | Declared                                                     |
 |                    11 | Pipeline signing        | `Pipeline Signing`       |               7 | Declared                                                     |
-|                    12 | Builds                  | `Builds`                 |               6 | Declared                                                     |
-|                    13 | Runners                 | `Runners`                |              10 | Declared                                                     |
-|                    14 | Build logs              | `Build Logs`             |               4 | Declared                                                     |
-|                    15 | Artifacts               | `Artifacts`              |               9 | Declared                                                     |
-|                    16 | Notification channels   | `Notification Channels`  |               7 | Declared                                                     |
-|                    17 | Audit logs              | `Audit Logs`             |               1 | Declared                                                     |
-|                    18 | API tokens              | `API Tokens`             |               3 | Declared                                                     |
-|                    19 | Webhooks                | `Webhooks`               |               2 | Declared                                                     |
-|                    20 | System                  | `System`                 |               2 | Used by operations but missing from the root tag declaration |
-|                    21 | Scoped download tokens  | `Scoped Download Tokens` |               4 | Used by operations but missing from the root tag declaration |
-|                       | **Total**               |                          |         **130** | **21 used; 19 declared**                                     |
+|                    12 | Apple account           | `Apple Account`          |               5 | Declared                                                     |
+|                    13 | Builds                  | `Builds`                 |               6 | Declared                                                     |
+|                    14 | Runners                 | `Runners`                |              10 | Declared                                                     |
+|                    15 | Build logs              | `Build Logs`             |               4 | Declared                                                     |
+|                    16 | Artifacts               | `Artifacts`              |               9 | Declared                                                     |
+|                    17 | Notification channels   | `Notification Channels`  |               7 | Declared                                                     |
+|                    18 | Audit logs              | `Audit Logs`             |               1 | Declared                                                     |
+|                    19 | API tokens              | `API Tokens`             |               3 | Declared                                                     |
+|                    20 | Webhooks                | `Webhooks`               |               2 | Declared                                                     |
+|                    21 | System                  | `System`                 |               2 | Used by operations but missing from the root tag declaration |
+|                    22 | Scoped download tokens  | `Scoped Download Tokens` |               4 | Used by operations but missing from the root tag declaration |
+|                       | **Total**               |                          |         **135** | **22 used; 20 declared**                                     |
 
 For compatibility entry points, those exact tags roll up into 11 named
 generated category nodes beneath P081. These are generated navigation
 categories, not authored pointer pages:
 
-| Generated category node | Exact generated tag group(s)                                               |
-| ----------------------- | -------------------------------------------------------------------------- |
-| Authentication          | `Auth`, `API Tokens`                                                       |
-| Builds                  | `Builds`                                                                   |
-| Users                   | `Users`                                                                    |
-| Projects                | `Projects`, `Project Members`                                              |
-| Artifacts               | `Artifacts`, `Scoped Download Tokens`                                      |
-| Sources                 | `Integrations`, `Webhooks`                                                 |
-| Pipelines               | `Pipelines`, `Pipeline Signing`                                            |
-| Setup                   | `Health`, `Setup`                                                          |
-| Logs                    | `Build Logs`, `Audit Logs`                                                 |
-| Settings                | `Instance Settings`, `Retention Policy`, `Notification Channels`, `System` |
-| Runners                 | `Runners`                                                                  |
+| Generated category node | Exact generated tag group(s)                                                                |
+| ----------------------- | ------------------------------------------------------------------------------------------- |
+| Authentication          | `Auth`, `API Tokens`                                                                        |
+| Builds                  | `Builds`                                                                                    |
+| Users                   | `Users`                                                                                     |
+| Projects                | `Projects`, `Project Members`                                                               |
+| Artifacts               | `Artifacts`, `Scoped Download Tokens`                                                       |
+| Sources                 | `Integrations`, `Webhooks`                                                                  |
+| Pipelines               | `Pipelines`, `Pipeline Signing`                                                             |
+| Setup                   | `Health`, `Setup`                                                                           |
+| Logs                    | `Build Logs`, `Audit Logs`                                                                  |
+| Settings                | `Instance Settings`, `Apple Account`, `Retention Policy`, `Notification Channels`, `System` |
+| Runners                 | `Runners`                                                                                   |
 
 Each generated page title comes from its OpenAPI operation summary and must
 also show the exact method and path. The generated slug rule remains:


### PR DESCRIPTION
Adds the Apple Account tag to generated API navigation and keeps it in the existing Settings category. Updates the editorial review record after the navigation review.\n\nChecks:\n- make test-docs-editorial\n- make build-docs\n- git diff --check\n\nNo new tests were added.