### PR TITLE
fix(settings): guide external access setup

### DIFF
--- a/apps/web/src/components/settings/preferences-external-access-card.tsx
+++ b/apps/web/src/components/settings/preferences-external-access-card.tsx
@@ -60,7 +60,7 @@ export function ExternalAccessCard({
             <ItemDescription>
               {externalAccessEnabled
                 ? 'Remote sign-in is available using the configured identity provider.'
-                : 'Configure a public URL and identity provider before enabling remote sign-in.'}
+                : 'Follow the steps below. Oore will enable this button when setup is ready.'}
             </ItemDescription>
           </ItemContent>
           <ItemActions>
@@ -81,6 +81,8 @@ export function ExternalAccessCard({
                   </>
                 ) : externalAccessEnabled ? (
                   'Turn off'
+                ) : !readinessReady ? (
+                  'Finish setup below'
                 ) : (
                   'Turn on'
                 )}

--- a/apps/web/src/components/settings/preferences-external-access-network-dialog.tsx
+++ b/apps/web/src/components/settings/preferences-external-access-network-dialog.tsx
@@ -41,9 +41,9 @@ export default function ExternalAccessNetworkDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>External access network settings</DialogTitle>
+          <DialogTitle>Public access address</DialogTitle>
           <DialogDescription>
-            Configure the public endpoint and allowed frontend origins.
+            Enter where Oore is available and where you will open its frontend.
           </DialogDescription>
         </DialogHeader>
 
@@ -54,7 +54,7 @@ export default function ExternalAccessNetworkDialog({
               name="public_url"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Public URL (HTTPS)</FormLabel>
+                  <FormLabel>Oore backend address</FormLabel>
                   <FormControl>
                     <Input
                       type="url"
@@ -64,7 +64,7 @@ export default function ExternalAccessNetworkDialog({
                     />
                   </FormControl>
                   <FormDescription>
-                    Must be non-loopback and HTTPS.
+                    Use the HTTPS address that points to this Oore backend.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -76,7 +76,7 @@ export default function ExternalAccessNetworkDialog({
               name="allowed_origins"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Allowed frontend origins</FormLabel>
+                  <FormLabel>Oore frontend addresses</FormLabel>
                   <FormControl>
                     <Textarea
                       rows={5}
@@ -86,7 +86,8 @@ export default function ExternalAccessNetworkDialog({
                     />
                   </FormControl>
                   <FormDescription>
-                    One origin per line (or comma-separated).
+                    Keep the local addresses. Add each hosted frontend address.
+                    Use one address per line.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -133,7 +134,7 @@ export default function ExternalAccessNetworkDialog({
                     Saving...
                   </>
                 ) : (
-                  'Save network settings'
+                  'Save public address'
                 )}
               </Button>
             </DialogFooter>

--- a/apps/web/src/components/settings/preferences-external-access-setup.tsx
+++ b/apps/web/src/components/settings/preferences-external-access-setup.tsx
@@ -7,9 +7,7 @@ import {
 } from '@hugeicons/core-free-icons'
 import type {
   useExternalAccessNetworkSettings,
-  useExternalAccessOidc,
   useExternalAccessPreflight,
-  useExternalAccessTrustedProxySettings,
 } from '@/hooks/use-artifact-storage'
 import type {
   GetExternalAccessOidcResponse,
@@ -48,17 +46,23 @@ import {
 import { Spinner } from '@/components/ui/spinner'
 
 export function ExternalAccessSetup({
-  identityQuery,
+  identityError,
+  identityLoading,
   identityReady,
+  identitySaving,
   isOwner,
   networkReady,
   networkSettingsQuery,
   oidcConfig,
   onEditIdentity,
   onEditNetwork,
+  onChooseCloudflare,
+  onChooseOidc,
+  onChooseOtherProxy,
   onPreloadIdentity,
   onPreloadNetwork,
   onReadinessOpenChange,
+  onRetryIdentity,
   preflightQuery,
   readinessOpen,
   readinessReady,
@@ -67,19 +71,23 @@ export function ExternalAccessSetup({
   setupStepsComplete,
   trustedProxySettings,
 }: {
-  identityQuery:
-    | ReturnType<typeof useExternalAccessOidc>
-    | ReturnType<typeof useExternalAccessTrustedProxySettings>
+  identityError: Error | null
+  identityLoading: boolean
   identityReady: boolean
+  identitySaving: boolean
   isOwner: boolean
   networkReady: boolean
   networkSettingsQuery: ReturnType<typeof useExternalAccessNetworkSettings>
   oidcConfig: GetExternalAccessOidcResponse | undefined
   onEditIdentity: () => void
   onEditNetwork: () => void
+  onChooseCloudflare: () => void
+  onChooseOidc: () => void
+  onChooseOtherProxy: () => void
   onPreloadIdentity: () => void
   onPreloadNetwork: () => void
   onReadinessOpenChange: (open: boolean) => void
+  onRetryIdentity: () => void
   preflightQuery: ReturnType<typeof useExternalAccessPreflight>
   readinessOpen: boolean
   readinessReady: boolean
@@ -93,8 +101,84 @@ export function ExternalAccessSetup({
     preflightQuery.data?.checks.filter((check) => !check.ok) ?? []
   const setupStepCount = 2
   const ReadinessIcon = readinessOpen ? ArrowDown01Icon : ArrowRight01Icon
+  const identityLabel =
+    remoteAuthMode === 'trusted_proxy' &&
+    trustedProxySettings?.proof_provider === 'cloudflare_access'
+      ? 'Cloudflare Access'
+      : authModeLabel(remoteAuthMode)
   return (
     <>
+      {!networkReady ? (
+        <Card size="sm">
+          <CardHeader>
+            <CardTitle>Next: Add the public address</CardTitle>
+            <CardDescription>
+              Enter the HTTPS address and the frontend address that will open
+              Oore.
+            </CardDescription>
+            <CardAction>
+              <Button
+                type="button"
+                onClick={onEditNetwork}
+                disabled={
+                  !isOwner ||
+                  networkSettingsQuery.isLoading ||
+                  !!networkSettingsQuery.error
+                }
+              >
+                Add public address
+              </Button>
+            </CardAction>
+          </CardHeader>
+        </Card>
+      ) : !identityReady && !identityError ? (
+        <Card size="sm">
+          <CardHeader>
+            <CardTitle>Next: Choose how users sign in</CardTitle>
+            <CardDescription>
+              Cloudflare Access is the best choice when Cloudflare protects the
+              public address.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+            <Button
+              type="button"
+              onClick={onChooseCloudflare}
+              disabled={!isOwner || identityLoading || identitySaving}
+            >
+              {identitySaving ? <Spinner className="size-4" /> : null}
+              Use Cloudflare Access
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onChooseOidc}
+              disabled={!isOwner || identityLoading || identitySaving}
+            >
+              Use OpenID Connect
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onChooseOtherProxy}
+              disabled={!isOwner || identityLoading || identitySaving}
+            >
+              Use another proxy
+            </Button>
+          </CardContent>
+        </Card>
+      ) : readinessReady ? (
+        <Card size="sm">
+          <CardHeader>
+            <CardTitle>Setup is ready</CardTitle>
+            <CardDescription>
+              Turn on remote access above, then sign in through the public
+              address.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      ) : null}
+
       <Card size="sm">
         <CardHeader>
           <CardTitle>Setup steps</CardTitle>
@@ -158,25 +242,27 @@ export function ExternalAccessSetup({
 
             <Item
               render={
-                <button
-                  type="button"
-                  disabled={
-                    !isOwner || identityQuery.isLoading || !!identityQuery.error
-                  }
-                />
+                identityReady ? (
+                  <button
+                    type="button"
+                    disabled={!isOwner || identityLoading || !!identityError}
+                  />
+                ) : (
+                  <div />
+                )
               }
               variant="outline"
               className="disabled:pointer-events-none disabled:opacity-50"
-              onMouseEnter={onPreloadIdentity}
-              onFocus={onPreloadIdentity}
-              onClick={onEditIdentity}
+              onMouseEnter={identityReady ? onPreloadIdentity : undefined}
+              onFocus={identityReady ? onPreloadIdentity : undefined}
+              onClick={identityReady ? onEditIdentity : undefined}
             >
               <ItemContent>
                 <ItemTitle>2. Identity</ItemTitle>
                 <ItemDescription>
                   {identityReady
-                    ? `${authModeLabel(remoteAuthMode)} configured.`
-                    : `Configure ${authModeLabel(remoteAuthMode)}.`}
+                    ? `${identityLabel} configured.`
+                    : 'Choose a sign-in method above.'}
                 </ItemDescription>
                 {remoteAuthMode === 'trusted_proxy' && trustedProxySettings ? (
                   <>
@@ -241,7 +327,9 @@ export function ExternalAccessSetup({
                 <Badge variant={identityReady ? 'secondary' : 'outline'}>
                   {identityReady ? 'Ready' : 'Setup'}
                 </Badge>
-                <HugeiconsIcon icon={ArrowRight01Icon} />
+                {identityReady ? (
+                  <HugeiconsIcon icon={ArrowRight01Icon} />
+                ) : null}
               </ItemActions>
             </Item>
           </ItemGroup>
@@ -275,17 +363,17 @@ export function ExternalAccessSetup({
         </Alert>
       ) : null}
 
-      {identityQuery.error ? (
+      {identityError ? (
         <Alert variant="destructive">
           <AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <span>
-              Failed to load identity settings: {identityQuery.error.message}
+              Failed to load identity settings: {identityError.message}
             </span>
             <Button
               type="button"
               variant="outline"
               size="sm"
-              onClick={() => void identityQuery.refetch()}
+              onClick={onRetryIdentity}
             >
               Retry
             </Button>

--- a/apps/web/src/components/settings/preferences-trusted-proxy-settings-dialog.tsx
+++ b/apps/web/src/components/settings/preferences-trusted-proxy-settings-dialog.tsx
@@ -61,40 +61,46 @@ export default function TrustedProxySettingsDialog({
     >
       <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>Trusted Proxy identity settings</DialogTitle>
+          <DialogTitle>
+            {proofProvider === 'cloudflare_access'
+              ? 'Connect Cloudflare Access'
+              : 'Connect another identity proxy'}
+          </DialogTitle>
           <DialogDescription>
-            Configure the backend trust contract used when an upstream proxy
-            provides the signed-in user email.
+            {proofProvider === 'cloudflare_access'
+              ? 'Enter the two values from your Cloudflare Access application.'
+              : 'Tell Oore how the proxy proves each signed-in user.'}
           </DialogDescription>
         </DialogHeader>
 
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-            <FormField
-              control={form.control}
-              name="proof_provider"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Identity proof</FormLabel>
-                  <FormControl>
-                    <Input
-                      value={
-                        field.value === 'cloudflare_access'
-                          ? 'Cloudflare Access token'
-                          : 'Trusted header and shared secret'
-                      }
-                      readOnly
-                      disabled
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Oore keeps the identity proof selected during setup. This
-                    alpha does not support changing it later.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+            {proofProvider !== 'cloudflare_access' ? (
+              <FormField
+                control={form.control}
+                name="proof_provider"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Identity proof</FormLabel>
+                    <FormControl>
+                      <Input
+                        value={
+                          field.value === 'cloudflare_access'
+                            ? 'Cloudflare Access token'
+                            : 'Trusted header and shared secret'
+                        }
+                        readOnly
+                        disabled
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Oore keeps this choice after remote access starts.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            ) : null}
 
             {proofProvider === 'cloudflare_access' ? (
               <>
@@ -111,6 +117,9 @@ export default function TrustedProxySettingsDialog({
                           disabled={isPending}
                         />
                       </FormControl>
+                      <FormDescription>
+                        Example: your-team.cloudflareaccess.com
+                      </FormDescription>
                       <FormMessage />
                     </FormItem>
                   )}
@@ -128,6 +137,10 @@ export default function TrustedProxySettingsDialog({
                           disabled={isPending}
                         />
                       </FormControl>
+                      <FormDescription>
+                        Copy the Application Audience (AUD) Tag from the Access
+                        application overview.
+                      </FormDescription>
                       <FormMessage />
                     </FormItem>
                   )}
@@ -289,8 +302,10 @@ export default function TrustedProxySettingsDialog({
                     <Spinner className="size-4" />
                     Saving...
                   </>
+                ) : proofProvider === 'cloudflare_access' ? (
+                  'Save Cloudflare Access'
                 ) : (
-                  'Save trusted proxy settings'
+                  'Save identity proxy'
                 )}
               </Button>
             </DialogFooter>

--- a/apps/web/src/routes/settings/preferences.lazy.tsx
+++ b/apps/web/src/routes/settings/preferences.lazy.tsx
@@ -132,6 +132,18 @@ function parseAllowedOriginsInput(value: string): Array<string> {
     .filter((entry) => entry.length > 0)
 }
 
+function getHttpOrigin(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:'
+      ? url.origin
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
 function PreferencesPage() {
   const navigate = useNavigate()
   const [readinessOpen, setReadinessOpen] = useState(false)
@@ -185,10 +197,13 @@ function PreferencesPage() {
   const networkSettings = networkSettingsQuery.data
   const networkValues = useMemo(() => {
     if (!networkSettings) return undefined
+    const publicOrigin = getHttpOrigin(networkSettings.public_url)
     return {
       public_url: networkSettings.public_url ?? '',
       artifact_delivery_url: networkSettings.artifact_delivery_url ?? '',
-      allowed_origins: networkSettings.allowed_origins.join('\n'),
+      allowed_origins: networkSettings.allowed_origins
+        .filter((origin) => origin !== publicOrigin)
+        .join('\n'),
     }
   }, [networkSettings])
 
@@ -239,7 +254,13 @@ function PreferencesPage() {
   ) {
     if (!isOwner) return
 
-    const allowedOrigins = parseAllowedOriginsInput(values.allowed_origins)
+    const publicOrigin = getHttpOrigin(values.public_url?.trim())
+    const allowedOrigins = Array.from(
+      new Set([
+        ...parseAllowedOriginsInput(values.allowed_origins),
+        ...(publicOrigin ? [publicOrigin] : []),
+      ]),
+    )
     if (allowedOrigins.length === 0) {
       toast.error('Add at least one allowed frontend origin.')
       return
@@ -458,13 +479,60 @@ function PreferencesPage() {
 
   const identitySettingsQuery =
     remoteAuthMode === 'trusted_proxy' ? trustedProxyQuery : oidcConfigQuery
+  const oidcNotConfigured =
+    oidcConfigQuery.error instanceof ApiClientError &&
+    oidcConfigQuery.error.code === 'oidc_not_configured'
+  const identityError =
+    remoteAuthMode === 'oidc' && oidcNotConfigured
+      ? null
+      : identitySettingsQuery.error
 
   usePerformanceSurface(
     'preferences-form',
     !preferencesQuery.isLoading &&
       !networkSettingsQuery.isLoading &&
-      !identitySettingsQuery.isLoading,
+      !identitySettingsQuery.isLoading &&
+      !identityError,
   )
+
+  function chooseIdentityProvider(
+    choice: 'cloudflare_access' | 'oidc' | 'other_proxy',
+  ) {
+    if (!preferences || !isOwner || updatePreferencesMutation.isPending) return
+
+    const nextRemoteAuthMode = choice === 'oidc' ? 'oidc' : 'trusted_proxy'
+    updatePreferencesMutation.mutate(
+      {
+        key_storage_mode: preferences.key_storage_mode,
+        runtime_mode: 'local',
+        remote_auth_mode: nextRemoteAuthMode,
+      },
+      {
+        onSuccess: () => {
+          if (choice === 'oidc') {
+            setOidcDialogOpen(true)
+            return
+          }
+
+          trustedProxyForm.setValue(
+            'proof_provider',
+            choice === 'cloudflare_access'
+              ? 'cloudflare_access'
+              : 'shared_secret',
+          )
+          setTrustedProxyDialogOpen(true)
+        },
+        onError: (error) => {
+          toast.error(
+            getApiErrorMessage(error, {
+              external_access_owner_required:
+                'Only the owner can choose the remote sign-in method.',
+            }),
+          )
+        },
+      },
+    )
+  }
 
   function openNetworkSettingsDialog() {
     setNetworkEditorOpen(true)
@@ -557,17 +625,25 @@ function PreferencesPage() {
             />
           ) : (
             <ExternalAccessSetup
-              identityQuery={identitySettingsQuery}
+              identityError={identityError}
+              identityLoading={identitySettingsQuery.isLoading}
               identityReady={identityReady}
+              identitySaving={updatePreferencesMutation.isPending}
               isOwner={isOwner}
               networkReady={networkReady}
               networkSettingsQuery={networkSettingsQuery}
               oidcConfig={oidcConfig}
               onEditIdentity={openIdentitySettingsDialog}
               onEditNetwork={openNetworkSettingsDialog}
+              onChooseCloudflare={() =>
+                chooseIdentityProvider('cloudflare_access')
+              }
+              onChooseOidc={() => chooseIdentityProvider('oidc')}
+              onChooseOtherProxy={() => chooseIdentityProvider('other_proxy')}
               onPreloadIdentity={preloadIdentitySettingsDialog}
               onPreloadNetwork={preloadExternalAccessNetworkDialog}
               onReadinessOpenChange={setReadinessOpen}
+              onRetryIdentity={() => void identitySettingsQuery.refetch()}
               preflightQuery={preflightQuery}
               readinessOpen={readinessOpen}
               readinessReady={readinessReady}
@@ -610,7 +686,7 @@ function PreferencesPage() {
       ) : null}
       {oidcDialogOpen &&
       !oidcConfigQuery.isLoading &&
-      !oidcConfigQuery.error ? (
+      (!oidcConfigQuery.error || oidcNotConfigured) ? (
         <Suspense fallback={null}>
           <OidcSettingsDialog
             form={externalAccessOidcForm}


### PR DESCRIPTION
## What changed

- Show one clear next action during external access setup.
- Ask for the public address before identity when the network is not ready.
- Offer Cloudflare Access, OpenID Connect, and another proxy by name.
- Treat missing OIDC configuration as a normal setup state.
- Open a Cloudflare-specific dialog with only the team domain and AUD.
- Add the backend origin automatically when network settings are saved.
- Replace internal network terms with user-facing labels.

## Why

Jarvis on `v0.2.0-alpha.2` reached a dead end. The page silently selected OIDC, displayed its missing configuration as a red error, and disabled the Identity action.

Closes #300.

## Checks

- `cd apps/web && bun run check`
- `cd apps/web && bun run build`

No tests were added or run, per the v0.2.0 test rule.
