### PR TITLE
feat(auth): add Cloudflare Access

### DIFF
--- a/apps/docs/content/docs/operate/access/cloudflare-access.mdx
+++ b/apps/docs/content/docs/operate/access/cloudflare-access.mdx
@@ -1,0 +1,62 @@
+---
+title: 'Protect a backend with Cloudflare Access'
+status: preview
+description: 'Use Cloudflare Tunnel and signed Access tokens for Oore remote sign-in.'
+---
+
+Use Cloudflare Access when the Oore UI and backend need secure remote access.
+The browser signs in with Cloudflare. Oore then verifies every signed Access
+token before it creates an Oore session.
+
+## What you need
+
+- A Cloudflare Tunnel hostname for the Oore backend.
+- A Cloudflare Access self-hosted application for that hostname.
+- An Access policy that permits your Oore users.
+- The Access team domain and Application Audience (AUD) Tag.
+- The exact hosted UI origin.
+
+Keep the tunnel origin on the backend loopback address. Do not expose the Oore
+port directly to the network.
+
+## Configure Cloudflare
+
+1. Create a tunnel hostname for the Oore backend.
+2. Point the hostname to the Oore loopback address and port.
+3. Create an Access self-hosted application for that hostname.
+4. Add the required user policy.
+5. Open **Advanced settings**, then **CORS settings**.
+6. Turn on **Bypass OPTIONS requests to origin**.
+7. Copy the team domain and Application Audience (AUD) Tag.
+
+Oore answers the forwarded preflight request. It permits only the exact
+frontend origins that you configure.
+
+## Configure Oore
+
+During setup, select **Remote**, then **Trusted Proxy**, then
+**Cloudflare Access**. Enter the team domain and audience tag. Add the exact UI
+origin to the allowed frontend origins.
+
+Oore derives the key URL from the team domain. It accepts only signed Access
+JWTs for the configured audience. It does not trust a plain email header in
+this mode.
+
+This alpha keeps the identity proof selected during setup. It does not support
+changing an existing Trusted Proxy installation to Cloudflare Access.
+
+## Verify the result
+
+1. Open the hosted Oore UI.
+2. Add the protected backend URL.
+3. Complete the Cloudflare Access sign-in.
+4. Confirm that Oore opens the expected account.
+5. Open **Settings > Runners** and confirm the expected runner appears.
+
+If the browser reports a CORS error, confirm the exact UI origin in Oore.
+Confirm that the Access application forwards OPTIONS requests to Oore.
+
+## Related guides
+
+- [Connect the hosted UI](/operate/access/hosted-ui)
+- [Configure External Access](/team/access)

--- a/apps/docs/content/docs/operate/access/meta.json
+++ b/apps/docs/content/docs/operate/access/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Browser clients",
-  "pages": ["hosted-ui", "self-hosted-ui"]
+  "pages": ["hosted-ui", "self-hosted-ui", "cloudflare-access"]
 }

--- a/apps/docs/content/docs/operate/access/self-hosted-ui.mdx
+++ b/apps/docs/content/docs/operate/access/self-hosted-ui.mdx
@@ -14,7 +14,7 @@ Oore backend or API proxy.
 - A static host with the routing needed by the web application.
 - A browser-reachable backend.
 - For a different UI and backend origin, HTTPS External Access and the exact UI
-  origin in backend CORS settings.
+origin in backend CORS settings.
 
 ## 1. Build the web assets
 
@@ -33,8 +33,8 @@ that host for the web application's client routes.
 If browsers call a different backend origin, enable
 [External Access](/team/access), use HTTPS, and add the static site's exact
 origin in **Settings > General**, under **External access**. Backend database
-settings take precedence over environment fallbacks; local client origins
-remain available.
+settings take precedence over environment fallbacks. Remote mode permits only
+the origins that the operator adds.
 
 ## Verify the result
 

--- a/apps/docs/public/openapi.json
+++ b/apps/docs/public/openapi.json
@@ -12607,6 +12607,21 @@
       "SetupTrustedProxyConfigureRequest": {
         "type": "object",
         "properties": {
+          "cloudflare_audience": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "cloudflare_team_domain": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "proof_provider": {
+            "$ref": "#/components/schemas/TrustedProxyProofProvider"
+          },
           "setup_owner_email": {
             "type": [
               "string",
@@ -12637,6 +12652,7 @@
         "type": "object",
         "required": [
           "state",
+          "proof_provider",
           "has_shared_secret",
           "configured_at"
         ],
@@ -12647,6 +12663,9 @@
           },
           "has_shared_secret": {
             "type": "boolean"
+          },
+          "proof_provider": {
+            "$ref": "#/components/schemas/TrustedProxyProofProvider"
           },
           "session_expires_at": {
             "type": [
@@ -12902,20 +12921,43 @@
           "schedule"
         ]
       },
+      "TrustedProxyProofProvider": {
+        "type": "string",
+        "enum": [
+          "shared_secret",
+          "cloudflare_access"
+        ]
+      },
       "TrustedProxySettingsPublic": {
         "type": "object",
         "required": [
+          "proof_provider",
           "user_email_header",
           "trusted_proxy_cidrs",
           "has_shared_secret",
           "has_warpgate_ticket"
         ],
         "properties": {
+          "cloudflare_audience": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "cloudflare_team_domain": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "has_shared_secret": {
             "type": "boolean"
           },
           "has_warpgate_ticket": {
             "type": "boolean"
+          },
+          "proof_provider": {
+            "$ref": "#/components/schemas/TrustedProxyProofProvider"
           },
           "trusted_proxy_cidrs": {
             "type": "array",
@@ -13535,6 +13577,28 @@
       "UpdateTrustedProxySettingsRequest": {
         "type": "object",
         "properties": {
+          "cloudflare_audience": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "cloudflare_team_domain": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "proof_provider": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/TrustedProxyProofProvider"
+              }
+            ]
+          },
           "shared_secret": {
             "type": [
               "string",

--- a/apps/web/src/components/settings/preferences-external-access-management.tsx
+++ b/apps/web/src/components/settings/preferences-external-access-management.tsx
@@ -95,12 +95,14 @@ export function ExternalAccessManagement({
               <ItemTitle>Identity settings</ItemTitle>
               <ItemDescription className="line-clamp-none">
                 {remoteAuthMode === 'trusted_proxy'
-                  ? trustedProxySettings?.user_email_header ===
-                    'x-warpgate-username'
-                    ? trustedProxySettings.has_warpgate_ticket
-                      ? `Warpgate identity and iOS installs configured (${trustedProxySettings.warpgate_ticket_source === 'environment' ? 'environment' : 'encrypted settings'} ticket).`
-                      : 'Warpgate identity configured. Add an access ticket for iOS installs.'
-                    : 'Update trusted proxy header, peer CIDRs, and secret.'
+                  ? trustedProxySettings?.proof_provider === 'cloudflare_access'
+                    ? `Cloudflare Access verifies signed identity tokens for ${trustedProxySettings.cloudflare_team_domain ?? 'the configured team'}.`
+                    : trustedProxySettings?.user_email_header ===
+                        'x-warpgate-username'
+                      ? trustedProxySettings.has_warpgate_ticket
+                        ? `Warpgate identity and iOS installs configured (${trustedProxySettings.warpgate_ticket_source === 'environment' ? 'environment' : 'encrypted settings'} ticket).`
+                        : 'Warpgate identity configured. Add an access ticket for iOS installs.'
+                      : 'Update trusted proxy header, peer CIDRs, and secret.'
                   : 'Update issuer and client credentials.'}
               </ItemDescription>
             </ItemContent>

--- a/apps/web/src/components/settings/preferences-external-access-setup.tsx
+++ b/apps/web/src/components/settings/preferences-external-access-setup.tsx
@@ -180,17 +180,32 @@ export function ExternalAccessSetup({
                 </ItemDescription>
                 {remoteAuthMode === 'trusted_proxy' && trustedProxySettings ? (
                   <>
-                    <ItemDescription>
-                      Header: {trustedProxySettings.user_email_header}
-                    </ItemDescription>
-                    <ItemDescription>
-                      Secret:{' '}
-                      {trustedProxySettings.has_shared_secret
-                        ? 'Stored'
-                        : 'Missing'}
-                    </ItemDescription>
-                    {trustedProxySettings.user_email_header ===
-                    'x-warpgate-username' ? (
+                    {trustedProxySettings.proof_provider ===
+                    'cloudflare_access' ? (
+                      <>
+                        <ItemDescription>
+                          Proof: Signed Cloudflare Access token
+                        </ItemDescription>
+                        <ItemDescription>
+                          Team: {trustedProxySettings.cloudflare_team_domain}
+                        </ItemDescription>
+                      </>
+                    ) : (
+                      <>
+                        <ItemDescription>
+                          Header: {trustedProxySettings.user_email_header}
+                        </ItemDescription>
+                        <ItemDescription>
+                          Secret:{' '}
+                          {trustedProxySettings.has_shared_secret
+                            ? 'Stored'
+                            : 'Missing'}
+                        </ItemDescription>
+                      </>
+                    )}
+                    {trustedProxySettings.proof_provider === 'shared_secret' &&
+                    trustedProxySettings.user_email_header ===
+                      'x-warpgate-username' ? (
                       <ItemDescription>
                         iOS installs:{' '}
                         {trustedProxySettings.has_warpgate_ticket

--- a/apps/web/src/components/settings/preferences-trusted-proxy-settings-dialog.tsx
+++ b/apps/web/src/components/settings/preferences-trusted-proxy-settings-dialog.tsx
@@ -24,6 +24,13 @@ import {
 import { Input } from '@/components/ui/input'
 import { Spinner } from '@/components/ui/spinner'
 import { Textarea } from '@/components/ui/textarea'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 
 export default function TrustedProxySettingsDialog({
   form,
@@ -43,9 +50,10 @@ export default function TrustedProxySettingsDialog({
   settings: TrustedProxySettingsPublic | undefined
 }) {
   const userEmailHeader = form.watch('user_email_header')
+  const proofProvider = form.watch('proof_provider')
   const clearWarpgateTicket = form.watch('clear_warpgate_ticket')
   const isWarpgate =
-    userEmailHeader.trim().toLowerCase() === 'x-warpgate-username'
+    userEmailHeader?.trim().toLowerCase() === 'x-warpgate-username'
   return (
     <Dialog
       open={open}
@@ -71,139 +79,215 @@ export default function TrustedProxySettingsDialog({
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
             <FormField
               control={form.control}
-              name="user_email_header"
+              name="proof_provider"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>User email header</FormLabel>
-                  <FormControl>
-                    <Input
-                      placeholder="x-oore-user-email"
-                      {...field}
-                      disabled={isPending}
-                    />
-                  </FormControl>
+                  <FormLabel>Identity proof</FormLabel>
+                  <Select
+                    value={field.value}
+                    onValueChange={field.onChange}
+                    disabled={isPending}
+                  >
+                    <FormControl>
+                      <SelectTrigger className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="cloudflare_access">
+                        Cloudflare Access token
+                      </SelectItem>
+                      <SelectItem value="shared_secret">
+                        Trusted header and shared secret
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
                   <FormDescription>
-                    Header forwarded by oore-web after the upstream proxy has
-                    proven the request.
+                    Cloudflare uses a signed token. Other proxies use a trusted
+                    header and shared secret.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
             />
 
-            <FormField
-              control={form.control}
-              name="trusted_proxy_cidrs"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Trusted proxy peer CIDRs</FormLabel>
-                  <FormControl>
-                    <Textarea
-                      rows={4}
-                      placeholder="127.0.0.1/32&#10;10.0.0.10/32"
-                      {...field}
-                      disabled={isPending}
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    One CIDR per line. Leave blank to accept loopback peers
-                    only.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+            {proofProvider === 'cloudflare_access' ? (
+              <>
+                <FormField
+                  control={form.control}
+                  name="cloudflare_team_domain"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Cloudflare Access team domain</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="your-team.cloudflareaccess.com"
+                          {...field}
+                          disabled={isPending}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="cloudflare_audience"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Application audience tag</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="Application Audience (AUD) Tag"
+                          {...field}
+                          disabled={isPending}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </>
+            ) : (
+              <>
+                <FormField
+                  control={form.control}
+                  name="user_email_header"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>User email header</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="x-oore-user-email"
+                          {...field}
+                          disabled={isPending}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Header forwarded by oore-web after the upstream proxy
+                        has proven the request.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
-            <FormField
-              control={form.control}
-              name="shared_secret"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Shared secret</FormLabel>
-                  <FormControl>
-                    <Input
-                      type="password"
-                      placeholder={
-                        settings?.has_shared_secret
-                          ? 'Leave empty to keep existing secret'
-                          : 'Paste shared secret'
-                      }
-                      {...field}
-                      disabled={isPending}
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Leave empty to keep the existing secret. Enter a new value
-                    only when rotating it.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+                <FormField
+                  control={form.control}
+                  name="trusted_proxy_cidrs"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Trusted proxy peer CIDRs</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          rows={4}
+                          placeholder="127.0.0.1/32&#10;10.0.0.10/32"
+                          {...field}
+                          disabled={isPending}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        One CIDR per line. Leave blank to accept loopback peers
+                        only.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
-            {isWarpgate ? (
-              <Card size="sm">
-                <CardContent className="space-y-3">
-                  <FormField
-                    control={form.control}
-                    name="warpgate_ticket"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>iOS install access ticket</FormLabel>
-                        <FormControl>
-                          <Input
-                            type="password"
-                            placeholder={
-                              settings?.has_warpgate_ticket
-                                ? 'Leave empty to keep existing ticket'
-                                : 'Paste Warpgate access ticket'
-                            }
-                            autoComplete="off"
-                            {...field}
-                            disabled={isPending || clearWarpgateTicket}
-                          />
-                        </FormControl>
-                        <FormDescription>
-                          {settings?.warpgate_ticket_source === 'environment'
-                            ? 'Currently supplied by OORE_WARPGATE_TICKET. Saving a value here stores an encrypted override.'
-                            : settings?.has_warpgate_ticket
-                              ? 'Stored encrypted. Leave empty to keep it; enter a value only to rotate it.'
-                              : 'Optional. Lets the iOS installer fetch the manifest and IPA through Warpgate without an interactive login.'}
-                        </FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
+                <FormField
+                  control={form.control}
+                  name="shared_secret"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Shared secret</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="password"
+                          placeholder={
+                            settings?.has_shared_secret
+                              ? 'Leave empty to keep existing secret'
+                              : 'Paste shared secret'
+                          }
+                          {...field}
+                          disabled={isPending}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Leave empty to keep the existing secret. Enter a new
+                        value only when rotating it.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
-                  {settings?.warpgate_ticket_source === 'database' ? (
-                    <FormField
-                      control={form.control}
-                      name="clear_warpgate_ticket"
-                      render={({ field }) => (
-                        <FormItem>
-                          <label className="flex items-center gap-2 text-sm font-medium">
+                {isWarpgate ? (
+                  <Card size="sm">
+                    <CardContent className="space-y-3">
+                      <FormField
+                        control={form.control}
+                        name="warpgate_ticket"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>iOS install access ticket</FormLabel>
                             <FormControl>
-                              <Checkbox
-                                checked={field.value}
-                                onCheckedChange={(checked) =>
-                                  field.onChange(!!checked)
+                              <Input
+                                type="password"
+                                placeholder={
+                                  settings?.has_warpgate_ticket
+                                    ? 'Leave empty to keep existing ticket'
+                                    : 'Paste Warpgate access ticket'
                                 }
-                                disabled={isPending}
+                                autoComplete="off"
+                                {...field}
+                                disabled={isPending || clearWarpgateTicket}
                               />
                             </FormControl>
-                            Remove stored install ticket
-                          </label>
-                          <FormDescription>
-                            Environment configuration will become active if
-                            OORE_WARPGATE_TICKET is also set.
-                          </FormDescription>
-                        </FormItem>
-                      )}
-                    />
-                  ) : null}
-                </CardContent>
-              </Card>
-            ) : null}
+                            <FormDescription>
+                              {settings?.warpgate_ticket_source ===
+                              'environment'
+                                ? 'Currently supplied by OORE_WARPGATE_TICKET. Saving a value here stores an encrypted override.'
+                                : settings?.has_warpgate_ticket
+                                  ? 'Stored encrypted. Leave empty to keep it; enter a value only to rotate it.'
+                                  : 'Optional. Lets the iOS installer fetch the manifest and IPA through Warpgate without an interactive login.'}
+                            </FormDescription>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+
+                      {settings?.warpgate_ticket_source === 'database' ? (
+                        <FormField
+                          control={form.control}
+                          name="clear_warpgate_ticket"
+                          render={({ field }) => (
+                            <FormItem>
+                              <label className="flex items-center gap-2 text-sm font-medium">
+                                <FormControl>
+                                  <Checkbox
+                                    checked={field.value}
+                                    onCheckedChange={(checked) =>
+                                      field.onChange(!!checked)
+                                    }
+                                    disabled={isPending}
+                                  />
+                                </FormControl>
+                                Remove stored install ticket
+                              </label>
+                              <FormDescription>
+                                Environment configuration will become active if
+                                OORE_WARPGATE_TICKET is also set.
+                              </FormDescription>
+                            </FormItem>
+                          )}
+                        />
+                      ) : null}
+                    </CardContent>
+                  </Card>
+                ) : null}
+              </>
+            )}
 
             <DialogFooter>
               <Button

--- a/apps/web/src/components/settings/preferences-trusted-proxy-settings-dialog.tsx
+++ b/apps/web/src/components/settings/preferences-trusted-proxy-settings-dialog.tsx
@@ -88,8 +88,8 @@ export default function TrustedProxySettingsDialog({
                     />
                   </FormControl>
                   <FormDescription>
-                    Use local recovery before you change the active identity
-                    proof.
+                    Oore keeps the identity proof selected during setup. This
+                    alpha does not support changing it later.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>

--- a/apps/web/src/components/settings/preferences-trusted-proxy-settings-dialog.tsx
+++ b/apps/web/src/components/settings/preferences-trusted-proxy-settings-dialog.tsx
@@ -24,13 +24,6 @@ import {
 import { Input } from '@/components/ui/input'
 import { Spinner } from '@/components/ui/spinner'
 import { Textarea } from '@/components/ui/textarea'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
 
 export default function TrustedProxySettingsDialog({
   form,
@@ -83,28 +76,20 @@ export default function TrustedProxySettingsDialog({
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Identity proof</FormLabel>
-                  <Select
-                    value={field.value}
-                    onValueChange={field.onChange}
-                    disabled={isPending}
-                  >
-                    <FormControl>
-                      <SelectTrigger className="w-full">
-                        <SelectValue />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      <SelectItem value="cloudflare_access">
-                        Cloudflare Access token
-                      </SelectItem>
-                      <SelectItem value="shared_secret">
-                        Trusted header and shared secret
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
+                  <FormControl>
+                    <Input
+                      value={
+                        field.value === 'cloudflare_access'
+                          ? 'Cloudflare Access token'
+                          : 'Trusted header and shared secret'
+                      }
+                      readOnly
+                      disabled
+                    />
+                  </FormControl>
                   <FormDescription>
-                    Cloudflare uses a signed token. Other proxies use a trusted
-                    header and shared secret.
+                    Use local recovery before you change the active identity
+                    proof.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>

--- a/apps/web/src/components/setup-route-components.tsx
+++ b/apps/web/src/components/setup-route-components.tsx
@@ -180,6 +180,19 @@ export function SetupRouteError({ error }: { error: Error }) {
         </Card>
 
         <div className="flex flex-col gap-2 sm:flex-row">
+          {backendUrl.startsWith('https://') ? (
+            <Button
+              onClick={() =>
+                window.open(
+                  `${backendUrl}/v1/public/setup-status`,
+                  '_blank',
+                  'noopener,noreferrer',
+                )
+              }
+            >
+              Open backend sign-in
+            </Button>
+          ) : null}
           <Button onClick={() => void router.invalidate()}>Retry</Button>
           <Button variant="outline" onClick={goBack}>
             Go back

--- a/apps/web/src/demo/state.ts
+++ b/apps/web/src/demo/state.ts
@@ -645,6 +645,7 @@ function createDemoState(scenario: DemoScenario = 'operating'): DemoState {
       updated_at: ago(86400 * 30),
     },
     trustedProxy: {
+      proof_provider: 'shared_secret',
       user_email_header: 'x-oore-user-email',
       trusted_proxy_cidrs: [],
       has_shared_secret: false,

--- a/apps/web/src/hooks/use-setup.ts
+++ b/apps/web/src/hooks/use-setup.ts
@@ -5,6 +5,7 @@ import {
   useQueryClient,
 } from '@tanstack/react-query'
 import type { Instance, OidcConfigureRequest } from '@/lib/types'
+import type { TrustedProxyProofProvider } from '@/lib/types'
 import {
   completeSetup,
   configureOidc,
@@ -138,22 +139,31 @@ export function useSetupTrustedProxyConfigure() {
   return useMutation({
     mutationFn: ({
       sessionToken,
+      proofProvider,
       userEmailHeader,
       setupOwnerEmail,
       trustedProxyCidrs,
       sharedSecret,
+      cloudflareTeamDomain,
+      cloudflareAudience,
     }: {
       sessionToken: string
+      proofProvider: TrustedProxyProofProvider
       userEmailHeader?: string
       setupOwnerEmail?: string
       trustedProxyCidrs: Array<string>
       sharedSecret?: string
+      cloudflareTeamDomain?: string
+      cloudflareAudience?: string
     }) =>
       setupTrustedProxyConfigure(requireInstance(instance), sessionToken, {
+        proof_provider: proofProvider,
         user_email_header: userEmailHeader,
         setup_owner_email: setupOwnerEmail,
         trusted_proxy_cidrs: trustedProxyCidrs,
         shared_secret: sharedSecret,
+        cloudflare_team_domain: cloudflareTeamDomain,
+        cloudflare_audience: cloudflareAudience,
       }),
     onSuccess: (data) => {
       if (data.session_expires_at) {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -159,6 +159,7 @@ async function requestResponse(
 
   const res = await fetch(`${baseUrl}${path}`, {
     ...options,
+    credentials: 'include',
     headers,
   })
 

--- a/apps/web/src/lib/setup-prefill.ts
+++ b/apps/web/src/lib/setup-prefill.ts
@@ -1,4 +1,8 @@
-export type TrustedProxySetupPreset = 'generic' | 'warpgate' | 'custom'
+export type TrustedProxySetupPreset =
+  | 'cloudflare_access'
+  | 'generic'
+  | 'warpgate'
+  | 'custom'
 
 export interface TrustedProxySetupPrefill {
   ownerEmail?: string
@@ -13,7 +17,12 @@ function keyForInstance(instanceId: string): string {
 export function normalizeTrustedProxySetupPreset(
   value: string | null,
 ): TrustedProxySetupPreset | undefined {
-  if (value === 'generic' || value === 'warpgate' || value === 'custom') {
+  if (
+    value === 'cloudflare_access' ||
+    value === 'generic' ||
+    value === 'warpgate' ||
+    value === 'custom'
+  ) {
     return value
   }
   return undefined

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -77,19 +77,25 @@ export interface SetupPreferencesResponse {
 }
 
 export interface SetupTrustedProxyConfigureRequest {
+  proof_provider: TrustedProxyProofProvider
   user_email_header?: string
   setup_owner_email?: string
   trusted_proxy_cidrs: Array<string>
   shared_secret?: string
+  cloudflare_team_domain?: string
+  cloudflare_audience?: string
 }
 
 export interface SetupTrustedProxyConfigureResponse {
   state: SetupState
+  proof_provider: TrustedProxyProofProvider
   setup_owner_email?: string
   has_shared_secret: boolean
   configured_at: number
   session_expires_at?: number
 }
+
+export type TrustedProxyProofProvider = 'shared_secret' | 'cloudflare_access'
 
 export interface SetupTrustedProxyClaimOwnerResponse {
   state: SetupState
@@ -630,11 +636,14 @@ export interface GetExternalAccessOidcResponse {
 }
 
 export interface TrustedProxySettingsPublic {
+  proof_provider: TrustedProxyProofProvider
   user_email_header: string
   trusted_proxy_cidrs: Array<string>
   has_shared_secret: boolean
   has_warpgate_ticket: boolean
   warpgate_ticket_source?: 'database' | 'environment'
+  cloudflare_team_domain?: string
+  cloudflare_audience?: string
   updated_at?: number
 }
 
@@ -643,10 +652,13 @@ export interface TrustedProxySettingsResponse {
 }
 
 export interface UpdateTrustedProxySettingsRequest {
+  proof_provider?: TrustedProxyProofProvider
   user_email_header?: string
   trusted_proxy_cidrs: Array<string>
   shared_secret?: string
   warpgate_ticket?: string
+  cloudflare_team_domain?: string
+  cloudflare_audience?: string
 }
 
 export interface InstancePreferences {

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -286,7 +286,8 @@ function IndexPage() {
           {backendUrl?.startsWith('https://') ? (
             <p className="text-sm text-muted-foreground">
               If Cloudflare Access protects this URL, sign in there first. Then
-              return here and retry.
+              enable Bypass OPTIONS requests to origin in the Access application
+              CORS settings. Return here and retry.
             </p>
           ) : null}
         </div>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -34,6 +34,7 @@ import { getSetupStatus } from '@/lib/api'
 import { isLoopbackHostname } from '@/lib/connectivity'
 import { PageMeta } from '@/lib/seo'
 import { isManagedFrontend } from '@/lib/managed-frontend'
+import { resolveInstanceApiBaseUrl } from '@/lib/instance-url'
 import { useAuthStore } from '@/stores/auth-store'
 import { useActiveInstance, useInstanceStore } from '@/stores/instance-store'
 
@@ -248,10 +249,11 @@ function IndexPage() {
   }
 
   if (error) {
+    const backendUrl = resolveInstanceApiBaseUrl(instance)
     return (
       <div className="flex flex-1 items-center justify-center p-6">
         <PageMeta />
-        <div className="w-full max-w-md">
+        <div className="w-full max-w-md space-y-3">
           <Alert variant="destructive">
             <AlertTitle>Connection failed</AlertTitle>
             <AlertDescription>
@@ -260,6 +262,33 @@ function IndexPage() {
               running.
             </AlertDescription>
           </Alert>
+          {backendUrl?.startsWith('https://') ? (
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Button
+                onClick={() =>
+                  window.open(
+                    `${backendUrl}/v1/public/setup-status`,
+                    '_blank',
+                    'noopener,noreferrer',
+                  )
+                }
+              >
+                Open backend sign-in
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => window.location.reload()}
+              >
+                Retry connection
+              </Button>
+            </div>
+          ) : null}
+          {backendUrl?.startsWith('https://') ? (
+            <p className="text-sm text-muted-foreground">
+              If Cloudflare Access protects this URL, sign in there first. Then
+              return here and retry.
+            </p>
+          ) : null}
         </div>
       </div>
     )

--- a/apps/web/src/routes/settings/preferences.lazy.tsx
+++ b/apps/web/src/routes/settings/preferences.lazy.tsx
@@ -55,16 +55,44 @@ export type ExternalAccessOidcFormValues = z.infer<
   typeof externalAccessOidcSchema
 >
 
-const trustedProxySchema = z.object({
-  user_email_header: z.string().trim().min(1, 'User email header is required.'),
-  trusted_proxy_cidrs: z.string().optional(),
-  shared_secret: z.string().optional(),
-  warpgate_ticket: z
-    .string()
-    .max(1024, 'Warpgate ticket must be 1024 characters or fewer.')
-    .optional(),
-  clear_warpgate_ticket: z.boolean(),
-})
+const trustedProxySchema = z
+  .object({
+    proof_provider: z.enum(['shared_secret', 'cloudflare_access']),
+    user_email_header: z.string().optional(),
+    trusted_proxy_cidrs: z.string().optional(),
+    shared_secret: z.string().optional(),
+    warpgate_ticket: z
+      .string()
+      .max(1024, 'Warpgate ticket must be 1024 characters or fewer.')
+      .optional(),
+    clear_warpgate_ticket: z.boolean(),
+    cloudflare_team_domain: z.string().optional(),
+    cloudflare_audience: z.string().optional(),
+  })
+  .superRefine((values, context) => {
+    if (values.proof_provider === 'cloudflare_access') {
+      if (!values.cloudflare_team_domain?.trim()) {
+        context.addIssue({
+          code: 'custom',
+          path: ['cloudflare_team_domain'],
+          message: 'Cloudflare Access team domain is required.',
+        })
+      }
+      if (!values.cloudflare_audience?.trim()) {
+        context.addIssue({
+          code: 'custom',
+          path: ['cloudflare_audience'],
+          message: 'Application audience tag is required.',
+        })
+      }
+    } else if (!values.user_email_header?.trim()) {
+      context.addIssue({
+        code: 'custom',
+        path: ['user_email_header'],
+        message: 'User email header is required.',
+      })
+    }
+  })
 
 export type TrustedProxyFormValues = z.infer<typeof trustedProxySchema>
 
@@ -179,22 +207,28 @@ function PreferencesPage() {
   const trustedProxyValues = useMemo(() => {
     if (!trustedProxySettings) return undefined
     return {
+      proof_provider: trustedProxySettings.proof_provider,
       user_email_header: trustedProxySettings.user_email_header,
       trusted_proxy_cidrs: trustedProxySettings.trusted_proxy_cidrs.join('\n'),
       shared_secret: '',
       warpgate_ticket: '',
       clear_warpgate_ticket: false,
+      cloudflare_team_domain: trustedProxySettings.cloudflare_team_domain ?? '',
+      cloudflare_audience: trustedProxySettings.cloudflare_audience ?? '',
     }
   }, [trustedProxySettings])
 
   const trustedProxyForm = useForm<TrustedProxyFormValues>({
     resolver: zodResolver(trustedProxySchema),
     defaultValues: {
+      proof_provider: 'shared_secret',
       user_email_header: 'x-oore-user-email',
       trusted_proxy_cidrs: '',
       shared_secret: '',
       warpgate_ticket: '',
       clear_warpgate_ticket: false,
+      cloudflare_team_domain: '',
+      cloudflare_audience: '',
     },
     values: trustedProxyValues,
     mode: 'onBlur',
@@ -290,10 +324,11 @@ function PreferencesPage() {
     const sharedSecret = values.shared_secret?.trim()
     const warpgateTicket = values.warpgate_ticket?.trim()
     const isWarpgate =
-      values.user_email_header.trim().toLowerCase() === 'x-warpgate-username'
+      values.user_email_header?.trim().toLowerCase() === 'x-warpgate-username'
     updateTrustedProxyMutation.mutate(
       {
-        user_email_header: values.user_email_header.trim(),
+        proof_provider: values.proof_provider,
+        user_email_header: values.user_email_header?.trim(),
         trusted_proxy_cidrs: parseTrustedProxyCidrs(values.trusted_proxy_cidrs),
         ...(sharedSecret ? { shared_secret: sharedSecret } : {}),
         ...(isWarpgate
@@ -302,6 +337,12 @@ function PreferencesPage() {
             : warpgateTicket
               ? { warpgate_ticket: warpgateTicket }
               : {}
+          : {}),
+        ...(values.proof_provider === 'cloudflare_access'
+          ? {
+              cloudflare_team_domain: values.cloudflare_team_domain?.trim(),
+              cloudflare_audience: values.cloudflare_audience?.trim(),
+            }
           : {}),
       },
       {

--- a/apps/web/src/routes/setup/mode.lazy.tsx
+++ b/apps/web/src/routes/setup/mode.lazy.tsx
@@ -60,9 +60,9 @@ const MODE_COMPARISON: Array<{
   },
   {
     value: 'remote_trusted',
-    label: 'Remote (Trusted Proxy)',
+    label: 'Remote (Access proxy)',
     access: 'Behind your proxy',
-    identity: 'Upstream headers',
+    identity: 'Cloudflare Access or trusted headers',
   },
 ]
 
@@ -185,7 +185,7 @@ function SetupModeStep() {
                       </SelectItem>
                       <SelectItem value="remote_oidc">Remote (OIDC)</SelectItem>
                       <SelectItem value="remote_trusted">
-                        Remote (Trusted Proxy)
+                        Remote (Access proxy)
                       </SelectItem>
                     </SelectContent>
                   </Select>

--- a/apps/web/src/routes/setup/trusted-proxy.lazy.tsx
+++ b/apps/web/src/routes/setup/trusted-proxy.lazy.tsx
@@ -352,10 +352,12 @@ function SetupTrustedProxyStep() {
               />
 
               <Alert>
-                <AlertTitle>Cloudflare protects the backend URL</AlertTitle>
+                <AlertTitle>Finish the Cloudflare CORS setting</AlertTitle>
                 <AlertDescription>
-                  Keep the tunnel pointed at Oore on loopback. Oore still
-                  verifies every signed Access token.
+                  In the Access application, open Advanced settings, then CORS
+                  settings. Turn on Bypass OPTIONS requests to origin. Oore
+                  answers these requests with its exact allowed frontend
+                  origins. Keep the tunnel pointed at Oore on loopback.
                 </AlertDescription>
               </Alert>
             </>

--- a/apps/web/src/routes/setup/trusted-proxy.lazy.tsx
+++ b/apps/web/src/routes/setup/trusted-proxy.lazy.tsx
@@ -31,21 +31,62 @@ import { useSetupStore } from '@/stores/setup-store'
 import { useSetupModeGuard } from '@/hooks/use-setup-route-transitions'
 import { SetupStepError } from '@/components/setup-route-components'
 
-const trustedProxyPresetSchema = z.enum(['generic', 'warpgate', 'custom'])
+const trustedProxyPresetSchema = z.enum([
+  'cloudflare_access',
+  'generic',
+  'warpgate',
+  'custom',
+])
 type TrustedProxyPreset = z.infer<typeof trustedProxyPresetSchema>
 
-const presetHeaders: Record<Exclude<TrustedProxyPreset, 'custom'>, string> = {
+const presetHeaders: Record<
+  Exclude<TrustedProxyPreset, 'custom' | 'cloudflare_access'>,
+  string
+> = {
   generic: 'x-oore-user-email',
   warpgate: 'x-warpgate-username',
 }
 
-const trustedProxySchema = z.object({
-  proxyPreset: trustedProxyPresetSchema,
-  ownerEmail: z.email('Enter a valid owner email'),
-  userEmailHeader: z.string().min(1, 'Header name is required'),
-  trustedProxyCidrs: z.string().optional(),
-  sharedSecret: z.string().optional(),
-})
+const trustedProxySchema = z
+  .object({
+    proxyPreset: trustedProxyPresetSchema,
+    ownerEmail: z.email('Enter a valid owner email'),
+    userEmailHeader: z.string().optional(),
+    trustedProxyCidrs: z.string().optional(),
+    sharedSecret: z.string().optional(),
+    cloudflareTeamDomain: z.string().optional(),
+    cloudflareAudience: z.string().optional(),
+  })
+  .superRefine((values, context) => {
+    if (values.proxyPreset === 'cloudflare_access') {
+      if (!values.cloudflareTeamDomain?.trim()) {
+        context.addIssue({
+          code: 'custom',
+          path: ['cloudflareTeamDomain'],
+          message: 'Enter your Cloudflare Access team domain',
+        })
+      }
+      if (!values.cloudflareAudience?.trim()) {
+        context.addIssue({
+          code: 'custom',
+          path: ['cloudflareAudience'],
+          message: 'Enter the application audience tag',
+        })
+      }
+    } else if (!values.userEmailHeader?.trim()) {
+      context.addIssue({
+        code: 'custom',
+        path: ['userEmailHeader'],
+        message: 'Header name is required',
+      })
+    } else if (!values.sharedSecret?.trim()) {
+      context.addIssue({
+        code: 'custom',
+        path: ['sharedSecret'],
+        message: 'Generate or enter a shared secret',
+      })
+    }
+  })
 
 type TrustedProxyForm = z.infer<typeof trustedProxySchema>
 
@@ -71,7 +112,9 @@ function generateSharedSecret(): string {
 }
 
 function headerForPreset(preset: TrustedProxyPreset): string | undefined {
-  return preset === 'custom' ? undefined : presetHeaders[preset]
+  return preset === 'custom' || preset === 'cloudflare_access'
+    ? undefined
+    : presetHeaders[preset]
 }
 
 function SetupTrustedProxyStep() {
@@ -95,11 +138,14 @@ function SetupTrustedProxyStep() {
       userEmailHeader: prefillHeader,
       trustedProxyCidrs: '',
       sharedSecret: '',
+      cloudflareTeamDomain: '',
+      cloudflareAudience: '',
     },
     mode: 'onBlur',
   })
 
   useSetupModeGuard(status, 'trusted_proxy')
+  const proxyPreset = form.watch('proxyPreset')
 
   const errorMessage = configureMutation.error
     ? getApiErrorMessage(configureMutation.error, {
@@ -120,10 +166,16 @@ function SetupTrustedProxyStep() {
     configureMutation.mutate(
       {
         sessionToken,
-        userEmailHeader: values.userEmailHeader.trim(),
+        proofProvider:
+          values.proxyPreset === 'cloudflare_access'
+            ? 'cloudflare_access'
+            : 'shared_secret',
+        userEmailHeader: values.userEmailHeader?.trim(),
         setupOwnerEmail: values.ownerEmail.trim().toLowerCase(),
         trustedProxyCidrs: parseCidrs(values.trustedProxyCidrs),
         sharedSecret: values.sharedSecret?.trim() || undefined,
+        cloudflareTeamDomain: values.cloudflareTeamDomain?.trim() || undefined,
+        cloudflareAudience: values.cloudflareAudience?.trim() || undefined,
       },
       {
         onSuccess: () => {
@@ -140,10 +192,9 @@ function SetupTrustedProxyStep() {
     <div className="space-y-4">
       <PageMeta title="Setup Trusted Proxy" />
       <div className="space-y-1">
-        <h2 className="text-lg font-medium">Trusted Proxy configuration</h2>
+        <h2 className="text-lg font-medium">Access provider</h2>
         <p className="text-sm text-muted-foreground">
-          Configure how Oore reads identity headers forwarded by your
-          authentication proxy.
+          Choose how the service in front of Oore proves each user identity.
         </p>
       </div>
 
@@ -199,6 +250,9 @@ function SetupTrustedProxyStep() {
                       <SelectValue placeholder="Choose proxy" />
                     </SelectTrigger>
                     <SelectContent>
+                      <SelectItem value="cloudflare_access">
+                        Cloudflare Access
+                      </SelectItem>
                       <SelectItem value="generic">Generic proxy</SelectItem>
                       <SelectItem value="warpgate">Warpgate</SelectItem>
                       <SelectItem value="custom">Custom header</SelectItem>
@@ -206,103 +260,167 @@ function SetupTrustedProxyStep() {
                   </Select>
                 </FormControl>
                 <p className="text-xs text-muted-foreground">
-                  Warpgate uses <code>x-warpgate-username</code>. Generic uses{' '}
-                  <code>x-oore-user-email</code>.
+                  Cloudflare Access uses a signed identity token. Other choices
+                  use a trusted header and shared secret.
                 </p>
                 <FormMessage />
               </FormItem>
             )}
           />
 
-          <FormField
-            control={form.control}
-            name="userEmailHeader"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>User email header</FormLabel>
-                <FormControl>
-                  <Input
-                    {...field}
-                    placeholder="x-oore-user-email"
-                    onChange={(event) => {
-                      const nextHeader = event.target.value
-                      field.onChange(nextHeader)
-                      const currentPreset = form.getValues('proxyPreset')
-                      const presetHeader = headerForPreset(currentPreset)
-                      if (
-                        presetHeader &&
-                        nextHeader.trim().toLowerCase() !== presetHeader
-                      ) {
-                        form.setValue('proxyPreset', 'custom', {
-                          shouldDirty: true,
-                          shouldValidate: true,
-                        })
-                      }
-                    }}
-                    disabled={configureMutation.isPending}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+          {proxyPreset !== 'cloudflare_access' ? (
+            <FormField
+              control={form.control}
+              name="userEmailHeader"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>User email header</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder="x-oore-user-email"
+                      onChange={(event) => {
+                        const nextHeader = event.target.value
+                        field.onChange(nextHeader)
+                        const currentPreset = form.getValues('proxyPreset')
+                        const presetHeader = headerForPreset(currentPreset)
+                        if (
+                          presetHeader &&
+                          nextHeader.trim().toLowerCase() !== presetHeader
+                        ) {
+                          form.setValue('proxyPreset', 'custom', {
+                            shouldDirty: true,
+                            shouldValidate: true,
+                          })
+                        }
+                      }}
+                      disabled={configureMutation.isPending}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          ) : null}
 
-          <FormField
-            control={form.control}
-            name="trustedProxyCidrs"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Trusted proxy CIDRs (optional)</FormLabel>
-                <FormControl>
-                  <Input
-                    {...field}
-                    placeholder="10.0.0.0/24, 100.64.0.0/10"
-                    disabled={configureMutation.isPending}
-                  />
-                </FormControl>
-                <p className="text-xs text-muted-foreground">
-                  Leave empty when the proxy reaches oored over loopback.
-                </p>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+          {proxyPreset === 'cloudflare_access' ? (
+            <>
+              <FormField
+                control={form.control}
+                name="cloudflareTeamDomain"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Cloudflare Access team domain</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        placeholder="your-team.cloudflareaccess.com"
+                        autoCapitalize="none"
+                        autoCorrect="off"
+                        disabled={configureMutation.isPending}
+                      />
+                    </FormControl>
+                    <p className="text-xs text-muted-foreground">
+                      Copy the team domain from Cloudflare Zero Trust settings.
+                    </p>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
-          <FormField
-            control={form.control}
-            name="sharedSecret"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Optional shared secret</FormLabel>
-                <FormControl>
-                  <Input
-                    {...field}
-                    type="password"
-                    placeholder="Optional defense-in-depth secret"
+              <FormField
+                control={form.control}
+                name="cloudflareAudience"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Application audience tag</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        placeholder="Application Audience (AUD) Tag"
+                        autoCapitalize="none"
+                        autoCorrect="off"
+                        disabled={configureMutation.isPending}
+                      />
+                    </FormControl>
+                    <p className="text-xs text-muted-foreground">
+                      Open the Access application overview and copy its AUD tag.
+                    </p>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <Alert>
+                <AlertTitle>Cloudflare protects the backend URL</AlertTitle>
+                <AlertDescription>
+                  Keep the tunnel pointed at Oore on loopback. Oore still
+                  verifies every signed Access token.
+                </AlertDescription>
+              </Alert>
+            </>
+          ) : null}
+
+          {proxyPreset !== 'cloudflare_access' ? (
+            <FormField
+              control={form.control}
+              name="trustedProxyCidrs"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Trusted proxy CIDRs (optional)</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder="10.0.0.0/24, 100.64.0.0/10"
+                      disabled={configureMutation.isPending}
+                    />
+                  </FormControl>
+                  <p className="text-xs text-muted-foreground">
+                    Leave empty when the proxy reaches oored over loopback.
+                  </p>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          ) : null}
+
+          {proxyPreset !== 'cloudflare_access' ? (
+            <FormField
+              control={form.control}
+              name="sharedSecret"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Shared secret</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      type="password"
+                      placeholder="Optional defense-in-depth secret"
+                      disabled={configureMutation.isPending}
+                    />
+                  </FormControl>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() =>
+                      form.setValue('sharedSecret', generateSharedSecret(), {
+                        shouldDirty: true,
+                      })
+                    }
                     disabled={configureMutation.isPending}
-                  />
-                </FormControl>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() =>
-                    form.setValue('sharedSecret', generateSharedSecret(), {
-                      shouldDirty: true,
-                    })
-                  }
-                  disabled={configureMutation.isPending}
-                  className="w-full"
-                >
-                  Generate random secret
-                </Button>
-                <p className="text-xs text-muted-foreground">
-                  Save this value now. After configuration, the secret is
-                  write-only.
-                </p>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+                    className="w-full"
+                  >
+                    Generate random secret
+                  </Button>
+                  <p className="text-xs text-muted-foreground">
+                    Save this value now. After configuration, the secret is
+                    write-only.
+                  </p>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          ) : null}
 
           {errorMessage ? (
             <Alert variant="destructive">

--- a/crates/oore-contract/src/lib.rs
+++ b/crates/oore-contract/src/lib.rs
@@ -185,6 +185,8 @@ pub struct SetupPreferencesResponse {
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct SetupTrustedProxyConfigureRequest {
+    #[serde(default)]
+    pub proof_provider: TrustedProxyProofProvider,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_email_header: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -193,17 +195,51 @@ pub struct SetupTrustedProxyConfigureRequest {
     pub trusted_proxy_cidrs: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shared_secret: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cloudflare_team_domain: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cloudflare_audience: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct SetupTrustedProxyConfigureResponse {
     pub state: SetupState,
+    pub proof_provider: TrustedProxyProofProvider,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub setup_owner_email: Option<String>,
     pub has_shared_secret: bool,
     pub configured_at: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session_expires_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum TrustedProxyProofProvider {
+    #[default]
+    SharedSecret,
+    CloudflareAccess,
+}
+
+impl TrustedProxyProofProvider {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SharedSecret => "shared_secret",
+            Self::CloudflareAccess => "cloudflare_access",
+        }
+    }
+}
+
+impl std::str::FromStr for TrustedProxyProofProvider {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "shared_secret" => Ok(Self::SharedSecret),
+            "cloudflare_access" => Ok(Self::CloudflareAccess),
+            other => Err(format!("invalid trusted proxy proof provider: {other}")),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -1902,12 +1938,17 @@ pub struct TestOidcConnectionResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct TrustedProxySettingsPublic {
+    pub proof_provider: TrustedProxyProofProvider,
     pub user_email_header: String,
     pub trusted_proxy_cidrs: Vec<String>,
     pub has_shared_secret: bool,
     pub has_warpgate_ticket: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warpgate_ticket_source: Option<WarpgateTicketSource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cloudflare_team_domain: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cloudflare_audience: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<i64>,
 }
@@ -1927,6 +1968,8 @@ pub struct TrustedProxySettingsResponse {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct UpdateTrustedProxySettingsRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub proof_provider: Option<TrustedProxyProofProvider>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub user_email_header: Option<String>,
     #[serde(default)]
     pub trusted_proxy_cidrs: Vec<String>,
@@ -1934,6 +1977,10 @@ pub struct UpdateTrustedProxySettingsRequest {
     pub shared_secret: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warpgate_ticket: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cloudflare_team_domain: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cloudflare_audience: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/crates/oored/migrations/041_cloudflare_access_auth.sql
+++ b/crates/oored/migrations/041_cloudflare_access_auth.sql
@@ -1,0 +1,9 @@
+ALTER TABLE trusted_proxy_settings
+  ADD COLUMN proof_provider TEXT NOT NULL DEFAULT 'shared_secret'
+  CHECK (proof_provider IN ('shared_secret', 'cloudflare_access'));
+
+ALTER TABLE trusted_proxy_settings
+  ADD COLUMN cloudflare_team_domain TEXT;
+
+ALTER TABLE trusted_proxy_settings
+  ADD COLUMN cloudflare_audience TEXT;

--- a/crates/oored/src/auth.rs
+++ b/crates/oored/src/auth.rs
@@ -1392,13 +1392,12 @@ pub async fn trusted_proxy_login(
         ));
     }
 
-    crate::instance_settings::verify_trusted_proxy_shared_secret(
+    let email = crate::instance_settings::authenticate_trusted_proxy_identity(
+        &state,
         &headers,
         &proxy_settings,
-        &state.encryption_key,
-    )?;
-
-    let email = crate::instance_settings::extract_trusted_proxy_email(&headers, &proxy_settings)?;
+    )
+    .await?;
     let subject = trusted_proxy_subject_for_email(&email);
 
     let row = sqlx::query(

--- a/crates/oored/src/auth.rs
+++ b/crates/oored/src/auth.rs
@@ -38,10 +38,6 @@ fn local_subject_for_email(email: &str) -> String {
     format!("local::{}", email.trim().to_lowercase())
 }
 
-fn trusted_proxy_subject_for_email(email: &str) -> String {
-    format!("trusted-proxy::{}", email.trim().to_lowercase())
-}
-
 fn require_verified_invitation_email(
     email_verified: Option<bool>,
 ) -> Result<(), (StatusCode, Json<ApiError>)> {
@@ -1392,19 +1388,20 @@ pub async fn trusted_proxy_login(
         ));
     }
 
-    let email = crate::instance_settings::authenticate_trusted_proxy_identity(
+    let identity = crate::instance_settings::authenticate_trusted_proxy_identity(
         &state,
         &headers,
         &proxy_settings,
     )
     .await?;
-    let subject = trusted_proxy_subject_for_email(&email);
+    let email = &identity.email;
+    let subject = identity.subject;
 
     let row = sqlx::query(
         "SELECT id, email, role, status, oidc_subject, avatar_url \
          FROM users WHERE lower(email) = lower(?1) LIMIT 1",
     )
-    .bind(&email)
+    .bind(email)
     .fetch_optional(pool)
     .await
     .map_err(|e| {
@@ -1468,6 +1465,13 @@ pub async fn trusted_proxy_login(
         .await;
         subject
     } else {
+        if current_subject != subject {
+            return Err(api_err(
+                StatusCode::FORBIDDEN,
+                "trusted_proxy_subject_mismatch",
+                "This user identity does not match the existing account",
+            ));
+        }
         current_subject
     };
 

--- a/crates/oored/src/cloudflare_access.rs
+++ b/crates/oored/src/cloudflare_access.rs
@@ -235,16 +235,25 @@ impl CloudflareAccessVerifier {
 }
 
 fn cache_ttl(headers: &reqwest::header::HeaderMap) -> Duration {
-    let Some(value) = headers
-        .get(reqwest::header::CACHE_CONTROL)
-        .and_then(|value| value.to_str().ok())
-    else {
-        return DEFAULT_CACHE_TTL;
-    };
-    value
-        .split(',')
-        .map(str::trim)
+    let directives = headers
+        .get_all(reqwest::header::CACHE_CONTROL)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .flat_map(|value| value.split(','))
+        .map(|directive| directive.trim().to_ascii_lowercase())
+        .collect::<Vec<_>>();
+    if directives.iter().any(|directive| {
+        matches!(
+            directive.as_str(),
+            "no-store" | "no-cache" | "must-revalidate"
+        )
+    }) {
+        return Duration::ZERO;
+    }
+    directives
+        .iter()
         .find_map(|directive| directive.strip_prefix("max-age="))
+        .map(|seconds| seconds.trim_matches('"'))
         .and_then(|seconds| seconds.parse::<u64>().ok())
         .map(Duration::from_secs)
         .map(|duration| duration.min(MAX_CACHE_TTL))

--- a/crates/oored/src/cloudflare_access.rs
+++ b/crates/oored/src/cloudflare_access.rs
@@ -20,9 +20,10 @@ const MAX_JWKS_KEYS: usize = 64;
 const MAX_KID_BYTES: usize = 256;
 const MAX_SUBJECT_BYTES: usize = 512;
 const MAX_AUDIENCE_BYTES: usize = 512;
-const CACHE_TTL: Duration = Duration::from_secs(5 * 60);
+const MAX_CACHE_TTL: Duration = Duration::from_secs(5 * 60);
 const UNKNOWN_KEY_REFRESH_COOLDOWN: Duration = Duration::from_secs(30);
 const CLOCK_LEEWAY_SECONDS: u64 = 30;
+const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(60);
 
 type ApiResult<T> = Result<T, (StatusCode, Json<ApiError>)>;
 
@@ -30,8 +31,13 @@ type ApiResult<T> = Result<T, (StatusCode, Json<ApiError>)>;
 struct CachedKeys {
     team_domain: String,
     keys: JwkSet,
-    fetched_at: Instant,
     expires_at: Instant,
+    last_unknown_refresh_at: Option<Instant>,
+}
+
+pub struct CloudflareAccessIdentity {
+    pub email: String,
+    pub subject: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -62,11 +68,11 @@ impl CloudflareAccessVerifier {
         })
     }
 
-    pub async fn verified_email(
+    pub async fn verified_identity(
         &self,
         headers: &HeaderMap,
         settings: &EffectiveTrustedProxySettings,
-    ) -> ApiResult<String> {
+    ) -> ApiResult<CloudflareAccessIdentity> {
         let team_domain = settings
             .cloudflare_team_domain
             .as_deref()
@@ -101,10 +107,10 @@ impl CloudflareAccessVerifier {
             .filter(|value| !value.is_empty() && value.len() <= MAX_KID_BYTES)
             .ok_or_else(invalid_assertion)?;
 
-        let mut keys = self.load_keys(team_domain, false).await?;
+        let (mut keys, fetched_now) = self.load_keys(team_domain, false).await?;
         let mut jwk = keys.find(kid);
-        if jwk.is_none() {
-            keys = self.load_keys(team_domain, true).await?;
+        if jwk.is_none() && !fetched_now {
+            (keys, _) = self.load_keys(team_domain, true).await?;
             jwk = keys.find(kid);
         }
         let jwk = jwk.ok_or_else(invalid_assertion)?;
@@ -121,6 +127,7 @@ impl CloudflareAccessVerifier {
         let mut validation = Validation::new(Algorithm::RS256);
         validation.algorithms = vec![Algorithm::RS256];
         validation.leeway = CLOCK_LEEWAY_SECONDS;
+        validation.validate_nbf = true;
         validation.set_required_spec_claims(&["exp", "iss", "aud", "sub", "iat"]);
         validation.set_issuer(&[issuer]);
         validation.set_audience(&[audience]);
@@ -140,24 +147,30 @@ impl CloudflareAccessVerifier {
             return Err(invalid_assertion());
         }
 
-        normalize_email_value(&claims.email).ok_or_else(invalid_assertion)
+        let email = normalize_email_value(&claims.email).ok_or_else(invalid_assertion)?;
+        Ok(CloudflareAccessIdentity {
+            email,
+            subject: format!("cloudflare-access::{team_domain}::{}", claims.sub),
+        })
     }
 
-    async fn load_keys(&self, team_domain: &str, force_refresh: bool) -> ApiResult<JwkSet> {
+    async fn load_keys(&self, team_domain: &str, force_refresh: bool) -> ApiResult<(JwkSet, bool)> {
         let mut cache = self.cache.lock().await;
         if !force_refresh
             && let Some(cached) = cache.as_ref()
             && cached.team_domain == team_domain
             && cached.expires_at > Instant::now()
         {
-            return Ok(cached.keys.clone());
+            return Ok((cached.keys.clone(), false));
         }
         if force_refresh
             && let Some(cached) = cache.as_ref()
             && cached.team_domain == team_domain
-            && cached.fetched_at.elapsed() < UNKNOWN_KEY_REFRESH_COOLDOWN
+            && cached
+                .last_unknown_refresh_at
+                .is_some_and(|refreshed_at| refreshed_at.elapsed() < UNKNOWN_KEY_REFRESH_COOLDOWN)
         {
-            return Ok(cached.keys.clone());
+            return Ok((cached.keys.clone(), false));
         }
 
         let url = format!("https://{team_domain}/cdn-cgi/access/certs");
@@ -178,6 +191,7 @@ impl CloudflareAccessVerifier {
         {
             return Err(unavailable("Cloudflare Access signing keys were too large"));
         }
+        let cache_ttl = cache_ttl(response.headers());
 
         let mut body = Vec::new();
         while let Some(chunk) = response
@@ -213,11 +227,28 @@ impl CloudflareAccessVerifier {
         *cache = Some(CachedKeys {
             team_domain: team_domain.to_string(),
             keys: keys.clone(),
-            fetched_at,
-            expires_at: fetched_at + CACHE_TTL,
+            expires_at: fetched_at + cache_ttl,
+            last_unknown_refresh_at: force_refresh.then_some(fetched_at),
         });
-        Ok(keys)
+        Ok((keys, true))
     }
+}
+
+fn cache_ttl(headers: &reqwest::header::HeaderMap) -> Duration {
+    let Some(value) = headers
+        .get(reqwest::header::CACHE_CONTROL)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return DEFAULT_CACHE_TTL;
+    };
+    value
+        .split(',')
+        .map(str::trim)
+        .find_map(|directive| directive.strip_prefix("max-age="))
+        .and_then(|seconds| seconds.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .map(|duration| duration.min(MAX_CACHE_TTL))
+        .unwrap_or(DEFAULT_CACHE_TTL)
 }
 
 pub fn normalize_team_domain(raw: Option<String>) -> ApiResult<Option<String>> {

--- a/crates/oored/src/cloudflare_access.rs
+++ b/crates/oored/src/cloudflare_access.rs
@@ -128,7 +128,7 @@ impl CloudflareAccessVerifier {
         validation.algorithms = vec![Algorithm::RS256];
         validation.leeway = CLOCK_LEEWAY_SECONDS;
         validation.validate_nbf = true;
-        validation.set_required_spec_claims(&["exp", "iss", "aud", "sub", "iat"]);
+        validation.set_required_spec_claims(&["exp", "iss", "aud", "sub", "iat", "nbf"]);
         validation.set_issuer(&[issuer]);
         validation.set_audience(&[audience]);
 

--- a/crates/oored/src/cloudflare_access.rs
+++ b/crates/oored/src/cloudflare_access.rs
@@ -1,0 +1,326 @@
+use std::collections::HashSet;
+use std::time::{Duration, Instant};
+
+use axum::Json;
+use axum::http::{HeaderMap, StatusCode};
+use jsonwebtoken::jwk::{JwkSet, KeyAlgorithm};
+use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header};
+use oore_contract::ApiError;
+use serde::Deserialize;
+use tokio::sync::Mutex;
+
+use crate::instance_settings::{EffectiveTrustedProxySettings, normalize_email_value};
+use crate::util::{api_err, now_unix};
+
+pub const ASSERTION_HEADER: &str = "cf-access-jwt-assertion";
+const TEAM_DOMAIN_SUFFIX: &str = ".cloudflareaccess.com";
+const MAX_TOKEN_BYTES: usize = 32 * 1024;
+const MAX_JWKS_BYTES: usize = 256 * 1024;
+const MAX_JWKS_KEYS: usize = 64;
+const MAX_KID_BYTES: usize = 256;
+const MAX_SUBJECT_BYTES: usize = 512;
+const MAX_AUDIENCE_BYTES: usize = 512;
+const CACHE_TTL: Duration = Duration::from_secs(5 * 60);
+const UNKNOWN_KEY_REFRESH_COOLDOWN: Duration = Duration::from_secs(30);
+const CLOCK_LEEWAY_SECONDS: u64 = 30;
+
+type ApiResult<T> = Result<T, (StatusCode, Json<ApiError>)>;
+
+#[derive(Debug, Clone)]
+struct CachedKeys {
+    team_domain: String,
+    keys: JwkSet,
+    fetched_at: Instant,
+    expires_at: Instant,
+}
+
+#[derive(Debug, Deserialize)]
+struct CloudflareClaims {
+    email: String,
+    sub: String,
+    iat: i64,
+    #[serde(rename = "type")]
+    token_type: Option<String>,
+}
+
+pub struct CloudflareAccessVerifier {
+    client: reqwest::Client,
+    cache: Mutex<Option<CachedKeys>>,
+}
+
+impl CloudflareAccessVerifier {
+    pub fn new() -> anyhow::Result<Self> {
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(10))
+            .redirect(reqwest::redirect::Policy::none())
+            .user_agent(concat!("oored/", env!("CARGO_PKG_VERSION")))
+            .build()?;
+        Ok(Self {
+            client,
+            cache: Mutex::new(None),
+        })
+    }
+
+    pub async fn verified_email(
+        &self,
+        headers: &HeaderMap,
+        settings: &EffectiveTrustedProxySettings,
+    ) -> ApiResult<String> {
+        let team_domain = settings
+            .cloudflare_team_domain
+            .as_deref()
+            .ok_or_else(|| config_error("Cloudflare Access team domain is not configured"))?;
+        let audience = settings.cloudflare_audience.as_deref().ok_or_else(|| {
+            config_error("Cloudflare Access application audience is not configured")
+        })?;
+
+        let token = headers
+            .get(ASSERTION_HEADER)
+            .and_then(|value| value.to_str().ok())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                api_err(
+                    StatusCode::UNAUTHORIZED,
+                    "cloudflare_access_assertion_missing",
+                    "Cloudflare Access did not provide a signed user assertion",
+                )
+            })?;
+        if token.len() > MAX_TOKEN_BYTES {
+            return Err(invalid_assertion());
+        }
+
+        let header = decode_header(token).map_err(|_| invalid_assertion())?;
+        if header.alg != Algorithm::RS256 {
+            return Err(invalid_assertion());
+        }
+        let kid = header
+            .kid
+            .as_deref()
+            .filter(|value| !value.is_empty() && value.len() <= MAX_KID_BYTES)
+            .ok_or_else(invalid_assertion)?;
+
+        let mut keys = self.load_keys(team_domain, false).await?;
+        let mut jwk = keys.find(kid);
+        if jwk.is_none() {
+            keys = self.load_keys(team_domain, true).await?;
+            jwk = keys.find(kid);
+        }
+        let jwk = jwk.ok_or_else(invalid_assertion)?;
+        if jwk
+            .common
+            .key_algorithm
+            .is_some_and(|alg| alg != KeyAlgorithm::RS256)
+        {
+            return Err(invalid_assertion());
+        }
+        let decoding_key = DecodingKey::from_jwk(jwk).map_err(|_| invalid_assertion())?;
+
+        let issuer = format!("https://{team_domain}");
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.algorithms = vec![Algorithm::RS256];
+        validation.leeway = CLOCK_LEEWAY_SECONDS;
+        validation.set_required_spec_claims(&["exp", "iss", "aud", "sub", "iat"]);
+        validation.set_issuer(&[issuer]);
+        validation.set_audience(&[audience]);
+
+        let claims = decode::<CloudflareClaims>(token, &decoding_key, &validation)
+            .map_err(|_| invalid_assertion())?
+            .claims;
+        if claims
+            .token_type
+            .as_deref()
+            .is_some_and(|token_type| token_type != "app")
+            || claims.sub.is_empty()
+            || claims.sub.len() > MAX_SUBJECT_BYTES
+            || claims.iat <= 0
+            || claims.iat > now_unix().saturating_add(CLOCK_LEEWAY_SECONDS as i64)
+        {
+            return Err(invalid_assertion());
+        }
+
+        normalize_email_value(&claims.email).ok_or_else(invalid_assertion)
+    }
+
+    async fn load_keys(&self, team_domain: &str, force_refresh: bool) -> ApiResult<JwkSet> {
+        let mut cache = self.cache.lock().await;
+        if !force_refresh
+            && let Some(cached) = cache.as_ref()
+            && cached.team_domain == team_domain
+            && cached.expires_at > Instant::now()
+        {
+            return Ok(cached.keys.clone());
+        }
+        if force_refresh
+            && let Some(cached) = cache.as_ref()
+            && cached.team_domain == team_domain
+            && cached.fetched_at.elapsed() < UNKNOWN_KEY_REFRESH_COOLDOWN
+        {
+            return Ok(cached.keys.clone());
+        }
+
+        let url = format!("https://{team_domain}/cdn-cgi/access/certs");
+        let mut response = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .map_err(|_| unavailable("Cloudflare Access signing keys could not be reached"))?;
+        if !response.status().is_success() {
+            return Err(unavailable(
+                "Cloudflare Access signing keys returned an error",
+            ));
+        }
+        if response
+            .content_length()
+            .is_some_and(|length| length > MAX_JWKS_BYTES as u64)
+        {
+            return Err(unavailable("Cloudflare Access signing keys were too large"));
+        }
+
+        let mut body = Vec::new();
+        while let Some(chunk) = response
+            .chunk()
+            .await
+            .map_err(|_| unavailable("Cloudflare Access signing keys could not be read"))?
+        {
+            if body.len().saturating_add(chunk.len()) > MAX_JWKS_BYTES {
+                return Err(unavailable("Cloudflare Access signing keys were too large"));
+            }
+            body.extend_from_slice(&chunk);
+        }
+
+        let keys: JwkSet = serde_json::from_slice(&body)
+            .map_err(|_| unavailable("Cloudflare Access signing keys were invalid"))?;
+        if keys.keys.is_empty() || keys.keys.len() > MAX_JWKS_KEYS {
+            return Err(unavailable("Cloudflare Access signing keys were invalid"));
+        }
+        let mut key_ids = HashSet::with_capacity(keys.keys.len());
+        for key in &keys.keys {
+            let Some(kid) = key.common.key_id.as_deref() else {
+                return Err(unavailable("Cloudflare Access signing keys were invalid"));
+            };
+            if kid.is_empty() || kid.len() > MAX_KID_BYTES {
+                return Err(unavailable("Cloudflare Access signing keys were invalid"));
+            }
+            if key.common.key_algorithm != Some(KeyAlgorithm::RS256) || !key_ids.insert(kid) {
+                return Err(unavailable("Cloudflare Access signing keys were invalid"));
+            }
+        }
+
+        let fetched_at = Instant::now();
+        *cache = Some(CachedKeys {
+            team_domain: team_domain.to_string(),
+            keys: keys.clone(),
+            fetched_at,
+            expires_at: fetched_at + CACHE_TTL,
+        });
+        Ok(keys)
+    }
+}
+
+pub fn normalize_team_domain(raw: Option<String>) -> ApiResult<Option<String>> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    let trimmed = raw.trim().trim_end_matches('/').to_ascii_lowercase();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let host = if trimmed.starts_with("https://") {
+        let url = url::Url::parse(&trimmed).map_err(|_| invalid_configuration())?;
+        if !url.username().is_empty()
+            || url.password().is_some()
+            || url.port().is_some()
+            || url.path() != "/"
+            || url.query().is_some()
+            || url.fragment().is_some()
+        {
+            return Err(invalid_configuration());
+        }
+        url.host_str()
+            .map(str::to_string)
+            .ok_or_else(invalid_configuration)?
+    } else if trimmed.contains("://") || trimmed.contains('/') {
+        return Err(invalid_configuration());
+    } else {
+        trimmed
+    };
+    let Some(team) = host.strip_suffix(TEAM_DOMAIN_SUFFIX) else {
+        return Err(invalid_configuration());
+    };
+    if host.len() > 253
+        || team.is_empty()
+        || team.len() > 63
+        || team.contains('.')
+        || !team
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        || !team
+            .as_bytes()
+            .first()
+            .is_some_and(u8::is_ascii_alphanumeric)
+        || !team
+            .as_bytes()
+            .last()
+            .is_some_and(u8::is_ascii_alphanumeric)
+    {
+        return Err(invalid_configuration());
+    }
+    Ok(Some(host))
+}
+
+pub fn normalize_audience(raw: Option<String>) -> ApiResult<Option<String>> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    let value = raw.trim();
+    if value.is_empty() {
+        return Ok(None);
+    }
+    if value.len() > MAX_AUDIENCE_BYTES
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+    {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "invalid_input",
+            "Cloudflare Access application audience is invalid",
+        ));
+    }
+    Ok(Some(value.to_string()))
+}
+
+fn invalid_configuration() -> (StatusCode, Json<ApiError>) {
+    api_err(
+        StatusCode::BAD_REQUEST,
+        "invalid_input",
+        "Cloudflare Access team domain must use the team.cloudflareaccess.com domain",
+    )
+}
+
+fn invalid_assertion() -> (StatusCode, Json<ApiError>) {
+    api_err(
+        StatusCode::UNAUTHORIZED,
+        "cloudflare_access_assertion_invalid",
+        "Cloudflare Access user assertion is invalid",
+    )
+}
+
+fn unavailable(message: &'static str) -> (StatusCode, Json<ApiError>) {
+    api_err(
+        StatusCode::SERVICE_UNAVAILABLE,
+        "cloudflare_access_keys_unavailable",
+        message,
+    )
+}
+
+fn config_error(message: &'static str) -> (StatusCode, Json<ApiError>) {
+    api_err(
+        StatusCode::SERVICE_UNAVAILABLE,
+        "trusted_proxy_config_invalid",
+        message,
+    )
+}

--- a/crates/oored/src/instance_settings.rs
+++ b/crates/oored/src/instance_settings.rs
@@ -159,6 +159,13 @@ fn with_local_defaults(mut origins: Vec<String>) -> Vec<String> {
     dedupe_preserve_order(origins)
 }
 
+fn without_local_defaults(origins: Vec<String>) -> Vec<String> {
+    origins
+        .into_iter()
+        .filter(|origin| !DEFAULT_ALLOWED_ORIGINS.contains(&origin.as_str()))
+        .collect()
+}
+
 fn parse_db_allowed_origins(raw_json: &str) -> Vec<String> {
     let parsed: Vec<String> = serde_json::from_str(raw_json).unwrap_or_default();
     dedupe_preserve_order(
@@ -232,7 +239,15 @@ pub(crate) fn normalize_requested_trusted_proxy_cidrs(
 pub async fn load_effective_external_access_network_settings(
     pool: &sqlx::SqlitePool,
 ) -> anyhow::Result<EffectiveExternalAccessNetworkSettings> {
-    let include_local_defaults = load_runtime_mode(pool).await? == RuntimeMode::Local;
+    let runtime_mode = load_runtime_mode(pool).await?;
+    load_effective_external_access_network_settings_for_mode(pool, runtime_mode).await
+}
+
+pub(crate) async fn load_effective_external_access_network_settings_for_mode(
+    pool: &sqlx::SqlitePool,
+    runtime_mode: RuntimeMode,
+) -> anyhow::Result<EffectiveExternalAccessNetworkSettings> {
+    let include_local_defaults = runtime_mode == RuntimeMode::Local;
     let env_public_url = std::env::var("OORE_PUBLIC_URL")
         .ok()
         .and_then(|value| trim_opt(Some(value)));
@@ -270,7 +285,7 @@ pub async fn load_effective_external_access_network_settings(
             allowed_origins: if include_local_defaults {
                 with_local_defaults(allowed_origins)
             } else {
-                allowed_origins
+                without_local_defaults(allowed_origins)
             },
             source: ExternalAccessNetworkSource::Database,
             updated_at: row.try_get::<Option<i64>, _>("updated_at").ok().flatten(),
@@ -290,7 +305,7 @@ pub async fn load_effective_external_access_network_settings(
             allowed_origins: if include_local_defaults {
                 with_local_defaults(parsed)
             } else {
-                parsed
+                without_local_defaults(parsed)
             },
             source: ExternalAccessNetworkSource::Environment,
             updated_at: None,
@@ -471,7 +486,7 @@ fn normalize_requested_allowed_origins(
     if include_local_defaults {
         Ok(with_local_defaults(normalized))
     } else {
-        Ok(normalized)
+        Ok(without_local_defaults(normalized))
     }
 }
 
@@ -2263,6 +2278,23 @@ pub async fn update_instance_preferences(
         preflight_result = Some(result);
     }
 
+    let next_network_settings = if runtime_mode_changed {
+        Some(
+            load_effective_external_access_network_settings_for_mode(&pool, runtime_mode)
+                .await
+                .map_err(|e| {
+                    error!(error = %e, "failed to prepare allowed origins for runtime mode change");
+                    api_err(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "store_error",
+                        "Failed to prepare the External Access network policy",
+                    )
+                })?,
+        )
+    } else {
+        None
+    };
+
     // File mode is the only supported mode in this release. The runtime key was
     // already loaded from (or created in) file storage during daemon startup, so
     // updating unrelated preferences must not rewrite it through a global path.
@@ -2310,6 +2342,11 @@ pub async fn update_instance_preferences(
             "preferences_changed",
             "Instance preferences changed while you were saving. Review the current settings and try again.",
         ));
+    }
+
+    if let Some(network_settings) = next_network_settings {
+        let mut allowed_origins = state.allowed_origins.write().await;
+        *allowed_origins = network_settings.allowed_origins;
     }
 
     let persisted_runtime_mode = load_runtime_mode(&pool).await.map_err(|e| {

--- a/crates/oored/src/instance_settings.rs
+++ b/crates/oored/src/instance_settings.rs
@@ -1610,6 +1610,7 @@ pub async fn update_external_access_network_settings(
     Json(req): Json<UpdateExternalAccessNetworkSettingsRequest>,
 ) -> ApiResult<ExternalAccessNetworkSettingsResponse> {
     check_permission(&state.enforcer, &auth.0.role, "instance_settings", "write").await?;
+    let _settings_update_guard = state.instance_settings_update.lock().await;
 
     if auth.0.role != "owner" {
         return Err(api_err(
@@ -2175,6 +2176,7 @@ pub async fn update_instance_preferences(
     Json(req): Json<UpdateInstancePreferencesRequest>,
 ) -> ApiResult<InstancePreferencesResponse> {
     check_permission(&state.enforcer, &auth.0.role, "instance_settings", "write").await?;
+    let _settings_update_guard = state.instance_settings_update.lock().await;
 
     let pool = state.db.clone();
     let now = now_unix();

--- a/crates/oored/src/instance_settings.rs
+++ b/crates/oored/src/instance_settings.rs
@@ -13,8 +13,8 @@ use oore_contract::{
     ExternalAccessNetworkSource, ExternalAccessPreflightCheck, ExternalAccessPreflightResponse,
     GetExternalAccessOidcResponse, InstancePreferences, InstancePreferencesResponse,
     KeyStorageMode, OidcConfigRecord, OidcSecretRecord, RemoteAuthMode, RuntimeMode, SetupState,
-    TestOidcConnectionRequest, TestOidcConnectionResponse, TrustedProxySettingsPublic,
-    TrustedProxySettingsResponse, UpdateArtifactStorageSettingsRequest,
+    TestOidcConnectionRequest, TestOidcConnectionResponse, TrustedProxyProofProvider,
+    TrustedProxySettingsPublic, TrustedProxySettingsResponse, UpdateArtifactStorageSettingsRequest,
     UpdateExternalAccessNetworkSettingsRequest, UpdateInstancePreferencesRequest,
     UpdateTrustedProxySettingsRequest, WarpgateTicketSource,
 };
@@ -80,6 +80,7 @@ pub struct EffectiveExternalAccessNetworkSettings {
 
 #[derive(Debug, Clone)]
 pub struct EffectiveTrustedProxySettings {
+    pub proof_provider: TrustedProxyProofProvider,
     pub user_email_header: String,
     pub setup_owner_email: Option<String>,
     pub trusted_proxy_cidrs: Vec<String>,
@@ -89,6 +90,8 @@ pub struct EffectiveTrustedProxySettings {
     pub has_warpgate_ticket: bool,
     pub warpgate_ticket_source: Option<WarpgateTicketSource>,
     pub encrypted_warpgate_ticket: Option<String>,
+    pub cloudflare_team_domain: Option<String>,
+    pub cloudflare_audience: Option<String>,
     pub configured: bool,
     pub updated_at: Option<i64>,
 }
@@ -293,13 +296,18 @@ pub async fn load_effective_trusted_proxy_settings(
     pool: &sqlx::SqlitePool,
 ) -> anyhow::Result<EffectiveTrustedProxySettings> {
     let row = sqlx::query(
-        "SELECT user_email_header, setup_owner_email, trusted_proxy_cidrs_json, encrypted_shared_secret, encrypted_warpgate_ticket, updated_at \
+        "SELECT proof_provider, user_email_header, setup_owner_email, trusted_proxy_cidrs_json, encrypted_shared_secret, encrypted_warpgate_ticket, cloudflare_team_domain, cloudflare_audience, updated_at \
          FROM trusted_proxy_settings WHERE id = 1",
     )
     .fetch_optional(pool)
     .await?;
 
     if let Some(row) = row {
+        let proof_provider = row
+            .try_get::<String, _>("proof_provider")
+            .ok()
+            .and_then(|value| value.parse::<TrustedProxyProofProvider>().ok())
+            .unwrap_or_default();
         let user_email_header = row
             .try_get::<String, _>("user_email_header")
             .ok()
@@ -339,6 +347,7 @@ pub async fn load_effective_trusted_proxy_settings(
         };
 
         return Ok(EffectiveTrustedProxySettings {
+            proof_provider,
             user_email_header,
             setup_owner_email,
             trusted_proxy_cidrs,
@@ -348,6 +357,14 @@ pub async fn load_effective_trusted_proxy_settings(
             has_warpgate_ticket: warpgate_ticket_source.is_some(),
             warpgate_ticket_source,
             encrypted_warpgate_ticket,
+            cloudflare_team_domain: row
+                .try_get::<Option<String>, _>("cloudflare_team_domain")
+                .ok()
+                .flatten(),
+            cloudflare_audience: row
+                .try_get::<Option<String>, _>("cloudflare_audience")
+                .ok()
+                .flatten(),
             configured: true,
             updated_at: row.try_get::<Option<i64>, _>("updated_at").ok().flatten(),
         });
@@ -355,6 +372,7 @@ pub async fn load_effective_trusted_proxy_settings(
 
     let trusted_proxy_cidrs = Vec::new();
     Ok(EffectiveTrustedProxySettings {
+        proof_provider: TrustedProxyProofProvider::SharedSecret,
         user_email_header: DEFAULT_TRUSTED_PROXY_EMAIL_HEADER.to_string(),
         setup_owner_email: None,
         trusted_proxy_networks: parse_cidr_list(&trusted_proxy_cidrs),
@@ -364,6 +382,8 @@ pub async fn load_effective_trusted_proxy_settings(
         has_warpgate_ticket: false,
         warpgate_ticket_source: None,
         encrypted_warpgate_ticket: None,
+        cloudflare_team_domain: None,
+        cloudflare_audience: None,
         configured: false,
         updated_at: None,
     })
@@ -532,11 +552,14 @@ fn trusted_proxy_settings_response(
 ) -> TrustedProxySettingsResponse {
     TrustedProxySettingsResponse {
         settings: TrustedProxySettingsPublic {
+            proof_provider: settings.proof_provider,
             user_email_header: settings.user_email_header,
             trusted_proxy_cidrs: settings.trusted_proxy_cidrs,
             has_shared_secret: settings.has_shared_secret,
             has_warpgate_ticket: settings.has_warpgate_ticket,
             warpgate_ticket_source: settings.warpgate_ticket_source,
+            cloudflare_team_domain: settings.cloudflare_team_domain,
+            cloudflare_audience: settings.cloudflare_audience,
             updated_at: settings.updated_at,
         },
     }
@@ -637,6 +660,25 @@ pub fn extract_trusted_proxy_email(
             "Trusted proxy identity must be an email address. Configure the upstream proxy to forward an email identity.",
         )
     })
+}
+
+pub async fn authenticate_trusted_proxy_identity(
+    state: &AppState,
+    headers: &HeaderMap,
+    settings: &EffectiveTrustedProxySettings,
+) -> Result<String, (StatusCode, Json<ApiError>)> {
+    match settings.proof_provider {
+        TrustedProxyProofProvider::SharedSecret => {
+            verify_trusted_proxy_shared_secret(headers, settings, &state.encryption_key)?;
+            extract_trusted_proxy_email(headers, settings)
+        }
+        TrustedProxyProofProvider::CloudflareAccess => {
+            state
+                .cloudflare_access
+                .verified_email(headers, settings)
+                .await
+        }
+    }
 }
 
 fn build_external_access_check(
@@ -750,8 +792,16 @@ async fn evaluate_external_access_preflight(
                 })?;
 
             let configured = proxy_settings.configured
-                && proxy_settings.has_shared_secret
-                && normalize_header_name(&proxy_settings.user_email_header).is_some();
+                && match proxy_settings.proof_provider {
+                    TrustedProxyProofProvider::SharedSecret => {
+                        proxy_settings.has_shared_secret
+                            && normalize_header_name(&proxy_settings.user_email_header).is_some()
+                    }
+                    TrustedProxyProofProvider::CloudflareAccess => {
+                        proxy_settings.cloudflare_team_domain.is_some()
+                            && proxy_settings.cloudflare_audience.is_some()
+                    }
+                };
             checks.push(build_external_access_check(
                 "trusted_proxy_configured",
                 "Trusted proxy settings are configured",
@@ -1266,7 +1316,7 @@ pub async fn update_external_access_trusted_proxy_settings(
     }
 
     let existing_row =
-        sqlx::query("SELECT encrypted_shared_secret, encrypted_warpgate_ticket FROM trusted_proxy_settings WHERE id = 1")
+        sqlx::query("SELECT proof_provider, encrypted_shared_secret, encrypted_warpgate_ticket, cloudflare_team_domain, cloudflare_audience FROM trusted_proxy_settings WHERE id = 1")
             .fetch_optional(&pool)
             .await
             .map_err(|e| {
@@ -1278,11 +1328,22 @@ pub async fn update_external_access_trusted_proxy_settings(
                 )
             })?;
 
-    let user_email_header = req
-        .user_email_header
-        .as_deref()
-        .and_then(normalize_header_name)
-        .unwrap_or_else(|| DEFAULT_TRUSTED_PROXY_EMAIL_HEADER.to_string());
+    let existing_proof_provider = existing_row
+        .as_ref()
+        .and_then(|row| row.try_get::<String, _>("proof_provider").ok())
+        .and_then(|value| value.parse::<TrustedProxyProofProvider>().ok())
+        .unwrap_or_default();
+    let proof_provider = req.proof_provider.unwrap_or(existing_proof_provider);
+    let user_email_header = match proof_provider {
+        TrustedProxyProofProvider::SharedSecret => req
+            .user_email_header
+            .as_deref()
+            .and_then(normalize_header_name)
+            .unwrap_or_else(|| DEFAULT_TRUSTED_PROXY_EMAIL_HEADER.to_string()),
+        TrustedProxyProofProvider::CloudflareAccess => {
+            crate::cloudflare_access::ASSERTION_HEADER.to_string()
+        }
+    };
 
     let trusted_proxy_cidrs = normalize_requested_trusted_proxy_cidrs(req.trusted_proxy_cidrs)?;
     let trusted_proxy_cidrs_json = serde_json::to_string(&trusted_proxy_cidrs).map_err(|e| {
@@ -1294,8 +1355,9 @@ pub async fn update_external_access_trusted_proxy_settings(
         )
     })?;
 
-    let encrypted_shared_secret = match req.shared_secret {
-        Some(value) => {
+    let encrypted_shared_secret = match (proof_provider, req.shared_secret) {
+        (TrustedProxyProofProvider::CloudflareAccess, _) => None,
+        (TrustedProxyProofProvider::SharedSecret, Some(value)) => {
             let trimmed = value.trim();
             if trimmed.is_empty() {
                 None
@@ -1319,7 +1381,7 @@ pub async fn update_external_access_trusted_proxy_settings(
                 )
             }
         }
-        None => existing_row.as_ref().and_then(|row| {
+        (TrustedProxyProofProvider::SharedSecret, None) => existing_row.as_ref().and_then(|row| {
             row.try_get::<Option<String>, _>("encrypted_shared_secret")
                 .ok()
                 .flatten()
@@ -1335,6 +1397,7 @@ pub async fn update_external_access_trusted_proxy_settings(
                 "Failed to determine remote auth mode",
             )
         })? == RemoteAuthMode::TrustedProxy
+        && proof_provider == TrustedProxyProofProvider::SharedSecret
         && encrypted_shared_secret.is_none()
     {
         return Err(api_err(
@@ -1344,8 +1407,9 @@ pub async fn update_external_access_trusted_proxy_settings(
         ));
     }
 
-    let encrypted_warpgate_ticket = match req.warpgate_ticket {
-        Some(value) => {
+    let encrypted_warpgate_ticket = match (proof_provider, req.warpgate_ticket) {
+        (TrustedProxyProofProvider::CloudflareAccess, _) => None,
+        (TrustedProxyProofProvider::SharedSecret, Some(value)) => {
             let trimmed = value.trim();
             if trimmed.is_empty() {
                 None
@@ -1371,29 +1435,71 @@ pub async fn update_external_access_trusted_proxy_settings(
                 )
             }
         }
-        None => existing_row.as_ref().and_then(|row| {
+        (TrustedProxyProofProvider::SharedSecret, None) => existing_row.as_ref().and_then(|row| {
             row.try_get::<Option<String>, _>("encrypted_warpgate_ticket")
                 .ok()
                 .flatten()
         }),
     };
 
+    let existing_team_domain = existing_row.as_ref().and_then(|row| {
+        row.try_get::<Option<String>, _>("cloudflare_team_domain")
+            .ok()
+            .flatten()
+    });
+    let existing_audience = existing_row.as_ref().and_then(|row| {
+        row.try_get::<Option<String>, _>("cloudflare_audience")
+            .ok()
+            .flatten()
+    });
+    let cloudflare_team_domain = match proof_provider {
+        TrustedProxyProofProvider::SharedSecret => None,
+        TrustedProxyProofProvider::CloudflareAccess => {
+            crate::cloudflare_access::normalize_team_domain(
+                req.cloudflare_team_domain.or(existing_team_domain),
+            )?
+        }
+    };
+    let cloudflare_audience = match proof_provider {
+        TrustedProxyProofProvider::SharedSecret => None,
+        TrustedProxyProofProvider::CloudflareAccess => {
+            crate::cloudflare_access::normalize_audience(
+                req.cloudflare_audience.or(existing_audience),
+            )?
+        }
+    };
+    if proof_provider == TrustedProxyProofProvider::CloudflareAccess
+        && (cloudflare_team_domain.is_none() || cloudflare_audience.is_none())
+    {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "invalid_input",
+            "Cloudflare Access team domain and application audience are required",
+        ));
+    }
+
     let now = now_unix();
     sqlx::query(
-        "INSERT INTO trusted_proxy_settings (id, user_email_header, trusted_proxy_cidrs_json, encrypted_shared_secret, encrypted_warpgate_ticket, updated_by, created_at, updated_at)
-         VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?6)
+        "INSERT INTO trusted_proxy_settings (id, proof_provider, user_email_header, trusted_proxy_cidrs_json, encrypted_shared_secret, encrypted_warpgate_ticket, cloudflare_team_domain, cloudflare_audience, updated_by, created_at, updated_at)
+         VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?9)
          ON CONFLICT(id) DO UPDATE SET
+            proof_provider = excluded.proof_provider,
             user_email_header = excluded.user_email_header,
             trusted_proxy_cidrs_json = excluded.trusted_proxy_cidrs_json,
             encrypted_shared_secret = excluded.encrypted_shared_secret,
             encrypted_warpgate_ticket = excluded.encrypted_warpgate_ticket,
+            cloudflare_team_domain = excluded.cloudflare_team_domain,
+            cloudflare_audience = excluded.cloudflare_audience,
             updated_by = excluded.updated_by,
             updated_at = excluded.updated_at",
     )
+    .bind(proof_provider.as_str())
     .bind(&user_email_header)
     .bind(&trusted_proxy_cidrs_json)
     .bind(encrypted_shared_secret.clone())
     .bind(encrypted_warpgate_ticket.clone())
+    .bind(&cloudflare_team_domain)
+    .bind(&cloudflare_audience)
     .bind(&auth.0.user_id)
     .bind(now)
     .execute(&pool)
@@ -1408,6 +1514,7 @@ pub async fn update_external_access_trusted_proxy_settings(
     })?;
 
     let details = serde_json::json!({
+        "proof_provider": proof_provider.as_str(),
         "user_email_header": user_email_header,
         "trusted_proxy_cidrs": trusted_proxy_cidrs,
         "has_shared_secret": encrypted_shared_secret.is_some(),

--- a/crates/oored/src/instance_settings.rs
+++ b/crates/oored/src/instance_settings.rs
@@ -232,6 +232,7 @@ pub(crate) fn normalize_requested_trusted_proxy_cidrs(
 pub async fn load_effective_external_access_network_settings(
     pool: &sqlx::SqlitePool,
 ) -> anyhow::Result<EffectiveExternalAccessNetworkSettings> {
+    let include_local_defaults = load_runtime_mode(pool).await? == RuntimeMode::Local;
     let env_public_url = std::env::var("OORE_PUBLIC_URL")
         .ok()
         .and_then(|value| trim_opt(Some(value)));
@@ -266,7 +267,11 @@ pub async fn load_effective_external_access_network_settings(
         return Ok(EffectiveExternalAccessNetworkSettings {
             public_url,
             artifact_delivery_url,
-            allowed_origins: with_local_defaults(allowed_origins),
+            allowed_origins: if include_local_defaults {
+                with_local_defaults(allowed_origins)
+            } else {
+                allowed_origins
+            },
             source: ExternalAccessNetworkSource::Database,
             updated_at: row.try_get::<Option<i64>, _>("updated_at").ok().flatten(),
         });
@@ -282,7 +287,11 @@ pub async fn load_effective_external_access_network_settings(
         return Ok(EffectiveExternalAccessNetworkSettings {
             public_url: env_public_url,
             artifact_delivery_url: env_artifact_delivery_url,
-            allowed_origins: with_local_defaults(parsed),
+            allowed_origins: if include_local_defaults {
+                with_local_defaults(parsed)
+            } else {
+                parsed
+            },
             source: ExternalAccessNetworkSource::Environment,
             updated_at: None,
         });
@@ -291,7 +300,11 @@ pub async fn load_effective_external_access_network_settings(
     Ok(EffectiveExternalAccessNetworkSettings {
         public_url: env_public_url,
         artifact_delivery_url: env_artifact_delivery_url,
-        allowed_origins: default_allowed_origins(),
+        allowed_origins: if include_local_defaults {
+            default_allowed_origins()
+        } else {
+            Vec::new()
+        },
         source: ExternalAccessNetworkSource::Default,
         updated_at: None,
     })
@@ -1362,8 +1375,8 @@ pub async fn update_external_access_trusted_proxy_settings(
     {
         return Err(api_err(
             StatusCode::CONFLICT,
-            "trusted_proxy_provider_change_requires_recovery",
-            "Change the active identity proof through local recovery",
+            "trusted_proxy_provider_change_unsupported",
+            "Changing the active identity proof is not supported in this alpha",
         ));
     }
     let user_email_header = match proof_provider {

--- a/crates/oored/src/instance_settings.rs
+++ b/crates/oored/src/instance_settings.rs
@@ -452,6 +452,7 @@ fn network_settings_response(
 
 fn normalize_requested_allowed_origins(
     values: Vec<String>,
+    include_local_defaults: bool,
 ) -> Result<Vec<String>, (StatusCode, Json<ApiError>)> {
     let mut normalized = Vec::new();
     for value in values {
@@ -467,7 +468,11 @@ fn normalize_requested_allowed_origins(
         }
     }
 
-    Ok(with_local_defaults(normalized))
+    if include_local_defaults {
+        Ok(with_local_defaults(normalized))
+    } else {
+        Ok(normalized)
+    }
 }
 
 pub async fn load_key_storage_mode(pool: &sqlx::SqlitePool) -> anyhow::Result<KeyStorageMode> {
@@ -1368,11 +1373,7 @@ pub async fn update_external_access_trusted_proxy_settings(
             "Failed to determine remote auth mode",
         )
     })?;
-    if runtime_mode == RuntimeMode::Remote
-        && remote_auth_mode == RemoteAuthMode::TrustedProxy
-        && existing_row.is_some()
-        && proof_provider != existing_proof_provider
-    {
+    if existing_row.is_some() && proof_provider != existing_proof_provider {
         return Err(api_err(
             StatusCode::CONFLICT,
             "trusted_proxy_provider_change_unsupported",
@@ -1624,7 +1625,10 @@ pub async fn update_external_access_network_settings(
 
     let mut public_url = trim_opt(req.public_url);
     let mut artifact_delivery_url = trim_opt(req.artifact_delivery_url);
-    let allowed_origins = normalize_requested_allowed_origins(req.allowed_origins)?;
+    let allowed_origins = normalize_requested_allowed_origins(
+        req.allowed_origins,
+        runtime_mode == RuntimeMode::Local,
+    )?;
     if let Some(raw) = public_url.as_ref() {
         let parsed = validate_external_access_public_url(raw).map_err(|reason| match reason {
             "https_required" => api_err(

--- a/crates/oored/src/instance_settings.rs
+++ b/crates/oored/src/instance_settings.rs
@@ -1738,26 +1738,41 @@ pub async fn update_external_access_network_settings(
         )
     })?;
 
+    let active_network_settings = load_effective_external_access_network_settings(&pool)
+        .await
+        .map_err(|e| {
+            error!(error = %e, "failed to reload External Access network policy");
+            api_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "store_error",
+                "Failed to apply the External Access network policy",
+            )
+        })?;
     {
         let mut runtime_public_url = state.public_url.write().await;
-        *runtime_public_url = public_url.clone();
+        *runtime_public_url = active_network_settings.public_url.clone();
     }
     {
         let mut runtime_allowed_origins = state.allowed_origins.write().await;
-        *runtime_allowed_origins = allowed_origins.clone();
+        *runtime_allowed_origins = active_network_settings.allowed_origins.clone();
     }
     state.recovery_capabilities.clear().await;
     // Hot-reload storage backend because local artifact links depend on public_base_url.
-    let backend = storage::load_backend(&pool, &state.encryption_key, public_url.clone()).await;
+    let backend = storage::load_backend(
+        &pool,
+        &state.encryption_key,
+        active_network_settings.public_url.clone(),
+    )
+    .await;
     {
         let mut guard = state.storage.write().await;
         *guard = backend;
     }
 
     let details = serde_json::json!({
-        "public_url": public_url,
-        "artifact_delivery_url": artifact_delivery_url,
-        "allowed_origins": allowed_origins,
+        "public_url": active_network_settings.public_url,
+        "artifact_delivery_url": active_network_settings.artifact_delivery_url,
+        "allowed_origins": active_network_settings.allowed_origins,
     })
     .to_string();
     let _ = write_audit_log(
@@ -1770,15 +1785,7 @@ pub async fn update_external_access_network_settings(
     )
     .await;
 
-    Ok(Json(network_settings_response(
-        EffectiveExternalAccessNetworkSettings {
-            public_url,
-            artifact_delivery_url,
-            allowed_origins,
-            source: ExternalAccessNetworkSource::Database,
-            updated_at: Some(now),
-        },
-    )))
+    Ok(Json(network_settings_response(active_network_settings)))
 }
 
 pub async fn get_external_access_preflight(

--- a/crates/oored/src/instance_settings.rs
+++ b/crates/oored/src/instance_settings.rs
@@ -96,6 +96,11 @@ pub struct EffectiveTrustedProxySettings {
     pub updated_at: Option<i64>,
 }
 
+pub struct TrustedProxyIdentity {
+    pub email: String,
+    pub subject: String,
+}
+
 pub fn default_allowed_origins() -> Vec<String> {
     DEFAULT_ALLOWED_ORIGINS
         .iter()
@@ -666,17 +671,25 @@ pub async fn authenticate_trusted_proxy_identity(
     state: &AppState,
     headers: &HeaderMap,
     settings: &EffectiveTrustedProxySettings,
-) -> Result<String, (StatusCode, Json<ApiError>)> {
+) -> Result<TrustedProxyIdentity, (StatusCode, Json<ApiError>)> {
     match settings.proof_provider {
         TrustedProxyProofProvider::SharedSecret => {
             verify_trusted_proxy_shared_secret(headers, settings, &state.encryption_key)?;
-            extract_trusted_proxy_email(headers, settings)
+            let email = extract_trusted_proxy_email(headers, settings)?;
+            Ok(TrustedProxyIdentity {
+                subject: format!("trusted-proxy::{email}"),
+                email,
+            })
         }
         TrustedProxyProofProvider::CloudflareAccess => {
-            state
+            let identity = state
                 .cloudflare_access
-                .verified_email(headers, settings)
-                .await
+                .verified_identity(headers, settings)
+                .await?;
+            Ok(TrustedProxyIdentity {
+                email: identity.email,
+                subject: identity.subject,
+            })
         }
     }
 }
@@ -1334,6 +1347,25 @@ pub async fn update_external_access_trusted_proxy_settings(
         .and_then(|value| value.parse::<TrustedProxyProofProvider>().ok())
         .unwrap_or_default();
     let proof_provider = req.proof_provider.unwrap_or(existing_proof_provider);
+    let remote_auth_mode = load_remote_auth_mode(&pool).await.map_err(|e| {
+        error!(error = %e, "failed to load remote auth mode for trusted proxy update");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to determine remote auth mode",
+        )
+    })?;
+    if runtime_mode == RuntimeMode::Remote
+        && remote_auth_mode == RemoteAuthMode::TrustedProxy
+        && existing_row.is_some()
+        && proof_provider != existing_proof_provider
+    {
+        return Err(api_err(
+            StatusCode::CONFLICT,
+            "trusted_proxy_provider_change_requires_recovery",
+            "Change the active identity proof through local recovery",
+        ));
+    }
     let user_email_header = match proof_provider {
         TrustedProxyProofProvider::SharedSecret => req
             .user_email_header
@@ -1389,14 +1421,7 @@ pub async fn update_external_access_trusted_proxy_settings(
     };
 
     if runtime_mode == RuntimeMode::Remote
-        && load_remote_auth_mode(&pool).await.map_err(|e| {
-            error!(error = %e, "failed to load remote auth mode for trusted proxy update");
-            api_err(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "store_error",
-                "Failed to determine remote auth mode",
-            )
-        })? == RemoteAuthMode::TrustedProxy
+        && remote_auth_mode == RemoteAuthMode::TrustedProxy
         && proof_provider == TrustedProxyProofProvider::SharedSecret
         && encrypted_shared_secret.is_none()
     {

--- a/crates/oored/src/lib.rs
+++ b/crates/oored/src/lib.rs
@@ -130,10 +130,6 @@ fn local_subject_for_email(email: &str) -> String {
     format!("local::{}", email.trim().to_lowercase())
 }
 
-fn trusted_proxy_subject_for_email(email: &str) -> String {
-    format!("trusted-proxy::{}", email.trim().to_lowercase())
-}
-
 fn normalize_optional_setup_owner_email(
     value: Option<String>,
 ) -> Result<Option<String>, (StatusCode, Json<ApiError>)> {
@@ -1095,10 +1091,13 @@ async fn setup_trusted_proxy_configure(
     } else {
         None
     };
-    let cloudflare_team_domain =
-        crate::cloudflare_access::normalize_team_domain(req.cloudflare_team_domain)?;
-    let cloudflare_audience =
-        crate::cloudflare_access::normalize_audience(req.cloudflare_audience)?;
+    let (cloudflare_team_domain, cloudflare_audience) = match proof_provider {
+        TrustedProxyProofProvider::SharedSecret => (None, None),
+        TrustedProxyProofProvider::CloudflareAccess => (
+            crate::cloudflare_access::normalize_team_domain(req.cloudflare_team_domain)?,
+            crate::cloudflare_access::normalize_audience(req.cloudflare_audience)?,
+        ),
+    };
     if proof_provider == TrustedProxyProofProvider::CloudflareAccess
         && (cloudflare_team_domain.is_none() || cloudflare_audience.is_none())
     {
@@ -1255,12 +1254,13 @@ async fn setup_owner_claim_trusted_proxy(
             "Trusted proxy owner claim must come from an allowlisted proxy peer",
         ));
     }
-    let email = crate::instance_settings::authenticate_trusted_proxy_identity(
+    let identity = crate::instance_settings::authenticate_trusted_proxy_identity(
         &state,
         &headers,
         &trusted_proxy_settings,
     )
     .await?;
+    let email = identity.email;
     if let Some(expected_owner_email) = trusted_proxy_settings.setup_owner_email.as_deref()
         && email != expected_owner_email
     {
@@ -1274,7 +1274,7 @@ async fn setup_owner_claim_trusted_proxy(
     let now = now_unix();
     sf.owner = Some(OwnerRecord {
         email: email.clone(),
-        oidc_subject: Some(trusted_proxy_subject_for_email(&email)),
+        oidc_subject: Some(identity.subject),
         created_at: now,
     });
     sf.setup_state = SetupState::OwnerCreated;

--- a/crates/oored/src/lib.rs
+++ b/crates/oored/src/lib.rs
@@ -8,6 +8,7 @@ pub mod audit_logs;
 pub mod auth;
 pub mod background;
 pub mod builds;
+pub mod cloudflare_access;
 pub mod credential_broker;
 pub mod crypto;
 pub mod embedded_runner;
@@ -58,10 +59,10 @@ use oore_contract::{
     SetupOidcVerifyRequest, SetupOidcVerifyResponse, SetupPreferencesRequest,
     SetupPreferencesResponse, SetupSessionRecord, SetupState, SetupStateFile, SetupStatus,
     SetupSummaryResponse, SetupTrustedProxyClaimOwnerResponse, SetupTrustedProxyConfigureRequest,
-    SetupTrustedProxyConfigureResponse,
+    SetupTrustedProxyConfigureResponse, TrustedProxyProofProvider,
 };
 use serde_json::json;
-use sqlx::{Row, SqlitePool};
+use sqlx::SqlitePool;
 use tokio::sync::{Mutex, RwLock};
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use zeroize::Zeroizing;
@@ -88,6 +89,8 @@ pub struct AppState {
     pub db: SqlitePool,
     pub sessions: SessionStore,
     pub pending_auth: Mutex<PendingAuthStore>,
+    /// Verifies Cloudflare Access assertions and caches public signing keys.
+    pub cloudflare_access: cloudflare_access::CloudflareAccessVerifier,
     /// AES-256 encryption key used to encrypt secrets at rest.
     /// Wrapped in Zeroizing so the key is zeroed on drop.
     pub encryption_key: Zeroizing<Vec<u8>>,
@@ -1039,13 +1042,19 @@ async fn setup_trusted_proxy_configure(
         ));
     }
 
-    let user_email_header = req
-        .user_email_header
-        .as_deref()
-        .and_then(crate::instance_settings::normalize_header_name)
-        .unwrap_or_else(|| {
-            crate::instance_settings::DEFAULT_TRUSTED_PROXY_EMAIL_HEADER.to_string()
-        });
+    let proof_provider = req.proof_provider;
+    let user_email_header = match proof_provider {
+        TrustedProxyProofProvider::SharedSecret => req
+            .user_email_header
+            .as_deref()
+            .and_then(crate::instance_settings::normalize_header_name)
+            .unwrap_or_else(|| {
+                crate::instance_settings::DEFAULT_TRUSTED_PROXY_EMAIL_HEADER.to_string()
+            }),
+        TrustedProxyProofProvider::CloudflareAccess => {
+            crate::cloudflare_access::ASSERTION_HEADER.to_string()
+        }
+    };
     let setup_owner_email = normalize_optional_setup_owner_email(req.setup_owner_email)?;
     let trusted_proxy_cidrs =
         crate::instance_settings::normalize_requested_trusted_proxy_cidrs(req.trusted_proxy_cidrs)?;
@@ -1058,7 +1067,9 @@ async fn setup_trusted_proxy_configure(
         )
     })?;
 
-    let encrypted_shared_secret = if let Some(secret) = req.shared_secret {
+    let encrypted_shared_secret = if proof_provider == TrustedProxyProofProvider::SharedSecret
+        && let Some(secret) = req.shared_secret
+    {
         let trimmed = secret.trim();
         if trimmed.is_empty() {
             None
@@ -1084,22 +1095,41 @@ async fn setup_trusted_proxy_configure(
     } else {
         None
     };
+    let cloudflare_team_domain =
+        crate::cloudflare_access::normalize_team_domain(req.cloudflare_team_domain)?;
+    let cloudflare_audience =
+        crate::cloudflare_access::normalize_audience(req.cloudflare_audience)?;
+    if proof_provider == TrustedProxyProofProvider::CloudflareAccess
+        && (cloudflare_team_domain.is_none() || cloudflare_audience.is_none())
+    {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "invalid_input",
+            "Cloudflare Access team domain and application audience are required",
+        ));
+    }
 
     let now = now_unix();
     sqlx::query(
-        "INSERT INTO trusted_proxy_settings (id, user_email_header, setup_owner_email, trusted_proxy_cidrs_json, encrypted_shared_secret, updated_by, created_at, updated_at)
-         VALUES (1, ?1, ?2, ?3, ?4, NULL, ?5, ?5)
+        "INSERT INTO trusted_proxy_settings (id, proof_provider, user_email_header, setup_owner_email, trusted_proxy_cidrs_json, encrypted_shared_secret, cloudflare_team_domain, cloudflare_audience, updated_by, created_at, updated_at)
+         VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, NULL, ?8, ?8)
          ON CONFLICT(id) DO UPDATE SET
+            proof_provider = excluded.proof_provider,
             user_email_header = excluded.user_email_header,
             setup_owner_email = excluded.setup_owner_email,
             trusted_proxy_cidrs_json = excluded.trusted_proxy_cidrs_json,
             encrypted_shared_secret = excluded.encrypted_shared_secret,
+            cloudflare_team_domain = excluded.cloudflare_team_domain,
+            cloudflare_audience = excluded.cloudflare_audience,
             updated_at = excluded.updated_at",
     )
+    .bind(proof_provider.as_str())
     .bind(&user_email_header)
     .bind(&setup_owner_email)
     .bind(&trusted_proxy_cidrs_json)
     .bind(encrypted_shared_secret.clone())
+    .bind(&cloudflare_team_domain)
+    .bind(&cloudflare_audience)
     .bind(now)
     .execute(&state.db)
     .await
@@ -1125,6 +1155,7 @@ async fn setup_trusted_proxy_configure(
 
     Ok(Json(SetupTrustedProxyConfigureResponse {
         state: sf.setup_state,
+        proof_provider,
         setup_owner_email,
         has_shared_secret: encrypted_shared_secret.is_some(),
         configured_at: now,
@@ -1224,13 +1255,12 @@ async fn setup_owner_claim_trusted_proxy(
             "Trusted proxy owner claim must come from an allowlisted proxy peer",
         ));
     }
-    crate::instance_settings::verify_trusted_proxy_shared_secret(
+    let email = crate::instance_settings::authenticate_trusted_proxy_identity(
+        &state,
         &headers,
         &trusted_proxy_settings,
-        &state.encryption_key,
-    )?;
-    let email =
-        crate::instance_settings::extract_trusted_proxy_email(&headers, &trusted_proxy_settings)?;
+    )
+    .await?;
     if let Some(expected_owner_email) = trusted_proxy_settings.setup_owner_email.as_deref()
         && email != expected_owner_email
     {
@@ -1903,10 +1933,9 @@ async fn complete_setup(
                 }
             }
             RemoteAuthMode::TrustedProxy => {
-                let row = sqlx::query(
-                    "SELECT user_email_header FROM trusted_proxy_settings WHERE id = 1",
+                let settings = crate::instance_settings::load_effective_trusted_proxy_settings(
+                    &state.db,
                 )
-                .fetch_optional(&state.db)
                 .await
                 .map_err(|e| {
                     error!(error = %e, "failed to load trusted proxy settings for setup completion");
@@ -1916,22 +1945,39 @@ async fn complete_setup(
                         "Failed to load trusted proxy settings",
                     )
                 })?;
-                let Some(row) = row else {
+                if !settings.configured {
                     return Err(api_err(
                         StatusCode::CONFLICT,
                         "remote_auth_not_configured",
                         "Trusted proxy authentication is not configured",
                     ));
-                };
-                let header_value: String = row.try_get("user_email_header").unwrap_or_else(|_| {
-                    crate::instance_settings::DEFAULT_TRUSTED_PROXY_EMAIL_HEADER.to_string()
-                });
-                if crate::instance_settings::normalize_header_name(&header_value).is_none() {
-                    return Err(api_err(
-                        StatusCode::CONFLICT,
-                        "trusted_proxy_config_invalid",
-                        "Trusted proxy email header configuration is invalid",
-                    ));
+                }
+                match settings.proof_provider {
+                    TrustedProxyProofProvider::SharedSecret => {
+                        if crate::instance_settings::normalize_header_name(
+                            &settings.user_email_header,
+                        )
+                        .is_none()
+                            || !settings.has_shared_secret
+                        {
+                            return Err(api_err(
+                                StatusCode::CONFLICT,
+                                "trusted_proxy_config_invalid",
+                                "Trusted proxy email header and shared secret are required",
+                            ));
+                        }
+                    }
+                    TrustedProxyProofProvider::CloudflareAccess => {
+                        if settings.cloudflare_team_domain.is_none()
+                            || settings.cloudflare_audience.is_none()
+                        {
+                            return Err(api_err(
+                                StatusCode::CONFLICT,
+                                "trusted_proxy_config_invalid",
+                                "Cloudflare Access settings are incomplete",
+                            ));
+                        }
+                    }
                 }
             }
         }
@@ -2222,6 +2268,7 @@ async fn build_router_inner(
         db,
         sessions: session_store,
         pending_auth: Mutex::new(PendingAuthStore::default()),
+        cloudflare_access: cloudflare_access::CloudflareAccessVerifier::new()?,
         encryption_key: Zeroizing::new(encryption_key),
         enforcer,
         #[cfg(any(test, feature = "test-support"))]
@@ -2270,7 +2317,8 @@ async fn build_router_inner(
             Method::DELETE,
             Method::OPTIONS,
         ])
-        .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION]);
+        .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION])
+        .allow_credentials(true);
 
     // Webhook routes are mounted OUTSIDE the CORS layer since they're called by providers
     let webhook_routes = Router::new()

--- a/crates/oored/src/lib.rs
+++ b/crates/oored/src/lib.rs
@@ -955,6 +955,22 @@ async fn setup_preferences(
         )
     })?;
 
+    let network_settings =
+        crate::instance_settings::load_effective_external_access_network_settings(&state.db)
+            .await
+            .map_err(|e| {
+                error!(error = %e, "failed to refresh allowed origins after setup mode change");
+                api_err(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "store_error",
+                    "Failed to apply the setup network policy",
+                )
+            })?;
+    {
+        let mut allowed_origins = state.allowed_origins.write().await;
+        *allowed_origins = network_settings.allowed_origins;
+    }
+
     // Persist bumped setup session expiry from validate_session.
     sf.updated_at = now;
     store.save(&sf).await.map_err(|e| {
@@ -2227,11 +2243,11 @@ async fn build_router_inner(
         {
             Ok(settings) => settings,
             Err(error) => {
-                warn!(error = %error, "failed to load external access network settings; falling back to defaults");
+                warn!(error = %error, "failed to load external access network settings; denying cross-origin access");
                 instance_settings::EffectiveExternalAccessNetworkSettings {
                     public_url: None,
                     artifact_delivery_url: None,
-                    allowed_origins: instance_settings::default_allowed_origins(),
+                    allowed_origins: Vec::new(),
                     source: oore_contract::ExternalAccessNetworkSource::Default,
                     updated_at: None,
                 }
@@ -2300,10 +2316,17 @@ async fn build_router_inner(
 
     let allowed_origins_for_cors = allowed_origins_state.clone();
     let cors = CorsLayer::new()
-        .allow_origin(AllowOrigin::predicate(move |origin, _request| {
+        .allow_origin(AllowOrigin::predicate(move |origin, request| {
             let Ok(value) = origin.to_str() else {
                 return false;
             };
+            if request.uri.path().starts_with("/v1/setup/")
+                && instance_settings::default_allowed_origins()
+                    .iter()
+                    .any(|allowed| allowed == value)
+            {
+                return true;
+            }
             match allowed_origins_for_cors.try_read() {
                 Ok(guard) => guard.iter().any(|allowed| allowed == value),
                 Err(_) => false,

--- a/crates/oored/src/lib.rs
+++ b/crates/oored/src/lib.rs
@@ -117,6 +117,8 @@ pub struct AppState {
     pub runtime_update: runtime_updates::RuntimeUpdateState,
     /// Short-lived, single-use local recovery capabilities minted over UDS.
     pub recovery_capabilities: local_recovery::RecoveryCapabilityStore,
+    /// Serializes runtime mode and network-policy updates.
+    pub instance_settings_update: Mutex<()>,
 }
 
 // ── Constants ────────────────────────────────────────────────────
@@ -2323,6 +2325,7 @@ async fn build_router_inner(
         public_url: public_url_state,
         runtime_update: runtime_updates::new_state(),
         recovery_capabilities,
+        instance_settings_update: Mutex::new(()),
     });
 
     // Start background tasks (lease timeout, build timeout, heartbeat monitor)

--- a/crates/oored/src/lib.rs
+++ b/crates/oored/src/lib.rs
@@ -930,6 +930,20 @@ async fn setup_preferences(
     } else {
         req.remote_auth_mode.unwrap_or(RemoteAuthMode::Oidc)
     };
+    let network_settings =
+        crate::instance_settings::load_effective_external_access_network_settings_for_mode(
+            &state.db,
+            runtime_mode,
+        )
+        .await
+        .map_err(|e| {
+            error!(error = %e, "failed to prepare allowed origins for setup mode change");
+            api_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "store_error",
+                "Failed to prepare the setup network policy",
+            )
+        })?;
 
     let now = now_unix();
     sqlx::query(
@@ -955,17 +969,6 @@ async fn setup_preferences(
         )
     })?;
 
-    let network_settings =
-        crate::instance_settings::load_effective_external_access_network_settings(&state.db)
-            .await
-            .map_err(|e| {
-                error!(error = %e, "failed to refresh allowed origins after setup mode change");
-                api_err(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "store_error",
-                    "Failed to apply the setup network policy",
-                )
-            })?;
     {
         let mut allowed_origins = state.allowed_origins.write().await;
         *allowed_origins = network_settings.allowed_origins;
@@ -1055,6 +1058,29 @@ async fn setup_trusted_proxy_configure(
     }
 
     let proof_provider = req.proof_provider;
+    let existing_proof_provider = sqlx::query_scalar::<_, String>(
+        "SELECT proof_provider FROM trusted_proxy_settings WHERE id = 1",
+    )
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|e| {
+        error!(error = %e, "failed to read existing trusted proxy proof provider");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to load trusted proxy settings",
+        )
+    })?;
+    if existing_proof_provider
+        .as_deref()
+        .is_some_and(|existing| existing != proof_provider.as_str())
+    {
+        return Err(api_err(
+            StatusCode::CONFLICT,
+            "trusted_proxy_provider_change_unsupported",
+            "Changing the selected identity proof is not supported in this alpha",
+        ));
+    }
     let user_email_header = match proof_provider {
         TrustedProxyProofProvider::SharedSecret => req
             .user_email_header


### PR DESCRIPTION
Closes #294.

## What changed

- Add Cloudflare Access as a signed Trusted Proxy identity provider.
- Verify the Access JWT issuer, audience, subject, time claims, and RS256 key.
- Derive and cache the Cloudflare JWKS endpoint with safe refresh rules.
- Bind Oore accounts to the signed Cloudflare subject, not only the email.
- Add Cloudflare setup and settings fields to the backend, web UI, and OpenAPI.
- Send browser credentials and keep credentialed CORS limited to approved origins.
- Keep localhost CORS access limited to setup routes.
- Add browser sign-in guidance and a public Cloudflare Access guide.
- Keep existing shared-secret Trusted Proxy installations unchanged.
- Block identity-provider changes after the first provider is saved in this alpha.

Tailscale and NetBird need a separate trusted-network adapter. They do not use the same signed JWT contract.

## Checks

- `cargo clippy -p oored -p oore-contract --lib --bins --locked -- -D warnings`
- `bun run --cwd apps/web build`
- `bun run --cwd apps/docs build`
- `cargo fmt --all -- --check`
- `git diff --check`
- Two independent Sol Medium review passes accepted the final exact SHA.

No tests were added or run. Project rules defer new tests until the v0.2.0 milestone review.
