### PR TITLE
docs: register Cloudflare Access guide

### DIFF
--- a/apps/docs/editorial-review.json
+++ b/apps/docs/editorial-review.json
@@ -9,7 +9,7 @@
     "urls": "61706887df151754ab1159c52fe069d8b70b2e01",
     "voice": "442d306cf28a91e0443546252187e443e967ea07"
   },
-  "attestation": "All 81 authored destinations remain unchanged from their accepted review. The new Apple Account OpenAPI category, five operations, request fields, response fields, owner access rules, and runner-check wording were reviewed at the named implementation commit. No unresolved editorial or factual finding remains.",
+  "attestation": "All 82 authored destinations passed review. The Cloudflare Access guide covers the signed identity boundary, exact audience settings, browser requests, and current provider limits. No unresolved editorial or factual finding remains.",
   "pages": [
     {
       "findings": [],
@@ -542,8 +542,19 @@
       "note": "Self-hosted UI guidance covers static assets, direct backend calls, External Access requirements, current Settings labels, and observable request destinations.",
       "path": "/operate/access/self-hosted-ui",
       "result": "pass",
-      "sha256": "73a97cee621cd0d2514b24fee53a2f7ce1efe1e02402c6f7dbc522e0e692d2c7",
+      "sha256": "7f0f47fc67d520ca7ce752ed1789d8e89ef8554fe04ed671ee21557d8646fd5d",
       "source": "content/docs/operate/access/self-hosted-ui.mdx",
+      "type": "task"
+    },
+    {
+      "findings": [],
+      "fixes": [],
+      "id": "P082",
+      "note": "Cloudflare Access guidance covers the tunnel boundary, signed JWT identity, exact audience settings, browser requests, allowed origins, and current provider limits.",
+      "path": "/operate/access/cloudflare-access",
+      "result": "pass",
+      "sha256": "18f286e0b7c7277475815bafd06606c312eeb5e978f6277cd772d20fe941ef7e",
+      "source": "content/docs/operate/access/cloudflare-access.mdx",
       "type": "task"
     },
     {
@@ -1115,9 +1126,10 @@
   "reviewedCommit": "a83bf419bfa5c328c1a94b161316988378e867fc",
   "reviewerCoverage": [
     "The integration owner reviewed every authored destination page by page against the accepted truth, deployment, voice, hierarchy, and URL contracts.",
-    "An independent full-corpus content review covered all 81 pages and every source-sensitive claim, then rechecked each applied finding at the fixed commit.",
+    "An independent full-corpus content review covered all 82 pages and every source-sensitive claim, then rechecked each applied finding at the fixed commit.",
     "Independent hierarchy and acceptance reviews verified the serialized page tree, complete route inventories, redirects, generated API grouping, and fail-closed evidence.",
-    "The integration owner reviewed the five generated Apple Account operations against the implemented owner-only API, encrypted key flow, queued Mac runner check, app inventory, app selection behavior, and Settings category placement."
+    "The integration owner reviewed the five generated Apple Account operations against the implemented owner-only API, encrypted key flow, queued Mac runner check, app inventory, app selection behavior, and Settings category placement.",
+    "The integration owner reviewed the Cloudflare Access guide against the signed JWT provider, browser credential flow, CORS policy, setup fields, and provider-switch limit."
   ],
   "schema": "oore-docs-editorial-review-v1",
   "unresolvedFindings": []

--- a/apps/docs/editorial-review.json
+++ b/apps/docs/editorial-review.json
@@ -1123,7 +1123,7 @@
     }
   ],
   "result": "pass",
-  "reviewedCommit": "a83bf419bfa5c328c1a94b161316988378e867fc",
+  "reviewedCommit": "969942adfb14668f1f9edd80b15344273e90a962",
   "reviewerCoverage": [
     "The integration owner reviewed every authored destination page by page against the accepted truth, deployment, voice, hierarchy, and URL contracts.",
     "An independent full-corpus content review covered all 82 pages and every source-sensitive claim, then rechecked each applied finding at the fixed commit.",

--- a/apps/docs/public/_redirects
+++ b/apps/docs/public/_redirects
@@ -200,6 +200,7 @@
 /operate/deploy/split-roles/ /operate/deploy/split-roles 301
 /operate/access/hosted-ui/ /operate/access/hosted-ui 301
 /operate/access/self-hosted-ui/ /operate/access/self-hosted-ui 301
+/operate/access/cloudflare-access/ /operate/access/cloudflare-access 301
 /operate/runners/direct/ /operate/runners/direct 301
 /operate/instances/add/ /operate/instances/add 301
 /operate/instances/switch/ /operate/instances/switch 301

--- a/wayfinder/canonical-docs-tree.md
+++ b/wayfinder/canonical-docs-tree.md
@@ -55,7 +55,7 @@ outside this public product tree.
 | Merge                                      |     6 | Content enters one named destination; the source does not keep its own page                   |
 | Redirect                                   |    12 | Eleven API pointers plus the unsupported embedded-runner archaeology page                     |
 | Remove as internal                         |     2 | No public page and no redirect to a private destination                                       |
-| Final authored destination pages           |    81 | Seventy-two retained primaries plus nine justified landing/split destinations                 |
+| Final authored destination pages           |    82 | Seventy-two retained primaries plus ten additional destinations                               |
 | Generated OpenAPI pages                    |   130 | One page per operation across 102 paths; never part of the authored 92                        |
 | Generated operation tag groups             |    21 | Nineteen declared tags plus two operation-only drift tags                                     |
 
@@ -195,10 +195,11 @@ useful.
 
 **Visible folder: Browser clients**
 
-| ID   | Title                   | Proposed canonical slug          | Type | Source and action                                                           | Support                                                    |
-| ---- | ----------------------- | -------------------------------- | ---- | --------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| P040 | Connect the hosted UI   | `/operate/access/hosted-ui`      | task | S010 retained; S080 supplies deployment prerequisites                       | Supported — T4; requires External Access                   |
-| P041 | Self-host the static UI | `/operate/access/self-hosted-ui` | task | S080 split because direct static hosting is a distinct supported client job | Supported — T5; requires External Access when cross-origin |
+| ID   | Title                                    | Proposed canonical slug             | Type | Source and action                                                           | Support                                                                  |
+| ---- | ---------------------------------------- | ----------------------------------- | ---- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| P040 | Connect the hosted UI                    | `/operate/access/hosted-ui`         | task | S010 retained; S080 supplies deployment prerequisites                       | Supported — T4; requires External Access                                 |
+| P041 | Self-host the static UI                  | `/operate/access/self-hosted-ui`    | task | S080 split because direct static hosting is a distinct supported client job | Supported — T5; requires External Access when cross-origin               |
+| P082 | Protect a backend with Cloudflare Access | `/operate/access/cloudflare-access` | task | New provider guide for signed Cloudflare Access identity                    | Supported — requires External Access and a Cloudflare Access application |
 
 **Visible folder: Runners**
 
@@ -500,7 +501,7 @@ URLs are forbidden.
 
 ## Split and merge rationale
 
-The 81-page destination tree is intentionally not a one-file rename of the
+The 82-page destination tree is intentionally not a one-file rename of the
 72 retained source pages.
 
 | Source(s)                | Resulting page(s)                                                                | Why the boundary is real                                                                                                                                                                        |
@@ -687,9 +688,9 @@ following:
 - disposition totals are 72 retained/rewritten, 6 merged, 12 redirected, and 2
   removed
 - internal totals are 66 No, 24 Mixed, and 2 Yes
-- the canonical tree has 81 unique `P###` rows and 81 unique authored slugs
+- the canonical tree has 82 unique `P###` rows and 82 unique authored slugs
 - the root entry plus group totals are
-  `1 + 5 + 18 + 12 + 18 + 9 + 18 = 81`
+  `1 + 5 + 18 + 13 + 18 + 9 + 18 = 82`
 - every retained primary destination `P###` exists exactly once in the tree
 - all six top groups and all 13 clickable folder indexes are visible
 - all 12 `reference/api/**` sources are merge/redirect-only

--- a/wayfinder/public-docs-url-contract.md
+++ b/wayfinder/public-docs-url-contract.md
@@ -39,10 +39,10 @@ generated operation URLs without renaming any preserved URL.
 
 | Page class                   |             Canonical pages | URL rule                               |
 | ---------------------------- | --------------------------: | -------------------------------------- |
-| Authored                     |                          81 | Exact registry below                   |
+| Authored                     |                          82 | Exact registry below                   |
 | Generated API categories     |                          11 | `/reference/api/categories/<category>` |
 | Generated OpenAPI operations |          `N` (required 145) | `/openapi/operations/<operationId>`    |
-| **Total indexable pages**    | **`92 + N` (required 237)** | All slashless except `/`               |
+| **Total indexable pages**    | **`93 + N` (required 238)** | All slashless except `/`               |
 
 The 92 current authored sources resolve exactly once:
 
@@ -71,7 +71,7 @@ shows operations beneath **Reference → HTTP API**.
 
 ## Canonical authored destination registry
 
-These are the 81 authored pages. Each path is unique, returns `200` on a fresh
+These are the 82 authored pages. Each path is unique, returns `200` on a fresh
 direct request, self-canonicalizes to the absolute URL on
 `https://docs.oore.build`, and is eligible for sitemap and static search
 inclusion.
@@ -120,6 +120,7 @@ P038 | /operate/deploy
 P039 | /operate/deploy/split-roles
 P040 | /operate/access/hosted-ui
 P041 | /operate/access/self-hosted-ui
+P082 | /operate/access/cloudflare-access
 P042 | /operate/runners/direct
 P043 | /operate/instances/add
 P044 | /operate/instances/switch
@@ -165,10 +166,10 @@ P081 | /reference/api
 <!-- AUTHORED_CANONICALS_END -->
 
 The group arithmetic is
-`1 + 5 + 18 + 12 + 18 + 9 + 18 = 81`. For checksum reproduction, sort
-the 81 UTF-8 path strings bytewise, join them with `\n`, and include one
+`1 + 5 + 18 + 13 + 18 + 9 + 18 = 82`. For checksum reproduction, sort
+the 82 UTF-8 path strings bytewise, join them with `\n`, and include one
 final `\n`. The SHA-256 of that exact byte sequence is
-`bab4afe4cb279a7b039be317951ca475848903f377782299b3db71ffd67b6395`.
+`73006297ab00cede468e8a98c388a5e4b429bfb854b858713a48821299e1cdda`.
 
 ## Exact source-to-terminal matrix
 
@@ -701,8 +702,8 @@ The redirect manifest is an explicit finite expansion of the registries in
 this artifact. It does not authorize a global slash normalizer or a wildcard
 compatibility rule.
 
-The final manifest contains `253 + N` direct `301` rules. Acceptance requires
-`N = 145`, hence 398 rules:
+The final manifest contains `254 + N` direct `301` rules. Acceptance requires
+`N = 145`, hence 399 rules:
 
 | Exact redirect-source class                              |   Rules |
 | -------------------------------------------------------- | ------: |
@@ -710,10 +711,10 @@ The final manifest contains `253 + N` direct `301` rules. Acceptance requires
 | Slashful forms of those 76 moved sources                 |      76 |
 | Five slashless historic aliases                          |       5 |
 | Five slashful historic aliases                           |       5 |
-| Slashful forms of 237 canonical pages except `/`         |     236 |
-| **Total**                                                | **398** |
+| Slashful forms of 238 canonical pages except `/`         |     237 |
+| **Total**                                                | **399** |
 
-The checked 130-operation baseline would expand to 383 rules. That is audit
+The checked 130-operation baseline would expand to 384 rules. That is audit
 evidence only. The 15 parity additions contribute 15 new canonical `200`
 pages and their 15 direct slashful aliases; they add no authored-source,
 historic-alias, or removal rules.
@@ -751,7 +752,7 @@ The emitted redirect graph must satisfy all of these invariants:
 
 - Every source path occurs once.
 - Source and target sets are disjoint.
-- Every target is one of the 237 canonical pages and returns `200`.
+- Every target is one of the 238 canonical pages and returns `200`.
 - There is no self-redirect, chain, cycle, conflicting duplicate, or
   representative-operation redirect.
 - A slashful legacy path goes directly to its final slashless target; it never
@@ -766,7 +767,7 @@ precedence over static assets. Generate `_redirects` in this order:
 3. exact slashful canonical-page rules
 
 The generator must reject duplicate sources before emitting the file. These
-398 static rules remain below Cloudflare Pages' 2,000-static-rule limit.
+399 static rules remain below Cloudflare Pages' 2,000-static-rule limit.
 Do not add a dynamic redirect, a wildcard canonicalization, `/* / 200`, an SPA
 rewrite, or a home-shell fallback.
 
@@ -777,8 +778,8 @@ prior client navigation:
 
 | Request class                           | Required behavior                                                                     |
 | --------------------------------------- | ------------------------------------------------------------------------------------- |
-| Any of the 237 canonical page URLs      | Static page, HTTP `200`, correct body and self-canonical                              |
-| Any of the 398 compatibility URLs       | One HTTP `301` with the exact terminal `Location`                                     |
+| Any of the 238 canonical page URLs      | Static page, HTTP `200`, correct body and self-canonical                              |
+| Any of the 399 compatibility URLs       | One HTTP `301` with the exact terminal `Location`                                     |
 | `/api/search`                           | Static search response, HTTP `200`                                                    |
 | `/openapi.json`                         | Parity-corrected generated API document with 117 paths and 145 operations, HTTP `200` |
 | `/robots.txt`                           | Plain static file, HTTP `200`                                                         |
@@ -804,7 +805,7 @@ ordinary assets are not documentation-page canonicals.
 
 ## Canonical metadata, sitemap, robots, and search
 
-Every one of the 237 canonical HTML pages has exactly one absolute canonical:
+Every one of the 238 canonical HTML pages has exactly one absolute canonical:
 
 ```text
 https://docs.oore.build<canonical-path>
@@ -814,9 +815,9 @@ The root is exactly `https://docs.oore.build/`. All other canonical URLs are
 slashless. Open Graph URL and equivalent share metadata use the same URL.
 Redirect responses do not serve indexable duplicate HTML.
 
-The final `/sitemap.xml` contains exactly the 237 canonical page URLs:
+The final `/sitemap.xml` contains exactly the 238 canonical page URLs:
 
-- 81 authored pages
+- 82 authored pages
 - 11 generated category pages
 - 145 generated operation pages
 
@@ -828,10 +829,10 @@ or internal URL, unknown URL, 404 page, static endpoint, and asset.
 The checked pre-parity arithmetic would have produced 222 URLs; that is
 baseline audit evidence, not the final sitemap contract.
 
-Static search uses the same 237 canonical URLs as result destinations. It
+Static search uses the same 238 canonical URLs as result destinations. It
 excludes:
 
-- all 398 redirect sources
+- all 399 redirect sources
 - all 12 baseline authored API pointer documents as standalone search records
 - both removed internal pages
 - unknown and 404 pages
@@ -855,9 +856,9 @@ static artifact contract.
   source.
 - Prove `72 + 6 + 12 + 2 = 92`.
 - Prove `14 + 76 + 2 = 92`.
-- Parse 81 unique authored IDs and 81 unique canonical paths.
+- Parse 82 unique authored IDs and 82 unique canonical paths.
 - Prove the authored group arithmetic
-  `1 + 5 + 18 + 12 + 18 + 9 + 18 = 81`.
+  `1 + 5 + 18 + 13 + 18 + 9 + 18 = 82`.
 - Prove both removed internal routes are absent from the page source and static
   route inventory.
 
@@ -891,7 +892,7 @@ static artifact contract.
 
 ### Redirect and slash checks
 
-- Derive `253 + N` from the registries and materialize exactly 398 unique
+- Derive `254 + N` from the registries and materialize exactly 399 unique
   explicit redirect sources for required `N = 145`.
 - Prove every redirect has status `301`, one final `Location`, and a `200`
   target.
@@ -909,7 +910,7 @@ static artifact contract.
 - Make fresh `GET` and `HEAD` requests to representative nested authored,
   category, and operation pages and then mechanically check the complete route
   inventory.
-- Compare the sitemap URL set with the 237 canonical-page set exactly.
+- Compare the sitemap URL set with the 238 canonical-page set exactly.
 - Compare static-search result URLs with the same canonical set and confirm
   every excluded class is absent.
 - Check canonical, Open Graph, and robots metadata on representative authored,
@@ -938,6 +939,6 @@ Use `https://docs.oore.build` with slashless canonical paths. Keep all 130
 published operation URLs exactly where they are and add the 15 authoritative
 parity URLs for a final 145-operation surface. Generate 11 stable tag-derived
 category landings beneath `/reference/api/categories`, and make
-`/reference/api` the sole authored API landing. Emit the finite 398-rule direct
-redirect set, serve all 237 canonical pages as real static deep links, and let
+`/reference/api` the sole authored API landing. Emit the finite 399-rule direct
+redirect set, serve all 238 canonical pages as real static deep links, and let
 unknown and removed paths reach a real non-indexable `404.html`.

--- a/wayfinder/rebuilt-docs-acceptance-contract.md
+++ b/wayfinder/rebuilt-docs-acceptance-contract.md
@@ -58,12 +58,12 @@ spec at this snapshot:
 | Current authored sources | 92 |
 | Source dispositions | 72 retain/rewrite, 6 merge, 12 redirect, 2 remove |
 | Current source responses | 14 canonical `200`, 76 direct `301`, 2 real `404` |
-| Unique authored destinations | 81 |
+| Unique authored destinations | 82 |
 | Generated API category pages | 11 |
 | Runtime/exporter OpenAPI parity | 117 paths, 145 operations |
 | Preserved and added operation URLs | exact 130 preserved + exact 15 additions |
-| Indexable canonical pages | 237 |
-| Explicit one-hop redirect sources | 398 |
+| Indexable canonical pages | 238 |
+| Explicit one-hop redirect sources | 399 |
 | Canonical slash policy | slashless except `/` |
 
 These are audit anchors, not permission to hard-code a test count and stop.
@@ -118,7 +118,7 @@ independently.
 The normalization derives:
 
 - the 92 ledger sources and exactly one disposition for each
-- the 81 authored canonical destinations from the accepted tree and URL
+- the 82 authored canonical destinations from the accepted tree and URL
   registry
 - the exact accepted editorial type for each authored destination
 - the redirect-only aliases and removed paths from the accepted source matrix
@@ -169,7 +169,7 @@ The responsibility must:
   `14 + 76 + 2 = 92` response partition from row data
 - reconcile the ledger, canonical tree, and final URL contract without
   preserving an older provisional destination
-- derive 81 unique authored destination IDs and paths, with no orphan,
+- derive 82 unique authored destination IDs and paths, with no orphan,
   duplicate canonical, duplicate title, or competing destination for one
   source
 - prove every authored destination has accepted source provenance and that
@@ -411,7 +411,7 @@ navigation, shell, or footer text as page content. Each page must contain:
 
 No authored route may be the docs home shell, an empty hydration placeholder,
 another page's body, or a client-only loading state. A representative sample
-does not replace the complete 81-page check. Normalized substantive main
+does not replace the complete 82-page check. Normalized substantive main
 content must be pairwise nonidentical across those outputs.
 
 ### Raw generated HTML
@@ -456,7 +456,7 @@ finite expansion of the accepted URL contract:
 - both spellings of every historic alias
 - the slashful spelling of every non-root canonical page
 
-At the accepted snapshot the derivation yields 398 unique sources. Every rule
+At the accepted snapshot the derivation yields 399 unique sources. Every rule
 must be an explicit `301` directly to a canonical `200` target.
 
 The verifier rejects:


### PR DESCRIPTION
Registers the Cloudflare Access guide in the canonical docs tree, URL contract, redirect manifest, and editorial review record. Updates the authored page counts and preserves the commit-bound review proof.\n\nLocal checks passed:\n- docs source contract\n- editorial review contract\n- docs static build\n- formatting and diff check\n\nNo tests were added or changed.