### PR TITLE
feat(components): install signed catalog components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,7 @@ Before changing release automation, read `Release Channels (alpha / beta / stabl
 - `crates/oored`
 - `crates/oore`
 - `crates/oore-bootstrap`
+- `crates/oore-catalog`
 - `crates/oore-install`
 - `crates/oore-contract`
 - Keep `/v1/public/setup-status` non-sensitive.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2590,7 +2590,13 @@ dependencies = [
 name = "oore-bootstrap"
 version = "0.2.0"
 dependencies = [
+ "chrono",
+ "oore-catalog",
+ "oore-component-store",
  "oore-install",
+ "reqwest",
+ "semver",
+ "tempfile",
 ]
 
 [[package]]
@@ -2637,6 +2643,22 @@ dependencies = [
  "rustix",
  "thiserror 2.0.18",
  "zeroize",
+]
+
+[[package]]
+name = "oore-component-store"
+version = "0.2.0"
+dependencies = [
+ "libc",
+ "oore-catalog",
+ "rustix",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tar",
+ "tempfile",
+ "thiserror 2.0.18",
+ "zstd",
 ]
 
 [[package]]
@@ -3413,6 +3435,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http 1.4.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2597,13 +2597,16 @@ dependencies = [
 name = "oore-catalog"
 version = "0.2.0"
 dependencies = [
+ "anyhow",
  "base64 0.22.1",
  "chrono",
+ "clap",
  "ring",
  "semver",
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "tempfile",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2601,6 +2601,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "clap",
+ "libc",
  "ring",
  "semver",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2609,6 +2609,7 @@ dependencies = [
  "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2594,6 +2594,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "oore-catalog"
+version = "0.2.0"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "ring",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "oore-component-protocol"
 version = "0.1.0"
 source = "git+https://github.com/oore-ci/components.git?rev=30a6f8a00a97742e5d5bdcf45c57af3655791005#30a6f8a00a97742e5d5bdcf45c57af3655791005"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,6 +2600,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "ring",
+ "semver",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/oore",
     "crates/oore-bootstrap",
     "crates/oore-catalog",
+    "crates/oore-component-store",
     "crates/oore-install",
     "crates/oore-runner",
     "crates/oored",
@@ -26,7 +27,7 @@ dirs = "5"
 hex = "0.4"
 humantime = "2.1"
 rand = "0.8"
-rustix = { version = "1.1.4", features = ["fs", "pipe"] }
+rustix = { version = "1.1.4", features = ["fs", "pipe", "process"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
@@ -36,7 +37,7 @@ tokio-stream = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 openidconnect = "4"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream", "blocking"] }
 url = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
 dialoguer = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "crates/oore",
     "crates/oore-bootstrap",
+    "crates/oore-catalog",
     "crates/oore-install",
     "crates/oore-runner",
     "crates/oored",
@@ -53,6 +54,7 @@ urlencoding = "2"
 jsonwebtoken = "9"
 ring = "0.17"
 base64 = "0.22"
+thiserror = "2"
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "sqlite"] }
 zeroize = { version = "1", features = ["derive"] }
 aws-sdk-s3 = "1"

--- a/Makefile
+++ b/Makefile
@@ -265,8 +265,8 @@ check-bootstrap:
 	cargo clippy -p oore-install -p oore-bootstrap --locked -- -D warnings
 
 check-catalog:
-	cargo check -p oore-catalog --lib --locked
-	cargo clippy -p oore-catalog --lib --locked -- -D warnings
+	cargo check -p oore-catalog --lib --bins --locked
+	cargo clippy -p oore-catalog --lib --bins --locked -- -D warnings
 
 check-release-source:
 	cargo fmt --all -- --check

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 		       check-docs-types check-docs-examples generate-docs-redirects check-docs-redirects docs-artifact-manifest test-docs test-docs-source test-docs-editorial test-docs-build install-docs-browser test-docs-browser lint-docs fix-docs knip-web test-rust test-rust-pr test-rust-scheduled test-rust-integration \
 		       test-required-result install-actionlint validate-workflows validate-shell validate-ci validate-required-result validate-web-launcher \
 		       format-oxc format-oxc-check fmt-rust fmt-rust-check clippy-rust compile-rust test-rust-workspace lint test \
-		       cargo-check build-bootstrap check-bootstrap check-release-source run-daemon run-daemon-debug run-daemon-release \
+		       cargo-check build-bootstrap check-bootstrap check-catalog check-release-source run-daemon run-daemon-debug run-daemon-release \
 		       run-runner register-runner run-cli doctor clean-dev-state dev-fresh-setup \
 		       install-local validate validate-frontend validate-docs validate-rust-pr validate-pr validate-scheduled validate-release gen-openapi check-openapi release-smoke \
 		       direct-runner-upgrade-smoke \
@@ -263,6 +263,10 @@ build-bootstrap:
 check-bootstrap:
 	cargo check -p oore-install -p oore-bootstrap --locked
 	cargo clippy -p oore-install -p oore-bootstrap --locked -- -D warnings
+
+check-catalog:
+	cargo check -p oore-catalog --lib --locked
+	cargo clippy -p oore-catalog --lib --locked -- -D warnings
 
 check-release-source:
 	cargo fmt --all -- --check

--- a/crates/oore-bootstrap/Cargo.toml
+++ b/crates/oore-bootstrap/Cargo.toml
@@ -6,3 +6,9 @@ license.workspace = true
 
 [dependencies]
 oore-install = { path = "../oore-install" }
+oore-catalog = { path = "../oore-catalog" }
+oore-component-store = { path = "../oore-component-store" }
+chrono.workspace = true
+reqwest.workspace = true
+semver.workspace = true
+tempfile.workspace = true

--- a/crates/oore-bootstrap/src/main.rs
+++ b/crates/oore-bootstrap/src/main.rs
@@ -1,16 +1,20 @@
 use std::env;
 use std::ffi::OsString;
 use std::fs::{self, OpenOptions};
-use std::io::{self, IsTerminal, Write};
+use std::io::{self, IsTerminal, Read as _, Write};
 use std::path::{Component, Path, PathBuf};
 use std::process::{Command, ExitCode};
 use std::str::FromStr;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use chrono::Utc;
+use oore_catalog::{CatalogState, CatalogUpdate, CatalogVerifier, VerifiedMetadataChain};
+use oore_component_store::{install_archive, load_active};
 use oore_install::{InstallPlan, InstallReceipt, MachineRole, ReleaseChannel};
 
 const PLAN_FILE: &str = "install-plan.json";
 const RECEIPT_FILE: &str = "install-receipt.json";
+const CATALOG_STATE_FILE: &str = "catalog-state.json";
 
 fn main() -> ExitCode {
     match run() {
@@ -41,13 +45,14 @@ fn run() -> Result<ExitCode, Box<dyn std::error::Error>> {
             Ok(ExitCode::SUCCESS)
         }
         "install" => install(&remaining[1..]),
+        "apple" => forward_to_component("oore-apple-sign", &remaining[1..]),
         _ => forward_to_core(&remaining),
     }
 }
 
 fn print_help() {
     println!(
-        "Oore control shell\n\nUsage: oore <COMMAND>\n\nCommands:\n  install  Select how this machine runs Oore\n  version  Print the Oore version\n  help     Print this help\n\nOther commands load the Oore core component when it is available."
+        "Oore control shell\n\nUsage: oore <COMMAND>\n\nCommands:\n  install  Select how this machine runs Oore\n  apple    Load the Apple component\n  version  Print the Oore version\n  help     Print this help\n\nOther commands load the Oore core component when it is available."
     );
 }
 
@@ -92,11 +97,12 @@ fn install(arguments: &[OsString]) -> Result<ExitCode, Box<dyn std::error::Error
     write_atomic(&plan_path, &plan.to_json()?)?;
     remove_file_if_present(&root.join(RECEIPT_FILE))?;
 
-    let installed = prebundled_components(&plan)?;
-    let missing = installed
-        .iter()
-        .filter_map(|component| component.path.is_none().then_some(component.id.as_str()))
-        .collect::<Vec<_>>();
+    let mut installed = prebundled_components(&plan)?;
+    for component in &mut installed {
+        if component.path.is_none() {
+            component.path = Some(install_catalog_component(&component.id)?);
+        }
+    }
 
     if options.json {
         io::stdout().write_all(&plan.to_json()?)?;
@@ -109,14 +115,6 @@ fn install(arguments: &[OsString]) -> Result<ExitCode, Box<dyn std::error::Error
             println!("Required components: {}", plan.components().join(", "));
         }
         println!("Plan: {}", plan_path.display());
-    }
-
-    if !missing.is_empty() {
-        return Err(format!(
-            "the signed package does not contain these required components: {}; the plan is saved and `oore install` can resume later",
-            missing.join(", ")
-        )
-        .into());
     }
 
     let mut owned_paths = vec![env::current_exe()?.to_string_lossy().into_owned()];
@@ -165,9 +163,11 @@ fn prebundled_components(
                 .map(|_| transition_binary);
             let component_root = managed_root.join(component);
             let managed_binary = component_root.join("current").join(component);
-            let managed = fs::canonicalize(&managed_binary).ok().and_then(|binary| {
-                let root = fs::canonicalize(&component_root).ok()?;
-                (binary.starts_with(root) && binary.is_file()).then_some(binary)
+            let managed = managed_component_path(component).or_else(|| {
+                fs::canonicalize(&managed_binary).ok().and_then(|binary| {
+                    let root = fs::canonicalize(&component_root).ok()?;
+                    (binary.starts_with(root) && binary.is_file()).then_some(binary)
+                })
             });
             ComponentLocation {
                 id: component.clone(),
@@ -176,6 +176,210 @@ fn prebundled_components(
         })
         .collect();
     Ok(components)
+}
+
+fn install_catalog_component(component_id: &str) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let (chain, state) = verified_catalog()?;
+    let (os, arch) = current_target()?;
+    let component = chain
+        .component_for_host(component_id, os, arch)?
+        .ok_or_else(|| {
+            format!("the signed catalog has no active {component_id} for {os}/{arch}")
+        })?;
+    verify_minimum_os(component.minimum_os_version())?;
+
+    let root = install_root()?;
+    let downloads = root.join("downloads");
+    fs::create_dir_all(&downloads)?;
+    let mut archive = tempfile::NamedTempFile::new_in(&downloads)?;
+    let client = reqwest::blocking::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(15))
+        .timeout(std::time::Duration::from_secs(120))
+        .user_agent(concat!("oore/", env!("CARGO_PKG_VERSION")))
+        .build()?;
+    let mut response = client.get(component_download_url(&component)?).send()?;
+    if !response.status().is_success() {
+        return Err(format!("component download failed with HTTP {}", response.status()).into());
+    }
+    if let Some(length) = response.content_length()
+        && length != component.archive_length()
+    {
+        return Err("component download length differs from the signed catalog".into());
+    }
+    let copied = io::copy(
+        &mut response.by_ref().take(component.archive_length() + 1),
+        archive.as_file_mut(),
+    )?;
+    if copied != component.archive_length() {
+        return Err("component download did not match the signed length".into());
+    }
+    archive.as_file().sync_all()?;
+    let installed = install_archive(&component, archive.path(), &root.join("components"))?;
+    write_atomic(&root.join(CATALOG_STATE_FILE), &state.to_bytes()?)?;
+    Ok(installed.entrypoint().to_path_buf())
+}
+
+fn component_download_url(
+    component: &oore_catalog::VerifiedComponent,
+) -> Result<String, Box<dyn std::error::Error>> {
+    if let Ok(url) = env::var("OORE_COMPONENT_URL") {
+        return validate_transport_url(url);
+    }
+    let root = install_root()?;
+    let direct_paths = [
+        root.join("COMPONENT_URL"),
+        package_metadata_path("COMPONENT_URL")?,
+    ];
+    if let Some(url) = read_first_metadata(&direct_paths)? {
+        return validate_transport_url(url.trim().to_owned());
+    }
+    let base = installed_value(
+        &root,
+        "COMPONENT_BASE_URL",
+        "OORE_COMPONENT_BASE_URL",
+        "https://components.oore.build/",
+    )?;
+    if !base.starts_with("https://") || !base.ends_with('/') {
+        return Err("the component base URL must use HTTPS and end with /".into());
+    }
+    Ok(format!("{base}{}", component.archive_path()))
+}
+
+fn validate_transport_url(url: String) -> Result<String, Box<dyn std::error::Error>> {
+    let parsed = reqwest::Url::parse(&url)?;
+    if parsed.scheme() != "https"
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || parsed.host_str().is_none()
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+    {
+        return Err("the component transport URL is not a plain HTTPS URL".into());
+    }
+    Ok(url)
+}
+
+fn verified_catalog() -> Result<(VerifiedMetadataChain, CatalogState), Box<dyn std::error::Error>> {
+    let directory = catalog_directory()?;
+    let root = read_catalog_file(&directory.join("root.json"), 1024 * 1024)?;
+    let targets = read_catalog_file(&directory.join("targets.json"), 8 * 1024 * 1024)?;
+    let snapshot = read_catalog_file(&directory.join("snapshot.json"), 2 * 1024 * 1024)?;
+    let timestamp = read_catalog_file(&directory.join("timestamp.json"), 256 * 1024)?;
+    let now = Utc::now();
+    let verifier = CatalogVerifier::from_pinned_root(&root, now)?;
+    let state_path = install_root()?.join(CATALOG_STATE_FILE);
+    let mut state = match fs::read(&state_path) {
+        Ok(bytes) => CatalogState::from_bytes(&bytes)?,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => verifier.initial_state(),
+        Err(error) => return Err(error.into()),
+    };
+    let chain = verifier.verify_update(
+        &mut state,
+        CatalogUpdate {
+            root_rotations: &[],
+            targets: &targets,
+            snapshot: &snapshot,
+            timestamp: &timestamp,
+        },
+        now,
+    )?;
+    Ok((chain, state))
+}
+
+fn catalog_directory() -> Result<PathBuf, Box<dyn std::error::Error>> {
+    if let Some(path) = env::var_os("OORE_CATALOG_DIR") {
+        return Ok(PathBuf::from(path));
+    }
+    let executable = env::current_exe()?;
+    let prefix = executable
+        .parent()
+        .and_then(Path::parent)
+        .ok_or("the Oore executable has no package prefix")?;
+    Ok(prefix.join("share/oore/catalog"))
+}
+
+fn read_catalog_file(path: &Path, limit: u64) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.file_type().is_file() || metadata.len() > limit {
+        return Err(format!("{} is not a bounded catalog file", path.display()).into());
+    }
+    Ok(fs::read(path)?)
+}
+
+fn current_target() -> Result<(&'static str, &'static str), Box<dyn std::error::Error>> {
+    let os = match env::consts::OS {
+        "macos" => "macos",
+        "linux" => "linux",
+        _ => return Err("this operating system cannot run Oore components".into()),
+    };
+    let arch = match env::consts::ARCH {
+        "aarch64" => "arm64",
+        "x86_64" => "x86_64",
+        _ => return Err("this processor cannot run Oore components".into()),
+    };
+    Ok((os, arch))
+}
+
+fn verify_minimum_os(minimum: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(minimum) = minimum else {
+        return Ok(());
+    };
+    if env::consts::OS != "macos" {
+        return Ok(());
+    }
+    let output = Command::new("/usr/bin/sw_vers")
+        .arg("-productVersion")
+        .output()?;
+    if !output.status.success() {
+        return Err("cannot read the macOS version".into());
+    }
+    let actual = String::from_utf8(output.stdout)?;
+    if parse_os_version(actual.trim())? < parse_os_version(minimum)? {
+        return Err(format!("this component needs macOS {minimum} or newer").into());
+    }
+    Ok(())
+}
+
+fn parse_os_version(value: &str) -> Result<semver::Version, Box<dyn std::error::Error>> {
+    let dots = value.bytes().filter(|byte| *byte == b'.').count();
+    let normalized = match dots {
+        0 => format!("{value}.0.0"),
+        1 => format!("{value}.0"),
+        _ => value.to_owned(),
+    };
+    Ok(semver::Version::parse(&normalized)?)
+}
+
+fn managed_component_path(component_id: &str) -> Option<PathBuf> {
+    let root = install_root().ok()?.join("components");
+    let digest = fs::read_to_string(root.join("active").join(component_id)).ok()?;
+    let digest = digest.trim();
+    if digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return None;
+    }
+    let object = root.join("objects/sha256").join(digest);
+    let entrypoint = match component_id {
+        "oore-apple-sign" => object.join("bin/oore-apple-sign"),
+        _ => return None,
+    };
+    let canonical = fs::canonicalize(&entrypoint).ok()?;
+    let canonical_root = fs::canonicalize(&object).ok()?;
+    (canonical.starts_with(canonical_root) && canonical.is_file()).then_some(canonical)
+}
+
+fn verified_component_path(component_id: &str) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let (chain, state) = verified_catalog()?;
+    let (os, arch) = current_target()?;
+    let component = chain
+        .component_for_host(component_id, os, arch)?
+        .ok_or_else(|| {
+            format!("the signed catalog has no active {component_id} for {os}/{arch}")
+        })?;
+    verify_minimum_os(component.minimum_os_version())?;
+    let root = install_root()?;
+    let installed = load_active(&component, &root.join("components"))?;
+    write_atomic(&root.join(CATALOG_STATE_FILE), &state.to_bytes()?)?;
+    Ok(installed.entrypoint().to_path_buf())
 }
 
 struct InstallOptions {
@@ -412,6 +616,24 @@ fn remove_file_if_present(path: &Path) -> Result<(), Box<dyn std::error::Error>>
 
 fn forward_to_core(arguments: &[OsString]) -> Result<ExitCode, Box<dyn std::error::Error>> {
     let executable = core_executable()?;
+    let status = Command::new(executable).args(arguments).status()?;
+    Ok(ExitCode::from(
+        status
+            .code()
+            .and_then(|code| u8::try_from(code).ok())
+            .unwrap_or(1),
+    ))
+}
+
+fn forward_to_component(
+    component_id: &str,
+    arguments: &[OsString],
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let executable = verified_component_path(component_id).map_err(|error| {
+        format!(
+            "{component_id} is not ready: {error}; run `oore install --role advanced --component {component_id}`"
+        )
+    })?;
     let status = Command::new(executable).args(arguments).status()?;
     Ok(ExitCode::from(
         status

--- a/crates/oore-catalog/Cargo.toml
+++ b/crates/oore-catalog/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 base64.workspace = true
 chrono.workspace = true
 ring.workspace = true
+semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/oore-catalog/Cargo.toml
+++ b/crates/oore-catalog/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "oore-catalog"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+
+[dependencies]
+base64.workspace = true
+chrono.workspace = true
+ring.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+thiserror.workspace = true

--- a/crates/oore-catalog/Cargo.toml
+++ b/crates/oore-catalog/Cargo.toml
@@ -7,11 +7,18 @@ repository.workspace = true
 readme = "README.md"
 
 [dependencies]
+anyhow.workspace = true
 base64.workspace = true
 chrono.workspace = true
+clap.workspace = true
 ring.workspace = true
 semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+tempfile.workspace = true
+
+[[bin]]
+name = "oore-catalog-author"
+path = "src/bin/oore-catalog-author.rs"

--- a/crates/oore-catalog/Cargo.toml
+++ b/crates/oore-catalog/Cargo.toml
@@ -11,6 +11,7 @@ anyhow.workspace = true
 base64.workspace = true
 chrono.workspace = true
 clap.workspace = true
+libc.workspace = true
 ring.workspace = true
 semver.workspace = true
 serde.workspace = true
@@ -22,3 +23,7 @@ tempfile.workspace = true
 [[bin]]
 name = "oore-catalog-author"
 path = "src/bin/oore-catalog-author.rs"
+
+[[bin]]
+name = "oore-catalog-local-signer"
+path = "src/bin/oore-catalog-local-signer.rs"

--- a/crates/oore-catalog/Cargo.toml
+++ b/crates/oore-catalog/Cargo.toml
@@ -19,6 +19,7 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tempfile.workspace = true
+zeroize.workspace = true
 
 [[bin]]
 name = "oore-catalog-author"

--- a/crates/oore-catalog/README.md
+++ b/crates/oore-catalog/README.md
@@ -13,16 +13,22 @@ The current checkpoint provides:
 - durable rollback and equivocation state;
 - a closed component, gate, service, lifecycle, and revocation schema;
 - exact dependency resolution and complete closure checks;
-- a safe summary of a verified catalog chain.
+- safe host selection from a complete verified catalog chain;
+- conversion of published Components evidence into a closed Oore record;
+- builders for unsigned Root, Targets, Snapshot, and Timestamp payloads.
 
-The crate does not expose component records yet. It cannot authorize a
-download, installation, activation, or execution. The next layer must add
-host and capability selection without allowing callers to fabricate records.
+Selected component values have private fields and no deserializer. Only the
+complete four-role verifier can create them. `oore-component-store` consumes
+these values for installation and launch checks.
 
 The catalog signer uses Oore release keys. Apple Developer credentials are not
 part of this trust chain.
 
 ## Detached signing
+
+`oore-catalog-author import-component` imports one published Components
+manifest and artifact record. `build-root`, `build-targets`, `build-snapshot`,
+and `build-timestamp` create the four unsigned payloads.
 
 `oore-catalog-author prepare` creates a short-lived canonical signing request.
 It does not load a private key.

--- a/crates/oore-catalog/README.md
+++ b/crates/oore-catalog/README.md
@@ -30,3 +30,49 @@ It does not load a private key.
 `oore-catalog-author assemble` verifies detached responses with their public
 keys. It then creates a canonical signed envelope. The complete catalog
 verifier must still accept that envelope before publication.
+
+## Local alpha signer
+
+`oore-catalog-local-signer` keeps local private-key use outside the catalog
+author. It does not support noninteractive signing.
+
+Create one signer on an encrypted offline volume:
+
+```console
+oore-catalog-local-signer generate \
+  --private-key ./targets-1.pk8 \
+  --public-key ./targets-1.public.json
+```
+
+The private-key file uses mode `0600` on Unix. It is not password-encrypted.
+Do not commit it, copy it to a runner, or store it in a CI secret.
+
+Prepare one short-lived request on the release machine:
+
+```console
+oore-catalog-author prepare \
+  --role targets \
+  --input ./targets.signed.json \
+  --output ./targets.request.json \
+  --repository oore-ci/oore.build \
+  --commit 0123456789abcdef0123456789abcdef01234567 \
+  --tag v0.2.0-alpha.1 \
+  --catalog-revision 1
+```
+
+Move only the request to the offline signer. Review the displayed release
+facts and type the complete payload digest:
+
+```console
+oore-catalog-local-signer sign \
+  --request ./targets.request.json \
+  --private-key ./targets-1.pk8 \
+  --output ./targets-1.signature.json
+```
+
+Return only the detached response. Repeat the operation with the required
+independent keys. The author then assembles the responses with the matching
+public-key files.
+
+OpenBao can replace one local signer later. The detached request, response,
+and catalog formats do not change.

--- a/crates/oore-catalog/README.md
+++ b/crates/oore-catalog/README.md
@@ -11,11 +11,13 @@ The current checkpoint provides:
 - Root, Targets, Snapshot, and Timestamp expiry checks;
 - exact metadata length and SHA-256 bindings;
 - durable rollback and equivocation state;
+- a closed component, gate, service, lifecycle, and revocation schema;
+- exact dependency resolution and complete closure checks;
 - a safe summary of a verified catalog chain.
 
-The crate does not yet expose component records. It cannot authorize a
-download, installation, activation, or execution. That remains blocked until
-the complete closed component schema and exact dependency resolver exist.
+The crate does not expose component records yet. It cannot authorize a
+download, installation, activation, or execution. The next layer must add
+host and capability selection without allowing callers to fabricate records.
 
 The catalog signer uses Oore release keys. Apple Developer credentials are not
 part of this trust chain.

--- a/crates/oore-catalog/README.md
+++ b/crates/oore-catalog/README.md
@@ -1,0 +1,21 @@
+# oore-catalog
+
+`oore-catalog` verifies Oore's official component metadata chain.
+
+The current checkpoint provides:
+
+- a shell-pinned Root trust anchor;
+- Ed25519 role thresholds;
+- old-and-new threshold Root rotation;
+- strict canonical JSON parsing;
+- Root, Targets, Snapshot, and Timestamp expiry checks;
+- exact metadata length and SHA-256 bindings;
+- durable rollback and equivocation state;
+- a safe summary of a verified catalog chain.
+
+The crate does not yet expose component records. It cannot authorize a
+download, installation, activation, or execution. That remains blocked until
+the complete closed component schema and exact dependency resolver exist.
+
+The catalog signer uses Oore release keys. Apple Developer credentials are not
+part of this trust chain.

--- a/crates/oore-catalog/README.md
+++ b/crates/oore-catalog/README.md
@@ -21,3 +21,12 @@ host and capability selection without allowing callers to fabricate records.
 
 The catalog signer uses Oore release keys. Apple Developer credentials are not
 part of this trust chain.
+
+## Detached signing
+
+`oore-catalog-author prepare` creates a short-lived canonical signing request.
+It does not load a private key.
+
+`oore-catalog-author assemble` verifies detached responses with their public
+keys. It then creates a canonical signed envelope. The complete catalog
+verifier must still accept that envelope before publication.

--- a/crates/oore-catalog/src/authoring.rs
+++ b/crates/oore-catalog/src/authoring.rs
@@ -1,0 +1,511 @@
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::{
+    CatalogChannel, CatalogError, MAX_COMPONENT_RECORD_BYTES, MAX_ROOT_BYTES, MAX_SNAPSHOT_BYTES,
+    MAX_TARGETS_BYTES, PublicKey, ROOT_VALIDITY, RootMetadata, SCHEMA_VERSION, SNAPSHOT_VALIDITY,
+    SnapshotMetadata, TIMESTAMP_VALIDITY, TimestampMetadata, TrustRoles, TrustedKey, VerifierKey,
+    canonical_value, invalid, invalid_error, parse_envelope, parse_strict, records, sha256,
+    validate_sha256,
+};
+
+const COMPONENT_EVIDENCE_BYTES: usize = 256 * 1024;
+const COMPONENTS_REPOSITORY: &str = "https://github.com/oore-ci/components";
+const OFFICIAL_REPOSITORY: &str = "oore-official";
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvidenceManifest {
+    schema_version: u8,
+    identity: EvidenceIdentity,
+    release: EvidenceRelease,
+    entrypoint: String,
+    capabilities: Vec<Value>,
+    dependencies: Vec<EvidenceDependency>,
+    dependency_closure: Vec<EvidenceDependency>,
+    requirements: EvidenceRequirements,
+    service: Option<Value>,
+    lifecycle: Value,
+    provenance: EvidenceProvenance,
+    bundle: EvidencePayloadBundle,
+    files: Vec<Value>,
+    manifest_sha256: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvidenceIdentity {
+    component_id: String,
+    component_version: String,
+    target: Value,
+    protocol: Value,
+    release_counter: u64,
+    payload_sha256: String,
+    payload_length: u64,
+    catalog_revision: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvidenceRelease {
+    coordinate: String,
+    package: String,
+    program: String,
+    package_version: String,
+    component_version: String,
+    tag: String,
+    commit: String,
+    repository: String,
+    publish: bool,
+    source: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvidenceDependency {
+    component_id: String,
+    component_version: String,
+    target: Value,
+    protocol: Value,
+    bundle_sha256: String,
+    bundle_length: u64,
+    release_counter: u64,
+    license: String,
+    dependency_kind: Value,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvidenceRequirements {
+    host: Value,
+    toolchains: Vec<Value>,
+    workspace: Value,
+    network: Value,
+    license: Option<Value>,
+    privileges: Vec<Value>,
+    download: EvidenceDownload,
+    destructive: Vec<Value>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvidenceDownload {
+    payload_bytes: u64,
+    expanded_bytes: u64,
+    file_count: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvidenceProvenance {
+    repository: String,
+    workflow: String,
+    workflow_name: String,
+    tag: String,
+    commit: String,
+    payload_subject: EvidencePayloadSubject,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvidencePayloadSubject {
+    name: String,
+    sha256: String,
+    length: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvidencePayloadBundle {
+    format: String,
+    digest_algorithm: String,
+    payload_length: u64,
+    payload_sha256: String,
+    path: String,
+    expanded_bytes: u64,
+    file_count: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvidenceArtifact {
+    schema_version: u8,
+    asset_name: String,
+    format: String,
+    sha256: String,
+    length: u64,
+    manifest_sha256: String,
+    inventory_sha256: String,
+    target: Value,
+    component_id: String,
+    component_version: String,
+    package_tag: String,
+    commit: String,
+}
+
+/// Converts one qualified Components release into Oore's closed admission record.
+pub fn import_component_release(
+    manifest_bytes: &[u8],
+    artifact_bytes: &[u8],
+    catalog_revision: u64,
+) -> Result<Vec<u8>, CatalogError> {
+    let manifest_value: Value = parse_strict(
+        manifest_bytes,
+        COMPONENT_EVIDENCE_BYTES,
+        "component release manifest",
+    )?;
+    if canonical_value(&manifest_value)? != manifest_bytes {
+        return invalid("component release manifest", "bytes are not canonical JSON");
+    }
+    let manifest: EvidenceManifest = serde_json::from_value(manifest_value)
+        .map_err(|error| invalid_error("component release manifest", &error.to_string()))?;
+    let artifact: EvidenceArtifact = parse_strict(
+        artifact_bytes,
+        COMPONENT_EVIDENCE_BYTES,
+        "component release artifact",
+    )?;
+    validate_evidence(&manifest, &artifact, catalog_revision)?;
+
+    let dependencies = manifest
+        .dependencies
+        .into_iter()
+        .map(dependency_value)
+        .collect::<Vec<_>>();
+    let dependency_closure = manifest
+        .dependency_closure
+        .into_iter()
+        .map(dependency_value)
+        .collect::<Vec<_>>();
+    let source_workflow = manifest.provenance.workflow.clone();
+    let record = json!({
+        "component_id": manifest.identity.component_id,
+        "component_version": manifest.identity.component_version,
+        "release_counter": manifest.identity.release_counter,
+        "target": manifest.identity.target,
+        "protocol": manifest.identity.protocol,
+        "entrypoint": manifest.entrypoint,
+        "capabilities": manifest.capabilities,
+        "dependencies": dependencies,
+        "dependency_closure": dependency_closure,
+        "bundle": {
+            "format": "tar_zst",
+            "digest_algorithm": "sha256",
+            "length": artifact.length,
+            "sha256": artifact.sha256,
+            "path": format!("sha256/{}/{}", artifact.sha256, artifact.asset_name),
+            "expanded_bytes": manifest.bundle.expanded_bytes,
+            "file_count": manifest.bundle.file_count
+        },
+        "manifest": {
+            "path": "component.manifest.json",
+            "length": manifest_bytes.len(),
+            "sha256": sha256(manifest_bytes)
+        },
+        "files": manifest.files,
+        "requirements": {
+            "host": manifest.requirements.host,
+            "toolchains": manifest.requirements.toolchains,
+            "workspace": manifest.requirements.workspace,
+            "network": manifest.requirements.network,
+            "license": manifest.requirements.license,
+            "privileges": manifest.requirements.privileges,
+            "download": {
+                "compressed_bytes": artifact.length,
+                "expanded_bytes": manifest.requirements.download.expanded_bytes,
+                "file_count": manifest.requirements.download.file_count
+            },
+            "destructive": manifest.requirements.destructive
+        },
+        "service": manifest.service,
+        "lifecycle": manifest.lifecycle,
+        "provenance_policy": {
+            "kind": "github_actions_oidc",
+            "repository": "oore-ci/components",
+            "workflow": source_workflow,
+            "issuer": "https://token.actions.githubusercontent.com"
+        }
+    });
+    records::CatalogDocument::component_from_value(record.clone())?.validate(catalog_revision)?;
+    let canonical = canonical_value(&record)?;
+    if canonical.len() > MAX_COMPONENT_RECORD_BYTES {
+        return Err(CatalogError::Limit("component admission record"));
+    }
+    Ok(canonical)
+}
+
+/// Creates one unsigned Targets payload from closed component records.
+pub fn build_targets_payload(
+    channel: CatalogChannel,
+    catalog_revision: u64,
+    component_records: &[&[u8]],
+    now: DateTime<Utc>,
+) -> Result<Vec<u8>, CatalogError> {
+    let mut components = component_records
+        .iter()
+        .map(|bytes| {
+            let value: Value = parse_strict(bytes, MAX_COMPONENT_RECORD_BYTES, "component record")?;
+            records::CatalogDocument::component_from_value(value)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    components.sort_by(|left, right| left.identity_key().cmp(&right.identity_key()));
+    records::CatalogDocument::compose(channel, catalog_revision, components, now)
+}
+
+/// Creates the first unsigned Root payload from ten disjoint signer keys.
+pub fn build_root_payload(
+    root_keys: &[&[u8]],
+    targets_keys: &[&[u8]],
+    snapshot_keys: &[&[u8]],
+    timestamp_keys: &[&[u8]],
+    version: u64,
+    now: DateTime<Utc>,
+) -> Result<Vec<u8>, CatalogError> {
+    if root_keys.len() != 3
+        || targets_keys.len() != 3
+        || snapshot_keys.len() != 2
+        || timestamp_keys.len() != 2
+        || version == 0
+    {
+        return invalid("Root", "signer counts or version are invalid");
+    }
+    let mut trusted_keys = Vec::with_capacity(10);
+    let root_ids = import_keys(root_keys, &mut trusted_keys)?;
+    let targets_ids = import_keys(targets_keys, &mut trusted_keys)?;
+    let snapshot_ids = import_keys(snapshot_keys, &mut trusted_keys)?;
+    let timestamp_ids = import_keys(timestamp_keys, &mut trusted_keys)?;
+    trusted_keys.sort_by(|left, right| left.key_id.cmp(&right.key_id));
+    if trusted_keys
+        .windows(2)
+        .any(|pair| pair[0].key_id == pair[1].key_id)
+    {
+        return invalid("Root", "one signer key has more than one role");
+    }
+    let expires = checked_expiry(now, ROOT_VALIDITY, "Root")?;
+    let root = RootMetadata {
+        schema_version: SCHEMA_VERSION,
+        repository: OFFICIAL_REPOSITORY.to_owned(),
+        version,
+        generated_at: timestamp(now),
+        expires: timestamp(expires),
+        consistent_snapshot: true,
+        keys: trusted_keys,
+        roles: TrustRoles {
+            root: threshold(2, root_ids),
+            targets: threshold(2, targets_ids),
+            snapshot: threshold(1, snapshot_ids),
+            timestamp: threshold(1, timestamp_ids),
+        },
+    };
+    root.validate(now, "Root")?;
+    super::canonical_bytes(&root, "Root")
+}
+
+/// Creates one unsigned Snapshot payload from exact signed metadata envelopes.
+pub fn build_snapshot_payload(
+    root_envelope: &[u8],
+    targets_envelope: &[u8],
+    version: u64,
+    now: DateTime<Utc>,
+) -> Result<Vec<u8>, CatalogError> {
+    if version == 0 {
+        return invalid("Snapshot", "version is zero");
+    }
+    let (root_value, root_bytes) = parse_envelope(root_envelope, MAX_ROOT_BYTES, "Root")?;
+    let root: RootMetadata = super::decode_signed(&root_value, "Root")?;
+    let (targets_value, targets_bytes) =
+        parse_envelope(targets_envelope, MAX_TARGETS_BYTES, "Targets")?;
+    let targets = records::CatalogDocument::from_value(
+        &targets_value.signed,
+        now,
+        &std::collections::BTreeMap::new(),
+    )?;
+    let expires = checked_expiry(now, SNAPSHOT_VALIDITY, "Snapshot")?;
+    let snapshot = SnapshotMetadata {
+        schema_version: SCHEMA_VERSION,
+        repository: OFFICIAL_REPOSITORY.to_owned(),
+        version,
+        generated_at: timestamp(now),
+        expires: timestamp(expires),
+        root: description(root.version, &root_bytes)?,
+        targets: description(targets.catalog_revision, &targets_bytes)?,
+    };
+    snapshot.validate(now)?;
+    super::canonical_bytes(&snapshot, "Snapshot")
+}
+
+/// Creates one unsigned Timestamp payload from an exact signed Snapshot envelope.
+pub fn build_timestamp_payload(
+    snapshot_envelope: &[u8],
+    version: u64,
+    now: DateTime<Utc>,
+) -> Result<Vec<u8>, CatalogError> {
+    if version == 0 {
+        return invalid("Timestamp", "version is zero");
+    }
+    let (snapshot_value, snapshot_bytes) =
+        parse_envelope(snapshot_envelope, MAX_SNAPSHOT_BYTES, "Snapshot")?;
+    let snapshot: SnapshotMetadata = super::decode_signed(&snapshot_value, "Snapshot")?;
+    let expires = checked_expiry(now, TIMESTAMP_VALIDITY, "Timestamp")?;
+    let timestamp_value = TimestampMetadata {
+        schema_version: SCHEMA_VERSION,
+        repository: OFFICIAL_REPOSITORY.to_owned(),
+        version,
+        generated_at: timestamp(now),
+        expires: timestamp(expires),
+        snapshot: description(snapshot.version, &snapshot_bytes)?,
+    };
+    timestamp_value.validate(now)?;
+    super::canonical_bytes(&timestamp_value, "Timestamp")
+}
+
+fn import_keys(
+    documents: &[&[u8]],
+    trusted_keys: &mut Vec<TrustedKey>,
+) -> Result<Vec<String>, CatalogError> {
+    let mut ids = Vec::with_capacity(documents.len());
+    for document in documents {
+        let key: PublicKey = parse_strict(document, 8 * 1024, "Root public key")?;
+        let verifier = VerifierKey::from_bytes(document)?;
+        ids.push(verifier.key_id().to_owned());
+        trusted_keys.push(TrustedKey {
+            key_id: verifier.key_id().to_owned(),
+            key,
+        });
+    }
+    ids.sort();
+    Ok(ids)
+}
+
+fn threshold(threshold: u8, key_ids: Vec<String>) -> super::ThresholdRole {
+    super::ThresholdRole { threshold, key_ids }
+}
+
+fn checked_expiry(
+    now: DateTime<Utc>,
+    validity: chrono::Duration,
+    label: &'static str,
+) -> Result<DateTime<Utc>, CatalogError> {
+    now.checked_add_signed(validity)
+        .ok_or_else(|| invalid_error(label, "expiry overflowed"))
+}
+
+fn timestamp(value: DateTime<Utc>) -> String {
+    value.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+fn description(version: u64, bytes: &[u8]) -> Result<super::MetadataDescription, CatalogError> {
+    Ok(super::MetadataDescription {
+        version,
+        length: u64::try_from(bytes.len()).map_err(|_| CatalogError::Limit("metadata length"))?,
+        sha256: sha256(bytes),
+    })
+}
+
+fn dependency_value(dependency: EvidenceDependency) -> Value {
+    let EvidenceDependency {
+        component_id,
+        component_version,
+        target,
+        protocol,
+        bundle_sha256,
+        bundle_length,
+        release_counter: _,
+        license: _,
+        dependency_kind,
+    } = dependency;
+    json!({
+        "component_id": component_id,
+        "component_version": component_version,
+        "target": target,
+        "protocol": protocol,
+        "bundle": {"sha256": bundle_sha256, "length": bundle_length},
+        "dependency_kind": dependency_kind
+    })
+}
+
+fn validate_evidence(
+    manifest: &EvidenceManifest,
+    artifact: &EvidenceArtifact,
+    catalog_revision: u64,
+) -> Result<(), CatalogError> {
+    validate_sha256(&manifest.manifest_sha256, "component manifest self digest")?;
+    validate_sha256(
+        &manifest.identity.payload_sha256,
+        "component payload digest",
+    )?;
+    validate_sha256(
+        &manifest.bundle.payload_sha256,
+        "component bundle payload digest",
+    )?;
+    validate_sha256(&artifact.sha256, "component artifact digest")?;
+    validate_sha256(
+        &artifact.manifest_sha256,
+        "component artifact manifest digest",
+    )?;
+    validate_sha256(
+        &artifact.inventory_sha256,
+        "component artifact inventory digest",
+    )?;
+    if manifest.dependencies.iter().any(|dependency| {
+        dependency.release_counter == 0
+            || dependency.license.trim().is_empty()
+            || dependency.license.len() > 128
+    }) || manifest.dependency_closure.iter().any(|dependency| {
+        dependency.release_counter == 0
+            || dependency.license.trim().is_empty()
+            || dependency.license.len() > 128
+    }) {
+        return invalid(
+            "component release evidence",
+            "dependency release facts are invalid",
+        );
+    }
+    if manifest.schema_version != 1
+        || artifact.schema_version != 1
+        || catalog_revision == 0
+        || manifest.identity.catalog_revision != catalog_revision
+        || manifest.identity.component_id != artifact.component_id
+        || manifest.identity.component_version != artifact.component_version
+        || manifest.identity.target != artifact.target
+        || manifest.identity.payload_sha256 != manifest.bundle.payload_sha256
+        || manifest.identity.payload_length != manifest.bundle.payload_length
+        || manifest.bundle.format != "tar_zst"
+        || manifest.bundle.digest_algorithm != "sha256"
+        || manifest.bundle.path != artifact.asset_name
+        || artifact.format != "tar_zst"
+        || artifact.manifest_sha256 != manifest.manifest_sha256
+        || manifest.release.repository != COMPONENTS_REPOSITORY
+        || manifest.provenance.repository != COMPONENTS_REPOSITORY
+        || manifest.provenance.workflow_name.trim().is_empty()
+        || manifest.provenance.workflow_name.len() > 128
+        || manifest.release.source != "generated"
+        || !manifest.release.publish
+        || manifest.release.program != manifest.identity.component_id
+        || manifest.release.component_version != manifest.identity.component_version
+        || manifest.release.package_version != manifest.identity.component_version
+        || manifest.release.tag != artifact.package_tag
+        || manifest.release.commit != artifact.commit
+        || manifest.provenance.tag != artifact.package_tag
+        || manifest.provenance.commit != artifact.commit
+        || manifest.provenance.payload_subject.name != artifact.asset_name
+        || manifest.provenance.payload_subject.sha256 != manifest.bundle.payload_sha256
+        || manifest.provenance.payload_subject.length != manifest.bundle.payload_length
+        || manifest.requirements.download.payload_bytes != manifest.bundle.payload_length
+        || manifest.requirements.download.expanded_bytes != manifest.bundle.expanded_bytes
+        || manifest.requirements.download.file_count != manifest.bundle.file_count
+        || manifest.release.coordinate
+            != format!("oore.components/{}", manifest.identity.component_id)
+        || manifest.release.tag
+            != format!(
+                "{}-v{}",
+                manifest.release.package, manifest.release.package_version
+            )
+    {
+        return invalid(
+            "component release evidence",
+            "manifest and artifact identities do not match",
+        );
+    }
+    Ok(())
+}

--- a/crates/oore-catalog/src/bin/oore-catalog-author.rs
+++ b/crates/oore-catalog/src/bin/oore-catalog-author.rs
@@ -8,7 +8,9 @@ use anyhow::{Context, Result, bail};
 use chrono::Utc;
 use clap::{Parser, Subcommand, ValueEnum};
 use oore_catalog::{
-    DetachedSignature, ReleaseBinding, SigningRequest, SigningRole, VerifierKey, assemble_envelope,
+    CatalogChannel, DetachedSignature, ReleaseBinding, SigningRequest, SigningRole, VerifierKey,
+    assemble_envelope, build_root_payload, build_snapshot_payload, build_targets_payload,
+    build_timestamp_payload, import_component_release,
 };
 
 const MAX_INPUT_BYTES: u64 = 16 * 1024 * 1024;
@@ -23,6 +25,84 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
+    /// Import one published Components release as a closed Oore record.
+    ImportComponent {
+        /// Canonical manifest from the Components release.
+        #[arg(long)]
+        manifest: PathBuf,
+        /// Artifact evidence from the Components release.
+        #[arg(long)]
+        artifact: PathBuf,
+        /// Catalog revision that admits this release.
+        #[arg(long)]
+        catalog_revision: u64,
+        /// Canonical component-record output.
+        #[arg(long)]
+        output: PathBuf,
+    },
+    /// Build the first unsigned Root payload.
+    BuildRoot {
+        /// Root signer public key. Provide exactly three.
+        #[arg(long, required = true, num_args = 3)]
+        root_key: Vec<PathBuf>,
+        /// Targets signer public key. Provide exactly three.
+        #[arg(long, required = true, num_args = 3)]
+        targets_key: Vec<PathBuf>,
+        /// Snapshot signer public key. Provide exactly two.
+        #[arg(long, required = true, num_args = 2)]
+        snapshot_key: Vec<PathBuf>,
+        /// Timestamp signer public key. Provide exactly two.
+        #[arg(long, required = true, num_args = 2)]
+        timestamp_key: Vec<PathBuf>,
+        /// Root metadata version.
+        #[arg(long, default_value_t = 1)]
+        version: u64,
+        /// Canonical unsigned Root output.
+        #[arg(long)]
+        output: PathBuf,
+    },
+    /// Build one unsigned Targets payload.
+    BuildTargets {
+        /// Catalog channel.
+        #[arg(long, value_enum)]
+        channel: ChannelArgument,
+        /// Catalog revision.
+        #[arg(long)]
+        catalog_revision: u64,
+        /// Closed component record. Repeat for each component.
+        #[arg(long, required = true)]
+        component: Vec<PathBuf>,
+        /// Canonical unsigned Targets output.
+        #[arg(long)]
+        output: PathBuf,
+    },
+    /// Build one unsigned Snapshot payload.
+    BuildSnapshot {
+        /// Exact signed Root envelope.
+        #[arg(long)]
+        root: PathBuf,
+        /// Exact signed Targets envelope.
+        #[arg(long)]
+        targets: PathBuf,
+        /// Snapshot metadata version.
+        #[arg(long)]
+        version: u64,
+        /// Canonical unsigned Snapshot output.
+        #[arg(long)]
+        output: PathBuf,
+    },
+    /// Build one unsigned Timestamp payload.
+    BuildTimestamp {
+        /// Exact signed Snapshot envelope.
+        #[arg(long)]
+        snapshot: PathBuf,
+        /// Timestamp metadata version.
+        #[arg(long)]
+        version: u64,
+        /// Canonical unsigned Timestamp output.
+        #[arg(long)]
+        output: PathBuf,
+    },
     /// Prepare canonical metadata for an external signer.
     Prepare {
         /// Metadata role to sign.
@@ -72,6 +152,23 @@ enum RoleArgument {
     Timestamp,
 }
 
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum ChannelArgument {
+    Alpha,
+    Beta,
+    Stable,
+}
+
+impl From<ChannelArgument> for CatalogChannel {
+    fn from(value: ChannelArgument) -> Self {
+        match value {
+            ChannelArgument::Alpha => Self::Alpha,
+            ChannelArgument::Beta => Self::Beta,
+            ChannelArgument::Stable => Self::Stable,
+        }
+    }
+}
+
 impl From<RoleArgument> for SigningRole {
     fn from(value: RoleArgument) -> Self {
         match value {
@@ -86,6 +183,78 @@ impl From<RoleArgument> for SigningRole {
 fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
+        Command::ImportComponent {
+            manifest,
+            artifact,
+            catalog_revision,
+            output,
+        } => {
+            let record = import_component_release(
+                &read_bounded(&manifest)?,
+                &read_bounded(&artifact)?,
+                catalog_revision,
+            )?;
+            write_atomic(&output, &record)?;
+        }
+        Command::BuildRoot {
+            root_key,
+            targets_key,
+            snapshot_key,
+            timestamp_key,
+            version,
+            output,
+        } => {
+            let root = read_many(&root_key)?;
+            let targets = read_many(&targets_key)?;
+            let snapshot = read_many(&snapshot_key)?;
+            let timestamp = read_many(&timestamp_key)?;
+            let payload = build_root_payload(
+                &references(&root),
+                &references(&targets),
+                &references(&snapshot),
+                &references(&timestamp),
+                version,
+                Utc::now(),
+            )?;
+            write_atomic(&output, &payload)?;
+        }
+        Command::BuildTargets {
+            channel,
+            catalog_revision,
+            component,
+            output,
+        } => {
+            let components = read_many(&component)?;
+            let payload = build_targets_payload(
+                channel.into(),
+                catalog_revision,
+                &references(&components),
+                Utc::now(),
+            )?;
+            write_atomic(&output, &payload)?;
+        }
+        Command::BuildSnapshot {
+            root,
+            targets,
+            version,
+            output,
+        } => {
+            let payload = build_snapshot_payload(
+                &read_bounded(&root)?,
+                &read_bounded(&targets)?,
+                version,
+                Utc::now(),
+            )?;
+            write_atomic(&output, &payload)?;
+        }
+        Command::BuildTimestamp {
+            snapshot,
+            version,
+            output,
+        } => {
+            let payload = build_timestamp_payload(&read_bounded(&snapshot)?, version, Utc::now())?;
+            write_atomic(&output, &payload)?;
+        }
         Command::Prepare {
             role,
             input,
@@ -121,6 +290,14 @@ fn main() -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn read_many(paths: &[PathBuf]) -> Result<Vec<Vec<u8>>> {
+    paths.iter().map(|path| read_bounded(path)).collect()
+}
+
+fn references(values: &[Vec<u8>]) -> Vec<&[u8]> {
+    values.iter().map(Vec::as_slice).collect()
 }
 
 fn read_bounded(path: &Path) -> Result<Vec<u8>> {

--- a/crates/oore-catalog/src/bin/oore-catalog-author.rs
+++ b/crates/oore-catalog/src/bin/oore-catalog-author.rs
@@ -1,0 +1,173 @@
+use std::fs::{self, File};
+use std::io::{Read, Write};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt as _;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use chrono::Utc;
+use clap::{Parser, Subcommand, ValueEnum};
+use oore_catalog::{
+    DetachedSignature, ReleaseBinding, SigningRequest, SigningRole, VerifierKey, assemble_envelope,
+};
+
+const MAX_INPUT_BYTES: u64 = 16 * 1024 * 1024;
+
+#[derive(Debug, Parser)]
+#[command(name = "oore-catalog-author")]
+#[command(about = "Prepare and assemble detached Oore catalog signatures")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Prepare canonical metadata for an external signer.
+    Prepare {
+        /// Metadata role to sign.
+        #[arg(long, value_enum)]
+        role: RoleArgument,
+        /// Unsigned role JSON file.
+        #[arg(long)]
+        input: PathBuf,
+        /// Canonical signing request output.
+        #[arg(long)]
+        output: PathBuf,
+        /// Exact source repository.
+        #[arg(long)]
+        repository: String,
+        /// Full lowercase source commit SHA.
+        #[arg(long)]
+        commit: String,
+        /// Exact source or release tag.
+        #[arg(long)]
+        tag: String,
+        /// Exact catalog revision.
+        #[arg(long)]
+        catalog_revision: u64,
+    },
+    /// Verify detached responses and assemble one metadata envelope.
+    Assemble {
+        /// Canonical signing request.
+        #[arg(long)]
+        request: PathBuf,
+        /// Detached response file. Repeat once per signer.
+        #[arg(long, required = true)]
+        signature: Vec<PathBuf>,
+        /// Matching public-key file. Repeat in signature order.
+        #[arg(long, required = true)]
+        key: Vec<PathBuf>,
+        /// Canonical signed metadata output.
+        #[arg(long)]
+        output: PathBuf,
+    },
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum RoleArgument {
+    Root,
+    Targets,
+    Snapshot,
+    Timestamp,
+}
+
+impl From<RoleArgument> for SigningRole {
+    fn from(value: RoleArgument) -> Self {
+        match value {
+            RoleArgument::Root => Self::Root,
+            RoleArgument::Targets => Self::Targets,
+            RoleArgument::Snapshot => Self::Snapshot,
+            RoleArgument::Timestamp => Self::Timestamp,
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Command::Prepare {
+            role,
+            input,
+            output,
+            repository,
+            commit,
+            tag,
+            catalog_revision,
+        } => {
+            let signed = read_bounded(&input)?;
+            let release = ReleaseBinding::new(&repository, &commit, &tag, catalog_revision)?;
+            let request = SigningRequest::prepare(role.into(), &signed, release, Utc::now())?;
+            write_atomic(&output, &request.to_bytes()?)?;
+        }
+        Command::Assemble {
+            request,
+            signature,
+            key,
+            output,
+        } => {
+            if signature.len() != key.len() {
+                bail!("each --signature needs one matching --key");
+            }
+            let request = SigningRequest::from_bytes(&read_bounded(&request)?)?;
+            let mut accepted = Vec::with_capacity(signature.len());
+            for (signature_path, key_path) in signature.iter().zip(&key) {
+                let response = DetachedSignature::from_bytes(&read_bounded(signature_path)?)?;
+                let verifier = VerifierKey::from_bytes(&read_bounded(key_path)?)?;
+                accepted.push(response.accept(&request, &verifier, Utc::now())?);
+            }
+            let envelope = assemble_envelope(&request, &accepted, Utc::now())?;
+            write_atomic(&output, &envelope)?;
+        }
+    }
+    Ok(())
+}
+
+fn read_bounded(path: &Path) -> Result<Vec<u8>> {
+    let file = File::open(path).with_context(|| format!("cannot open {}", path.display()))?;
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("cannot inspect {}", path.display()))?;
+    if !metadata.is_file() || metadata.len() > MAX_INPUT_BYTES {
+        bail!("{} is not a bounded regular file", path.display());
+    }
+    let capacity = usize::try_from(metadata.len()).context("input length does not fit memory")?;
+    let mut bytes = Vec::with_capacity(capacity);
+    file.take(MAX_INPUT_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .with_context(|| format!("cannot read {}", path.display()))?;
+    if bytes.len() as u64 > MAX_INPUT_BYTES {
+        bail!("{} grew beyond the input limit", path.display());
+    }
+    Ok(bytes)
+}
+
+fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent).with_context(|| format!("cannot create {}", parent.display()))?;
+    let mut temporary = tempfile::NamedTempFile::new_in(parent)
+        .with_context(|| format!("cannot stage output in {}", parent.display()))?;
+    #[cfg(unix)]
+    temporary
+        .as_file()
+        .set_permissions(fs::Permissions::from_mode(0o600))
+        .context("cannot protect staged output")?;
+    temporary
+        .write_all(bytes)
+        .context("cannot write staged output")?;
+    temporary
+        .as_file()
+        .sync_all()
+        .context("cannot sync staged output")?;
+    temporary
+        .persist(path)
+        .map_err(|error| error.error)
+        .with_context(|| format!("cannot publish {}", path.display()))?;
+    File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .with_context(|| format!("cannot sync {}", parent.display()))?;
+    Ok(())
+}

--- a/crates/oore-catalog/src/bin/oore-catalog-local-signer.rs
+++ b/crates/oore-catalog/src/bin/oore-catalog-local-signer.rs
@@ -13,6 +13,7 @@ use clap::{Parser, Subcommand};
 use oore_catalog::{DetachedSignature, SigningRequest, VerifierKey};
 use ring::rand::SystemRandom;
 use ring::signature::{Ed25519KeyPair, KeyPair as _};
+use zeroize::Zeroizing;
 
 const MAX_REQUEST_BYTES: u64 = 16 * 1024 * 1024;
 const MAX_PRIVATE_KEY_BYTES: u64 = 4 * 1024;
@@ -152,7 +153,7 @@ fn public_key_document(public_key: &[u8]) -> Result<Vec<u8>> {
     serde_json::to_vec(&document).context("cannot encode the public-key document")
 }
 
-fn read_private_key(path: &Path) -> Result<Vec<u8>> {
+fn read_private_key(path: &Path) -> Result<Zeroizing<Vec<u8>>> {
     let mut options = OpenOptions::new();
     options.read(true);
     #[cfg(unix)]
@@ -170,10 +171,10 @@ fn read_private_key(path: &Path) -> Result<Vec<u8>> {
         bail!("the private key is not a bounded regular file");
     }
     #[cfg(unix)]
-    if metadata.mode() & 0o077 != 0 || metadata.nlink() != 1 {
+    if metadata.mode() & 0o777 != 0o600 || metadata.nlink() != 1 {
         bail!("the private key must have mode 0600 and exactly one filesystem link");
     }
-    read_open_file(file, metadata.len(), MAX_PRIVATE_KEY_BYTES, "private key")
+    read_open_file(file, metadata.len(), MAX_PRIVATE_KEY_BYTES, "private key").map(Zeroizing::new)
 }
 
 fn read_regular(path: &Path, limit: u64) -> Result<Vec<u8>> {

--- a/crates/oore-catalog/src/bin/oore-catalog-local-signer.rs
+++ b/crates/oore-catalog/src/bin/oore-catalog-local-signer.rs
@@ -1,0 +1,234 @@
+use std::collections::BTreeMap;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, BufRead as _, IsTerminal, Read, Write};
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _, PermissionsExt as _};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow, bail};
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use chrono::Utc;
+use clap::{Parser, Subcommand};
+use oore_catalog::{DetachedSignature, SigningRequest, VerifierKey};
+use ring::rand::SystemRandom;
+use ring::signature::{Ed25519KeyPair, KeyPair as _};
+
+const MAX_REQUEST_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_PRIVATE_KEY_BYTES: u64 = 4 * 1024;
+const MAX_APPROVAL_BYTES: u64 = 256;
+
+#[derive(Debug, Parser)]
+#[command(name = "oore-catalog-local-signer")]
+#[command(about = "Create and use offline Oore catalog signing keys")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Create one Ed25519 key pair without replacing existing files.
+    Generate {
+        /// New PKCS#8 private-key file.
+        #[arg(long)]
+        private_key: PathBuf,
+        /// New canonical public-key JSON file.
+        #[arg(long)]
+        public_key: PathBuf,
+    },
+    /// Review and sign one short-lived catalog request.
+    Sign {
+        /// Canonical signing request.
+        #[arg(long)]
+        request: PathBuf,
+        /// PKCS#8 private-key file.
+        #[arg(long)]
+        private_key: PathBuf,
+        /// New detached signature response.
+        #[arg(long)]
+        output: PathBuf,
+    },
+}
+
+fn main() -> Result<()> {
+    match Cli::parse().command {
+        Command::Generate {
+            private_key,
+            public_key,
+        } => generate(&private_key, &public_key),
+        Command::Sign {
+            request,
+            private_key,
+            output,
+        } => sign(&request, &private_key, &output),
+    }
+}
+
+fn generate(private_key_path: &Path, public_key_path: &Path) -> Result<()> {
+    ensure_absent(private_key_path)?;
+    ensure_absent(public_key_path)?;
+
+    let document = Ed25519KeyPair::generate_pkcs8(&SystemRandom::new())
+        .map_err(|_| anyhow!("cannot generate the Ed25519 private key"))?;
+    let key_pair = Ed25519KeyPair::from_pkcs8(document.as_ref())
+        .map_err(|_| anyhow!("generated private key is invalid"))?;
+    let public_document = public_key_document(key_pair.public_key().as_ref())?;
+    let verifier = VerifierKey::from_bytes(&public_document)?;
+
+    write_new_file(private_key_path, document.as_ref(), 0o600)?;
+    write_new_file(public_key_path, &public_document, 0o644)?;
+
+    println!("Created catalog signer {}.", verifier.key_id());
+    println!("Private key: {}", private_key_path.display());
+    println!("Public key: {}", public_key_path.display());
+    println!(
+        "The private-key file is not password-encrypted. Keep it on an encrypted offline volume."
+    );
+    Ok(())
+}
+
+fn sign(request_path: &Path, private_key_path: &Path, output_path: &Path) -> Result<()> {
+    ensure_absent(output_path)?;
+    let request = SigningRequest::from_bytes(&read_regular(request_path, MAX_REQUEST_BYTES)?)?;
+    let private_key = read_private_key(private_key_path)?;
+    let key_pair = Ed25519KeyPair::from_pkcs8(&private_key)
+        .map_err(|_| anyhow!("the local private key is not valid PKCS#8 Ed25519 data"))?;
+    let public_document = public_key_document(key_pair.public_key().as_ref())?;
+    let verifier = VerifierKey::from_bytes(&public_document)?;
+
+    show_request(&request, &verifier);
+    approve_request(request.payload_sha256())?;
+
+    let signature = key_pair.sign(&request.payload()?);
+    let response =
+        DetachedSignature::record_external(&request, &verifier, signature.as_ref(), Utc::now())?;
+    write_new_file(output_path, &response.to_bytes()?, 0o600)?;
+    println!("Created detached signature: {}", output_path.display());
+    Ok(())
+}
+
+fn show_request(request: &SigningRequest, verifier: &VerifierKey) {
+    let release = request.release();
+    println!("Signer key: {}", verifier.key_id());
+    println!("Role: {}", request.role().as_str());
+    println!("Repository: {}", release.repository());
+    println!("Commit: {}", release.commit());
+    println!("Tag: {}", release.tag());
+    println!("Catalog revision: {}", release.catalog_revision());
+    println!("Payload SHA-256: {}", request.payload_sha256());
+}
+
+fn approve_request(expected_digest: &str) -> Result<()> {
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        bail!("local catalog signing requires an interactive terminal");
+    }
+    print!("Type the full payload SHA-256 to approve this signature: ");
+    io::stdout()
+        .flush()
+        .context("cannot show the approval prompt")?;
+    let mut approval = String::new();
+    io::stdin()
+        .lock()
+        .read_line(&mut approval)
+        .context("cannot read the signing approval")?;
+    if approval.len() as u64 > MAX_APPROVAL_BYTES {
+        bail!("the signing approval is too long");
+    }
+    if approval.trim() != expected_digest {
+        bail!("the typed payload SHA-256 does not match the request");
+    }
+    Ok(())
+}
+
+fn public_key_document(public_key: &[u8]) -> Result<Vec<u8>> {
+    if public_key.len() != 32 {
+        bail!("the Ed25519 public key is not 32 bytes");
+    }
+    let mut document = BTreeMap::new();
+    document.insert("key_type", "ed25519".to_owned());
+    document.insert("public", URL_SAFE_NO_PAD.encode(public_key));
+    document.insert("scheme", "ed25519".to_owned());
+    serde_json::to_vec(&document).context("cannot encode the public-key document")
+}
+
+fn read_private_key(path: &Path) -> Result<Vec<u8>> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    let file = options
+        .open(path)
+        .with_context(|| format!("cannot open private key {}", path.display()))?;
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("cannot inspect private key {}", path.display()))?;
+    if !metadata.file_type().is_file()
+        || metadata.len() == 0
+        || metadata.len() > MAX_PRIVATE_KEY_BYTES
+    {
+        bail!("the private key is not a bounded regular file");
+    }
+    #[cfg(unix)]
+    if metadata.mode() & 0o077 != 0 || metadata.nlink() != 1 {
+        bail!("the private key must have mode 0600 and exactly one filesystem link");
+    }
+    read_open_file(file, metadata.len(), MAX_PRIVATE_KEY_BYTES, "private key")
+}
+
+fn read_regular(path: &Path, limit: u64) -> Result<Vec<u8>> {
+    let file = File::open(path).with_context(|| format!("cannot open {}", path.display()))?;
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("cannot inspect {}", path.display()))?;
+    if !metadata.file_type().is_file() || metadata.len() > limit {
+        bail!("{} is not a bounded regular file", path.display());
+    }
+    read_open_file(file, metadata.len(), limit, "input")
+}
+
+fn read_open_file(mut file: File, length: u64, limit: u64, label: &str) -> Result<Vec<u8>> {
+    let capacity = usize::try_from(length).context("input length does not fit memory")?;
+    let mut bytes = Vec::with_capacity(capacity);
+    Read::by_ref(&mut file)
+        .take(limit + 1)
+        .read_to_end(&mut bytes)
+        .with_context(|| format!("cannot read {label}"))?;
+    if bytes.len() as u64 > limit {
+        bail!("{label} grew beyond its limit");
+    }
+    Ok(bytes)
+}
+
+fn ensure_absent(path: &Path) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => bail!("{} already exists", path.display()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error).with_context(|| format!("cannot inspect {}", path.display())),
+    }
+}
+
+fn write_new_file(path: &Path, bytes: &[u8], mode: u32) -> Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent).with_context(|| format!("cannot create {}", parent.display()))?;
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    options.mode(mode);
+    let mut file = options
+        .open(path)
+        .with_context(|| format!("cannot create {}", path.display()))?;
+    file.write_all(bytes)
+        .with_context(|| format!("cannot write {}", path.display()))?;
+    file.sync_all()
+        .with_context(|| format!("cannot sync {}", path.display()))?;
+    #[cfg(unix)]
+    file.set_permissions(fs::Permissions::from_mode(mode))
+        .with_context(|| format!("cannot protect {}", path.display()))?;
+    File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .with_context(|| format!("cannot sync {}", parent.display()))
+}

--- a/crates/oore-catalog/src/detached.rs
+++ b/crates/oore-catalog/src/detached.rs
@@ -1,0 +1,389 @@
+use std::collections::BTreeSet;
+
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use chrono::{DateTime, Duration, SecondsFormat, Utc};
+use ring::signature::{ED25519, UnparsedPublicKey};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::{
+    CatalogError, MAX_ROOT_BYTES, MAX_SIGNATURES, MAX_SNAPSHOT_BYTES, MAX_TARGETS_BYTES,
+    MAX_TIMESTAMP_BYTES, MetadataSignature, PublicKey, SCHEMA_VERSION, SignedEnvelope,
+    canonical_bytes, canonical_value, decode_base64url, invalid, invalid_error, parse_strict,
+    parse_timestamp, sha256, validate_sha256,
+};
+
+const SIGNING_REQUEST_VALIDITY: Duration = Duration::minutes(15);
+const MAX_SIGNING_REQUEST_BYTES: usize = 12 * 1024 * 1024;
+const MAX_SIGNATURE_RESPONSE_BYTES: usize = 8 * 1024;
+
+/// One metadata role that accepts detached signatures.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SigningRole {
+    /// Root keys and role policy.
+    Root,
+    /// Component membership and revocations.
+    Targets,
+    /// Exact metadata set binding.
+    Snapshot,
+    /// Snapshot freshness binding.
+    Timestamp,
+}
+
+impl SigningRole {
+    fn maximum_payload_bytes(self) -> usize {
+        match self {
+            Self::Root => MAX_ROOT_BYTES,
+            Self::Targets => MAX_TARGETS_BYTES,
+            Self::Snapshot => MAX_SNAPSHOT_BYTES,
+            Self::Timestamp => MAX_TIMESTAMP_BYTES,
+        }
+    }
+}
+
+/// Public release facts attached to one signing request.
+///
+/// These fields support audit records. Signatures still cover the canonical
+/// metadata payload directly.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReleaseBinding {
+    repository: String,
+    commit: String,
+    tag: String,
+    catalog_revision: u64,
+}
+
+impl ReleaseBinding {
+    /// Creates a release binding for one exact Oore source revision.
+    pub fn new(
+        repository: &str,
+        commit: &str,
+        tag: &str,
+        catalog_revision: u64,
+    ) -> Result<Self, CatalogError> {
+        if !matches!(repository, "oore-ci/oore.build" | "oore-ci/components") {
+            return invalid("release binding", "repository is not owned by Oore");
+        }
+        if commit.len() != 40
+            || !commit
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            return invalid("release binding", "commit is not a full lowercase Git SHA");
+        }
+        if tag.is_empty()
+            || tag.len() > 192
+            || !tag.bytes().all(|byte| {
+                byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_' | b'/')
+            })
+            || catalog_revision == 0
+        {
+            return invalid("release binding", "tag or catalog revision is invalid");
+        }
+        Ok(Self {
+            repository: repository.to_owned(),
+            commit: commit.to_owned(),
+            tag: tag.to_owned(),
+            catalog_revision,
+        })
+    }
+
+    fn validate(&self) -> Result<(), CatalogError> {
+        Self::new(
+            &self.repository,
+            &self.commit,
+            &self.tag,
+            self.catalog_revision,
+        )
+        .map(|_| ())
+    }
+}
+
+/// Canonical metadata bytes prepared for an external signer.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SigningRequest {
+    schema_version: u8,
+    role: SigningRole,
+    payload_sha256: String,
+    payload_base64url: String,
+    release: ReleaseBinding,
+    created_at: String,
+    expires: String,
+}
+
+impl SigningRequest {
+    /// Prepares strict canonical JSON for an external signing service.
+    ///
+    /// This function does not claim that the role document is admissible. The
+    /// final four-role verifier remains the only admission boundary.
+    pub fn prepare(
+        role: SigningRole,
+        signed_json: &[u8],
+        release: ReleaseBinding,
+        now: DateTime<Utc>,
+    ) -> Result<Self, CatalogError> {
+        release.validate()?;
+        let value: Value =
+            parse_strict(signed_json, role.maximum_payload_bytes(), "signing payload")?;
+        if !value.is_object() {
+            return invalid("signing payload", "top-level JSON is not an object");
+        }
+        let payload = canonical_value(&value)?;
+        let created_at = now.to_rfc3339_opts(SecondsFormat::Secs, true);
+        let expires_at = now
+            .checked_add_signed(SIGNING_REQUEST_VALIDITY)
+            .ok_or_else(|| invalid_error("signing request", "expiry overflowed"))?;
+        let expires = expires_at.to_rfc3339_opts(SecondsFormat::Secs, true);
+        Ok(Self {
+            schema_version: SCHEMA_VERSION,
+            role,
+            payload_sha256: sha256(&payload),
+            payload_base64url: URL_SAFE_NO_PAD.encode(payload),
+            release,
+            created_at,
+            expires,
+        })
+    }
+
+    /// Parses a saved request with strict bounds.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, CatalogError> {
+        let request: Self = parse_strict(bytes, MAX_SIGNING_REQUEST_BYTES, "signing request")?;
+        request.validate(Utc::now(), false)?;
+        Ok(request)
+    }
+
+    /// Returns canonical request bytes for transport or audit storage.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, CatalogError> {
+        self.validate(Utc::now(), false)?;
+        canonical_bytes(self, "signing request")
+    }
+
+    /// Returns the metadata role.
+    #[must_use]
+    pub const fn role(&self) -> SigningRole {
+        self.role
+    }
+
+    /// Returns the canonical payload digest.
+    #[must_use]
+    pub fn payload_sha256(&self) -> &str {
+        &self.payload_sha256
+    }
+
+    /// Returns the canonical metadata bytes that the signer must sign.
+    pub fn payload(&self) -> Result<Vec<u8>, CatalogError> {
+        self.validate(Utc::now(), false)?;
+        decode_payload(self)
+    }
+
+    fn digest(&self) -> Result<String, CatalogError> {
+        Ok(sha256(&canonical_bytes(self, "signing request")?))
+    }
+
+    fn validate(&self, now: DateTime<Utc>, require_fresh: bool) -> Result<(), CatalogError> {
+        if self.schema_version != SCHEMA_VERSION {
+            return invalid("signing request", "schema version is invalid");
+        }
+        self.release.validate()?;
+        validate_sha256(&self.payload_sha256, "signing payload digest")?;
+        let payload = decode_payload(self)?;
+        if payload.len() > self.role.maximum_payload_bytes()
+            || sha256(&payload) != self.payload_sha256
+        {
+            return invalid("signing request", "payload length or digest is invalid");
+        }
+        let value: Value = parse_strict(
+            &payload,
+            self.role.maximum_payload_bytes(),
+            "signing payload",
+        )?;
+        if canonical_value(&value)? != payload {
+            return invalid("signing request", "payload is not canonical JSON");
+        }
+        let created = parse_timestamp(&self.created_at, "signing request time")?;
+        let expires = parse_timestamp(&self.expires, "signing request time")?;
+        if expires - created != SIGNING_REQUEST_VALIDITY
+            || (require_fresh && (now < created || now >= expires))
+        {
+            return Err(CatalogError::Freshness("signing request"));
+        }
+        Ok(())
+    }
+}
+
+/// An Ed25519 public key accepted from a trusted Root document.
+pub struct VerifierKey {
+    key_id: String,
+    public: Vec<u8>,
+}
+
+impl VerifierKey {
+    /// Parses one canonical public-key object and derives its key ID.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, CatalogError> {
+        let key: PublicKey = parse_strict(bytes, MAX_SIGNATURE_RESPONSE_BYTES, "verifier key")?;
+        if key.key_type != "ed25519" || key.scheme != "ed25519" {
+            return invalid("verifier key", "only Ed25519 is supported");
+        }
+        let canonical = canonical_bytes(&key, "verifier key")?;
+        let public = decode_base64url(&key.public, 32, "verifier key")?;
+        Ok(Self {
+            key_id: sha256(&canonical),
+            public,
+        })
+    }
+
+    /// Returns the derived Root-compatible key ID.
+    #[must_use]
+    pub fn key_id(&self) -> &str {
+        &self.key_id
+    }
+}
+
+/// A detached response produced by an external signer.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DetachedSignature {
+    schema_version: u8,
+    role: SigningRole,
+    request_sha256: String,
+    payload_sha256: String,
+    key_id: String,
+    signature: String,
+    signed_at: String,
+}
+
+impl DetachedSignature {
+    /// Parses a detached signer response.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, CatalogError> {
+        let signature: Self =
+            parse_strict(bytes, MAX_SIGNATURE_RESPONSE_BYTES, "detached signature")?;
+        signature.validate()?;
+        Ok(signature)
+    }
+
+    /// Returns canonical response bytes for audit storage.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, CatalogError> {
+        self.validate()?;
+        canonical_bytes(self, "detached signature")
+    }
+
+    /// Verifies this response against one request and public key.
+    pub fn accept(
+        &self,
+        request: &SigningRequest,
+        key: &VerifierKey,
+        now: DateTime<Utc>,
+    ) -> Result<AcceptedSignature, CatalogError> {
+        self.validate()?;
+        request.validate(now, true)?;
+        if self.role != request.role
+            || self.request_sha256 != request.digest()?
+            || self.payload_sha256 != request.payload_sha256
+            || self.key_id != key.key_id
+        {
+            return invalid("detached signature", "request or key binding differs");
+        }
+        let signed_at = parse_timestamp(&self.signed_at, "signature time")?;
+        let created = parse_timestamp(&request.created_at, "signing request time")?;
+        let expires = parse_timestamp(&request.expires, "signing request time")?;
+        if signed_at < created || signed_at >= expires || signed_at > now {
+            return Err(CatalogError::Freshness("detached signature"));
+        }
+        let signature = decode_base64url(&self.signature, 64, "detached signature")?;
+        let payload = request.payload()?;
+        UnparsedPublicKey::new(&ED25519, &key.public)
+            .verify(&payload, &signature)
+            .map_err(|_| CatalogError::Signature("detached signature"))?;
+        Ok(AcceptedSignature {
+            role: self.role,
+            payload_sha256: self.payload_sha256.clone(),
+            key_id: self.key_id.clone(),
+            signature: self.signature.clone(),
+        })
+    }
+
+    fn validate(&self) -> Result<(), CatalogError> {
+        if self.schema_version != SCHEMA_VERSION {
+            return invalid("detached signature", "schema version is invalid");
+        }
+        validate_sha256(&self.request_sha256, "signing request digest")?;
+        validate_sha256(&self.payload_sha256, "signing payload digest")?;
+        validate_sha256(&self.key_id, "signer key ID")?;
+        decode_base64url(&self.signature, 64, "detached signature")?;
+        parse_timestamp(&self.signed_at, "signature time")?;
+        Ok(())
+    }
+}
+
+/// A verified detached signature bound to one canonical payload.
+pub struct AcceptedSignature {
+    role: SigningRole,
+    payload_sha256: String,
+    key_id: String,
+    signature: String,
+}
+
+/// Assembles canonical signed metadata from verified detached signatures.
+///
+/// The returned envelope remains untrusted until [`crate::CatalogVerifier`]
+/// verifies the complete four-role chain.
+pub fn assemble_envelope(
+    request: &SigningRequest,
+    signatures: &[AcceptedSignature],
+    now: DateTime<Utc>,
+) -> Result<Vec<u8>, CatalogError> {
+    request.validate(now, true)?;
+    if signatures.is_empty() || signatures.len() > MAX_SIGNATURES {
+        return Err(CatalogError::Limit("accepted signatures"));
+    }
+    let mut entries = Vec::with_capacity(signatures.len());
+    let mut key_ids = BTreeSet::new();
+    for signature in signatures {
+        if signature.role != request.role
+            || signature.payload_sha256 != request.payload_sha256
+            || !key_ids.insert(&signature.key_id)
+        {
+            return invalid(
+                "accepted signatures",
+                "role, payload, or key binding differs",
+            );
+        }
+        entries.push(MetadataSignature {
+            key_id: signature.key_id.clone(),
+            signature: signature.signature.clone(),
+        });
+    }
+    entries.sort_by(|left, right| left.key_id.cmp(&right.key_id));
+    let payload = request.payload()?;
+    let signed: Value = parse_strict(
+        &payload,
+        request.role.maximum_payload_bytes(),
+        "signing payload",
+    )?;
+    canonical_bytes(
+        &SignedEnvelope {
+            signed,
+            signatures: entries,
+        },
+        "signed metadata envelope",
+    )
+}
+
+fn decode_payload(request: &SigningRequest) -> Result<Vec<u8>, CatalogError> {
+    let decoded = URL_SAFE_NO_PAD
+        .decode(&request.payload_base64url)
+        .map_err(|error| {
+            invalid_error(
+                "signing request",
+                &format!("payload base64url failed: {error}"),
+            )
+        })?;
+    if URL_SAFE_NO_PAD.encode(&decoded) != request.payload_base64url {
+        return invalid("signing request", "payload base64url is not canonical");
+    }
+    Ok(decoded)
+}

--- a/crates/oore-catalog/src/detached.rs
+++ b/crates/oore-catalog/src/detached.rs
@@ -33,6 +33,17 @@ pub enum SigningRole {
 }
 
 impl SigningRole {
+    /// Returns the canonical role name.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Root => "root",
+            Self::Targets => "targets",
+            Self::Snapshot => "snapshot",
+            Self::Timestamp => "timestamp",
+        }
+    }
+
     fn maximum_payload_bytes(self) -> usize {
         match self {
             Self::Root => MAX_ROOT_BYTES,
@@ -89,6 +100,30 @@ impl ReleaseBinding {
             tag: tag.to_owned(),
             catalog_revision,
         })
+    }
+
+    /// Returns the exact source repository.
+    #[must_use]
+    pub fn repository(&self) -> &str {
+        &self.repository
+    }
+
+    /// Returns the full source commit SHA.
+    #[must_use]
+    pub fn commit(&self) -> &str {
+        &self.commit
+    }
+
+    /// Returns the exact release or source tag.
+    #[must_use]
+    pub fn tag(&self) -> &str {
+        &self.tag
+    }
+
+    /// Returns the catalog revision.
+    #[must_use]
+    pub const fn catalog_revision(&self) -> u64 {
+        self.catalog_revision
     }
 
     fn validate(&self) -> Result<(), CatalogError> {
@@ -174,6 +209,12 @@ impl SigningRequest {
         &self.payload_sha256
     }
 
+    /// Returns the exact release facts bound to this request.
+    #[must_use]
+    pub const fn release(&self) -> &ReleaseBinding {
+        &self.release
+    }
+
     /// Returns the canonical metadata bytes that the signer must sign.
     pub fn payload(&self) -> Result<Vec<u8>, CatalogError> {
         self.validate(Utc::now(), false)?;
@@ -257,6 +298,33 @@ pub struct DetachedSignature {
 }
 
 impl DetachedSignature {
+    /// Records and verifies raw signature bytes returned by an external signer.
+    pub fn record_external(
+        request: &SigningRequest,
+        key: &VerifierKey,
+        signature: &[u8],
+        signed_at: DateTime<Utc>,
+    ) -> Result<Self, CatalogError> {
+        request.validate(signed_at, true)?;
+        if signature.len() != 64 {
+            return invalid("detached signature", "Ed25519 signature is not 64 bytes");
+        }
+        UnparsedPublicKey::new(&ED25519, &key.public)
+            .verify(&request.payload()?, signature)
+            .map_err(|_| CatalogError::Signature("external signer"))?;
+        let response = Self {
+            schema_version: SCHEMA_VERSION,
+            role: request.role,
+            request_sha256: request.digest()?,
+            payload_sha256: request.payload_sha256.clone(),
+            key_id: key.key_id.clone(),
+            signature: URL_SAFE_NO_PAD.encode(signature),
+            signed_at: signed_at.to_rfc3339_opts(SecondsFormat::Secs, true),
+        };
+        response.validate()?;
+        Ok(response)
+    }
+
     /// Parses a detached signer response.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, CatalogError> {
         let signature: Self =

--- a/crates/oore-catalog/src/lib.rs
+++ b/crates/oore-catalog/src/lib.rs
@@ -1,0 +1,1039 @@
+//! Verification for Oore's official signed component metadata.
+//!
+//! This crate verifies the Root, Targets, Snapshot, and Timestamp chain. It
+//! does not download, install, activate, or execute component bytes.
+
+#![deny(missing_docs)]
+#![forbid(unsafe_code)]
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use chrono::{DateTime, Duration, SecondsFormat, Utc};
+use ring::signature::{ED25519, UnparsedPublicKey};
+use serde::de::{self, DeserializeOwned, MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+const SCHEMA_VERSION: u8 = 1;
+const OFFICIAL_REPOSITORY: &str = "oore-official";
+const MAX_ROOT_BYTES: usize = 1024 * 1024;
+const MAX_TARGETS_BYTES: usize = 8 * 1024 * 1024;
+const MAX_SNAPSHOT_BYTES: usize = 2 * 1024 * 1024;
+const MAX_TIMESTAMP_BYTES: usize = 256 * 1024;
+const MAX_STATE_BYTES: usize = 256 * 1024;
+const MAX_COMPONENTS: usize = 2_048;
+const MAX_COMPONENT_RECORD_BYTES: usize = 64 * 1024;
+const MAX_SIGNATURES: usize = 32;
+const MAX_ROOT_ROTATIONS: usize = 32;
+const CLOCK_SKEW: Duration = Duration::minutes(5);
+const ROOT_VALIDITY: Duration = Duration::days(365);
+const TARGETS_VALIDITY: Duration = Duration::days(30);
+const SNAPSHOT_VALIDITY: Duration = Duration::days(30);
+const TIMESTAMP_VALIDITY: Duration = Duration::days(7);
+
+/// Errors returned before any catalog data becomes usable.
+#[derive(Debug, Error)]
+pub enum CatalogError {
+    /// Input exceeded its fixed byte or item limit.
+    #[error("{0} exceeds its fixed catalog limit")]
+    Limit(&'static str),
+    /// JSON was malformed, ambiguous, or outside a closed schema.
+    #[error("invalid {subject}: {detail}")]
+    Invalid {
+        /// The document or field that failed.
+        subject: &'static str,
+        /// A bounded explanation without document contents.
+        detail: String,
+    },
+    /// A required signature was missing or invalid.
+    #[error("{0} signature verification failed")]
+    Signature(&'static str),
+    /// Metadata was expired, future-dated, or outside its role window.
+    #[error("{0} is not fresh")]
+    Freshness(&'static str),
+    /// A lower metadata version was presented.
+    #[error("{0} metadata rollback was detected")]
+    Rollback(&'static str),
+    /// One version appeared with different canonical bytes.
+    #[error("{0} metadata equivocation was detected")]
+    Equivocation(&'static str),
+    /// The local catalog state remains poisoned after equivocation.
+    #[error("the local catalog state is poisoned")]
+    Poisoned,
+}
+
+/// One fetched metadata update.
+#[derive(Clone, Copy, Debug)]
+pub struct CatalogUpdate<'a> {
+    /// Consecutive Root documents after the embedded Root.
+    pub root_rotations: &'a [&'a [u8]],
+    /// The current signed Targets document.
+    pub targets: &'a [u8],
+    /// The current signed Snapshot document.
+    pub snapshot: &'a [u8],
+    /// The current signed Timestamp document.
+    pub timestamp: &'a [u8],
+}
+
+/// Durable version and digest high-water marks.
+///
+/// Fields stay private so callers cannot assemble trusted state in memory.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CatalogState {
+    schema_version: u8,
+    repository: String,
+    root: StateMark,
+    targets: Option<StateMark>,
+    snapshot: Option<StateMark>,
+    timestamp: Option<StateMark>,
+    catalog_sha256: Option<String>,
+    poisoned: bool,
+}
+
+impl CatalogState {
+    /// Parses a saved state with duplicate-key and size checks.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, CatalogError> {
+        let state: Self = parse_strict(bytes, MAX_STATE_BYTES, "catalog state")?;
+        state.validate()?;
+        Ok(state)
+    }
+
+    /// Returns canonical bytes for an owner-protected state file.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, CatalogError> {
+        canonical_bytes(self, "catalog state")
+    }
+
+    /// Reports whether equivocation has poisoned this state.
+    #[must_use]
+    pub const fn is_poisoned(&self) -> bool {
+        self.poisoned
+    }
+
+    /// Returns the highest accepted catalog revision.
+    #[must_use]
+    pub fn catalog_revision(&self) -> Option<u64> {
+        self.targets.as_ref().map(|mark| mark.version)
+    }
+
+    fn validate(&self) -> Result<(), CatalogError> {
+        if self.schema_version != SCHEMA_VERSION || self.repository != OFFICIAL_REPOSITORY {
+            return invalid("catalog state", "identity does not match Oore");
+        }
+        self.root.validate("Root state")?;
+        for (label, mark) in [
+            ("Targets state", self.targets.as_ref()),
+            ("Snapshot state", self.snapshot.as_ref()),
+            ("Timestamp state", self.timestamp.as_ref()),
+        ] {
+            if let Some(mark) = mark {
+                mark.validate(label)?;
+            }
+        }
+        let complete = self.targets.is_some()
+            && self.snapshot.is_some()
+            && self.timestamp.is_some()
+            && self.catalog_sha256.is_some();
+        let empty = self.targets.is_none()
+            && self.snapshot.is_none()
+            && self.timestamp.is_none()
+            && self.catalog_sha256.is_none();
+        if !complete && !empty {
+            return invalid("catalog state", "metadata marks are incomplete");
+        }
+        if let Some(digest) = &self.catalog_sha256 {
+            validate_sha256(digest, "catalog state digest")?;
+        }
+        Ok(())
+    }
+}
+
+/// A verifier rooted in one shell-embedded Root document.
+pub struct CatalogVerifier {
+    pinned_root: RootMetadata,
+    pinned_envelope: Vec<u8>,
+    pinned_digest: String,
+}
+
+impl CatalogVerifier {
+    /// Loads and checks the Root document embedded in an Oore release.
+    ///
+    /// The caller must supply bytes shipped inside the trusted shell package.
+    pub fn from_pinned_root(bytes: &[u8], now: DateTime<Utc>) -> Result<Self, CatalogError> {
+        let (envelope, canonical_envelope) = parse_envelope(bytes, MAX_ROOT_BYTES, "pinned Root")?;
+        let root: RootMetadata = decode_signed(&envelope, "pinned Root")?;
+        let keyring = root.validate(now, "pinned Root")?;
+        keyring.verify(
+            &root.roles.root,
+            &canonical_value(&envelope.signed)?,
+            &envelope.signatures,
+            "pinned Root",
+        )?;
+        Ok(Self {
+            pinned_root: root,
+            pinned_digest: sha256(&canonical_envelope),
+            pinned_envelope: canonical_envelope,
+        })
+    }
+
+    /// Creates the first durable state for this embedded Root.
+    #[must_use]
+    pub fn initial_state(&self) -> CatalogState {
+        CatalogState {
+            schema_version: SCHEMA_VERSION,
+            repository: OFFICIAL_REPOSITORY.to_owned(),
+            root: StateMark {
+                version: self.pinned_root.version,
+                sha256: self.pinned_digest.clone(),
+            },
+            targets: None,
+            snapshot: None,
+            timestamp: None,
+            catalog_sha256: None,
+            poisoned: false,
+        }
+    }
+
+    /// Verifies one complete update and advances the high-water state.
+    ///
+    /// Equivocation poisons `state`. Other failures leave it unchanged.
+    pub fn verify_update(
+        &self,
+        state: &mut CatalogState,
+        update: CatalogUpdate<'_>,
+        now: DateTime<Utc>,
+    ) -> Result<VerifiedMetadataChain, CatalogError> {
+        state.validate()?;
+        if state.poisoned {
+            return Err(CatalogError::Poisoned);
+        }
+        if update.root_rotations.len() > MAX_ROOT_ROTATIONS {
+            return Err(CatalogError::Limit("Root rotation chain"));
+        }
+
+        let mut root = self.pinned_root.clone();
+        let mut root_envelope = self.pinned_envelope.clone();
+        for bytes in update.root_rotations {
+            let (candidate_envelope, candidate_canonical) =
+                parse_envelope(bytes, MAX_ROOT_BYTES, "rotated Root")?;
+            let candidate: RootMetadata = decode_signed(&candidate_envelope, "rotated Root")?;
+            if candidate.version
+                != root
+                    .version
+                    .checked_add(1)
+                    .ok_or_else(|| invalid_error("rotated Root", "version overflowed"))?
+            {
+                return Err(CatalogError::Rollback("Root"));
+            }
+            let old_keys = root.keyring()?;
+            let signed_bytes = canonical_value(&candidate_envelope.signed)?;
+            old_keys.verify(
+                &root.roles.root,
+                &signed_bytes,
+                &candidate_envelope.signatures,
+                "old Root threshold",
+            )?;
+            let new_keys = candidate.validate(now, "rotated Root")?;
+            new_keys.verify(
+                &candidate.roles.root,
+                &signed_bytes,
+                &candidate_envelope.signatures,
+                "new Root threshold",
+            )?;
+            root = candidate;
+            root_envelope = candidate_canonical;
+        }
+
+        let root_mark = StateMark {
+            version: root.version,
+            sha256: sha256(&root_envelope),
+        };
+        let previous_root = state.root.clone();
+        compare_mark(state, "Root", &previous_root, &root_mark)?;
+        let keys = root.keyring()?;
+
+        let (targets_envelope, targets_canonical) =
+            parse_envelope(update.targets, MAX_TARGETS_BYTES, "Targets")?;
+        let targets = CatalogHeader::from_value(&targets_envelope.signed, now)?;
+        keys.verify(
+            &root.roles.targets,
+            &canonical_value(&targets_envelope.signed)?,
+            &targets_envelope.signatures,
+            "Targets",
+        )?;
+        let targets_mark = StateMark {
+            version: targets.catalog_revision,
+            sha256: sha256(&targets_canonical),
+        };
+        if let Some(previous) = state.targets.clone() {
+            compare_mark(state, "Targets", &previous, &targets_mark)?;
+        }
+
+        let (snapshot_envelope, snapshot_canonical) =
+            parse_envelope(update.snapshot, MAX_SNAPSHOT_BYTES, "Snapshot")?;
+        let snapshot: SnapshotMetadata = decode_signed(&snapshot_envelope, "Snapshot")?;
+        snapshot.validate(now)?;
+        snapshot
+            .root
+            .matches(&root_mark, root_envelope.len(), "Root")?;
+        snapshot
+            .targets
+            .matches(&targets_mark, targets_canonical.len(), "Targets")?;
+        keys.verify(
+            &root.roles.snapshot,
+            &canonical_value(&snapshot_envelope.signed)?,
+            &snapshot_envelope.signatures,
+            "Snapshot",
+        )?;
+        let snapshot_mark = StateMark {
+            version: snapshot.version,
+            sha256: sha256(&snapshot_canonical),
+        };
+        if let Some(previous) = state.snapshot.clone() {
+            compare_mark(state, "Snapshot", &previous, &snapshot_mark)?;
+        }
+
+        let (timestamp_envelope, timestamp_canonical) =
+            parse_envelope(update.timestamp, MAX_TIMESTAMP_BYTES, "Timestamp")?;
+        let timestamp: TimestampMetadata = decode_signed(&timestamp_envelope, "Timestamp")?;
+        timestamp.validate(now)?;
+        timestamp
+            .snapshot
+            .matches(&snapshot_mark, snapshot_canonical.len(), "Snapshot")?;
+        keys.verify(
+            &root.roles.timestamp,
+            &canonical_value(&timestamp_envelope.signed)?,
+            &timestamp_envelope.signatures,
+            "Timestamp",
+        )?;
+        let timestamp_mark = StateMark {
+            version: timestamp.version,
+            sha256: sha256(&timestamp_canonical),
+        };
+        if let Some(previous) = state.timestamp.clone() {
+            compare_mark(state, "Timestamp", &previous, &timestamp_mark)?;
+        }
+
+        let next = CatalogState {
+            schema_version: SCHEMA_VERSION,
+            repository: OFFICIAL_REPOSITORY.to_owned(),
+            root: root_mark,
+            targets: Some(targets_mark),
+            snapshot: Some(snapshot_mark),
+            timestamp: Some(timestamp_mark),
+            catalog_sha256: Some(targets.catalog_sha256.clone()),
+            poisoned: false,
+        };
+        next.validate()?;
+        *state = next.clone();
+        Ok(VerifiedMetadataChain {
+            channel: targets.channel,
+            catalog_revision: targets.catalog_revision,
+            component_count: targets.component_count,
+            catalog_sha256: targets.catalog_sha256,
+            state: next,
+        })
+    }
+}
+
+/// Safe facts from a complete verified metadata chain.
+///
+/// Component records remain unavailable until the closed component parser is
+/// added. This prevents partial verification from authorizing execution.
+#[derive(Clone, Debug)]
+pub struct VerifiedMetadataChain {
+    channel: CatalogChannel,
+    catalog_revision: u64,
+    component_count: usize,
+    catalog_sha256: String,
+    state: CatalogState,
+}
+
+impl VerifiedMetadataChain {
+    /// Returns the signed catalog channel.
+    #[must_use]
+    pub const fn channel(&self) -> CatalogChannel {
+        self.channel
+    }
+
+    /// Returns the signed catalog revision.
+    #[must_use]
+    pub const fn catalog_revision(&self) -> u64 {
+        self.catalog_revision
+    }
+
+    /// Returns the bounded number of component records.
+    #[must_use]
+    pub const fn component_count(&self) -> usize {
+        self.component_count
+    }
+
+    /// Returns the SHA-256 of the canonical signed catalog object.
+    #[must_use]
+    pub fn catalog_sha256(&self) -> &str {
+        &self.catalog_sha256
+    }
+
+    /// Returns the next durable high-water state.
+    #[must_use]
+    pub fn state(&self) -> &CatalogState {
+        &self.state
+    }
+}
+
+/// Official catalog channels.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CatalogChannel {
+    /// Early product releases.
+    Alpha,
+    /// Feature-complete preview releases.
+    Beta,
+    /// Production releases.
+    Stable,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct SignedEnvelope {
+    signed: Value,
+    signatures: Vec<MetadataSignature>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct MetadataSignature {
+    key_id: String,
+    signature: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct RootMetadata {
+    schema_version: u8,
+    repository: String,
+    version: u64,
+    generated_at: String,
+    expires: String,
+    consistent_snapshot: bool,
+    keys: Vec<TrustedKey>,
+    roles: TrustRoles,
+}
+
+impl RootMetadata {
+    fn validate(&self, now: DateTime<Utc>, label: &'static str) -> Result<Keyring, CatalogError> {
+        if self.schema_version != SCHEMA_VERSION
+            || self.repository != OFFICIAL_REPOSITORY
+            || self.version == 0
+            || !self.consistent_snapshot
+        {
+            return invalid(label, "identity or consistent-snapshot policy is invalid");
+        }
+        validate_window(&self.generated_at, &self.expires, ROOT_VALIDITY, now, label)?;
+        self.keyring()
+    }
+
+    fn keyring(&self) -> Result<Keyring, CatalogError> {
+        if self.keys.is_empty() || self.keys.len() > MAX_SIGNATURES {
+            return Err(CatalogError::Limit("Root keys"));
+        }
+        if !is_sorted_unique_by(&self.keys, |key| &key.key_id) {
+            return invalid("Root", "keys are not sorted and unique");
+        }
+        let mut keys = BTreeMap::new();
+        for key in &self.keys {
+            let public = key.validate()?;
+            keys.insert(key.key_id.clone(), public);
+        }
+        self.roles.validate(&keys)?;
+        Ok(Keyring { keys })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct TrustedKey {
+    key_id: String,
+    key: PublicKey,
+}
+
+impl TrustedKey {
+    fn validate(&self) -> Result<Vec<u8>, CatalogError> {
+        validate_sha256(&self.key_id, "Root key ID")?;
+        if self.key.key_type != "ed25519" || self.key.scheme != "ed25519" {
+            return invalid("Root key", "only Ed25519 is supported");
+        }
+        let public = decode_base64url(&self.key.public, 32, "Root public key")?;
+        let digest = sha256(&canonical_bytes(&self.key, "Root public key")?);
+        if digest != self.key_id {
+            return invalid("Root key", "key ID does not match the canonical key");
+        }
+        Ok(public)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct PublicKey {
+    key_type: String,
+    scheme: String,
+    public: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct TrustRoles {
+    root: ThresholdRole,
+    targets: ThresholdRole,
+    snapshot: ThresholdRole,
+    timestamp: ThresholdRole,
+}
+
+impl TrustRoles {
+    fn validate(&self, keys: &BTreeMap<String, Vec<u8>>) -> Result<(), CatalogError> {
+        for (label, role, threshold, count) in [
+            ("Root", &self.root, 2, 3),
+            ("Targets", &self.targets, 2, 3),
+            ("Snapshot", &self.snapshot, 1, 2),
+            ("Timestamp", &self.timestamp, 1, 2),
+        ] {
+            role.validate(keys, threshold, count, label)?;
+        }
+        let members = self
+            .root
+            .key_ids
+            .iter()
+            .chain(&self.targets.key_ids)
+            .chain(&self.snapshot.key_ids)
+            .chain(&self.timestamp.key_ids)
+            .collect::<Vec<_>>();
+        if members.iter().copied().collect::<BTreeSet<_>>().len() != members.len()
+            || members.len() != keys.len()
+        {
+            return invalid(
+                "Root roles",
+                "role keys must be disjoint and fully assigned",
+            );
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct ThresholdRole {
+    threshold: u8,
+    key_ids: Vec<String>,
+}
+
+impl ThresholdRole {
+    fn validate(
+        &self,
+        keys: &BTreeMap<String, Vec<u8>>,
+        threshold: u8,
+        count: usize,
+        label: &'static str,
+    ) -> Result<(), CatalogError> {
+        if self.threshold != threshold
+            || self.key_ids.len() != count
+            || !is_sorted_unique_by(&self.key_ids, |key| key)
+            || self.key_ids.iter().any(|key| !keys.contains_key(key))
+        {
+            return invalid(label, "threshold role is invalid");
+        }
+        Ok(())
+    }
+}
+
+struct Keyring {
+    keys: BTreeMap<String, Vec<u8>>,
+}
+
+impl Keyring {
+    fn verify(
+        &self,
+        role: &ThresholdRole,
+        signed: &[u8],
+        signatures: &[MetadataSignature],
+        label: &'static str,
+    ) -> Result<(), CatalogError> {
+        if signatures.is_empty()
+            || signatures.len() > MAX_SIGNATURES
+            || !is_sorted_unique_by(signatures, |signature| &signature.key_id)
+        {
+            return invalid(label, "signatures are not sorted, unique, and bounded");
+        }
+        let allowed = role.key_ids.iter().collect::<BTreeSet<_>>();
+        let mut valid = 0usize;
+        for signature in signatures {
+            if !allowed.contains(&signature.key_id) {
+                continue;
+            }
+            let key = self
+                .keys
+                .get(&signature.key_id)
+                .ok_or(CatalogError::Signature(label))?;
+            let bytes = decode_base64url(&signature.signature, 64, label)?;
+            UnparsedPublicKey::new(&ED25519, key)
+                .verify(signed, &bytes)
+                .map_err(|_| CatalogError::Signature(label))?;
+            valid += 1;
+        }
+        if valid < usize::from(role.threshold) {
+            return Err(CatalogError::Signature(label));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+struct CatalogHeader {
+    channel: CatalogChannel,
+    catalog_revision: u64,
+    component_count: usize,
+    catalog_sha256: String,
+}
+
+impl CatalogHeader {
+    fn from_value(value: &Value, now: DateTime<Utc>) -> Result<Self, CatalogError> {
+        let object = value
+            .as_object()
+            .ok_or_else(|| invalid_error("Targets", "signed value is not an object"))?;
+        require_exact_keys(
+            object,
+            &[
+                "catalog_id",
+                "catalog_revision",
+                "channel",
+                "components",
+                "expires",
+                "generated_at",
+                "policy",
+                "revocations",
+                "schema_version",
+            ],
+            "Targets",
+        )?;
+        let schema = get_u64(object, "schema_version", "Targets")?;
+        let revision = get_u64(object, "catalog_revision", "Targets")?;
+        if schema != u64::from(SCHEMA_VERSION) || revision == 0 {
+            return invalid("Targets", "schema or catalog revision is invalid");
+        }
+        if get_str(object, "catalog_id", "Targets")? != OFFICIAL_REPOSITORY {
+            return invalid("Targets", "catalog ID is not official");
+        }
+        let channel: CatalogChannel = serde_json::from_value(
+            object
+                .get("channel")
+                .cloned()
+                .ok_or_else(|| invalid_error("Targets", "channel is missing"))?,
+        )
+        .map_err(|error| invalid_error("Targets", &format!("channel is invalid: {error}")))?;
+        validate_window(
+            get_str(object, "generated_at", "Targets")?,
+            get_str(object, "expires", "Targets")?,
+            TARGETS_VALIDITY,
+            now,
+            "Targets",
+        )?;
+        let components = object
+            .get("components")
+            .and_then(Value::as_array)
+            .ok_or_else(|| invalid_error("Targets", "components is not an array"))?;
+        if components.len() > MAX_COMPONENTS {
+            return Err(CatalogError::Limit("Targets components"));
+        }
+        for component in components {
+            if canonical_value(component)?.len() > MAX_COMPONENT_RECORD_BYTES {
+                return Err(CatalogError::Limit("component record"));
+            }
+        }
+        if !object.get("revocations").is_some_and(Value::is_array)
+            || !object.get("policy").is_some_and(Value::is_object)
+        {
+            return invalid("Targets", "revocations or policy has the wrong type");
+        }
+        Ok(Self {
+            channel,
+            catalog_revision: revision,
+            component_count: components.len(),
+            catalog_sha256: sha256(&canonical_value(value)?),
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SnapshotMetadata {
+    schema_version: u8,
+    repository: String,
+    version: u64,
+    generated_at: String,
+    expires: String,
+    root: MetadataDescription,
+    targets: MetadataDescription,
+}
+
+impl SnapshotMetadata {
+    fn validate(&self, now: DateTime<Utc>) -> Result<(), CatalogError> {
+        if self.schema_version != SCHEMA_VERSION
+            || self.repository != OFFICIAL_REPOSITORY
+            || self.version == 0
+        {
+            return invalid("Snapshot", "identity or version is invalid");
+        }
+        validate_window(
+            &self.generated_at,
+            &self.expires,
+            SNAPSHOT_VALIDITY,
+            now,
+            "Snapshot",
+        )
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TimestampMetadata {
+    schema_version: u8,
+    repository: String,
+    version: u64,
+    generated_at: String,
+    expires: String,
+    snapshot: MetadataDescription,
+}
+
+impl TimestampMetadata {
+    fn validate(&self, now: DateTime<Utc>) -> Result<(), CatalogError> {
+        if self.schema_version != SCHEMA_VERSION
+            || self.repository != OFFICIAL_REPOSITORY
+            || self.version == 0
+        {
+            return invalid("Timestamp", "identity or version is invalid");
+        }
+        validate_window(
+            &self.generated_at,
+            &self.expires,
+            TIMESTAMP_VALIDITY,
+            now,
+            "Timestamp",
+        )
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MetadataDescription {
+    version: u64,
+    length: u64,
+    sha256: String,
+}
+
+impl MetadataDescription {
+    fn matches(
+        &self,
+        mark: &StateMark,
+        length: usize,
+        label: &'static str,
+    ) -> Result<(), CatalogError> {
+        validate_sha256(&self.sha256, label)?;
+        let expected_length = u64::try_from(length).map_err(|_| CatalogError::Limit(label))?;
+        if self.version != mark.version
+            || self.length != expected_length
+            || self.sha256 != mark.sha256
+        {
+            return invalid(label, "metadata description does not match exact bytes");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct StateMark {
+    version: u64,
+    sha256: String,
+}
+
+impl StateMark {
+    fn validate(&self, label: &'static str) -> Result<(), CatalogError> {
+        if self.version == 0 {
+            return invalid(label, "version is zero");
+        }
+        validate_sha256(&self.sha256, label)
+    }
+}
+
+fn compare_mark(
+    state: &mut CatalogState,
+    label: &'static str,
+    previous: &StateMark,
+    candidate: &StateMark,
+) -> Result<(), CatalogError> {
+    if candidate.version < previous.version {
+        return Err(CatalogError::Rollback(label));
+    }
+    if candidate.version == previous.version && candidate.sha256 != previous.sha256 {
+        state.poisoned = true;
+        return Err(CatalogError::Equivocation(label));
+    }
+    Ok(())
+}
+
+fn validate_window(
+    generated_at: &str,
+    expires: &str,
+    maximum: Duration,
+    now: DateTime<Utc>,
+    label: &'static str,
+) -> Result<(), CatalogError> {
+    let generated = parse_timestamp(generated_at, label)?;
+    let expiry = parse_timestamp(expires, label)?;
+    if expiry <= generated
+        || expiry - generated > maximum
+        || now + CLOCK_SKEW < generated
+        || now >= expiry
+    {
+        return Err(CatalogError::Freshness(label));
+    }
+    Ok(())
+}
+
+fn parse_timestamp(value: &str, label: &'static str) -> Result<DateTime<Utc>, CatalogError> {
+    let parsed = DateTime::parse_from_rfc3339(value)
+        .map_err(|error| invalid_error(label, &format!("timestamp is invalid: {error}")))?
+        .with_timezone(&Utc);
+    if parsed.to_rfc3339_opts(SecondsFormat::Secs, true) != value {
+        return invalid(label, "timestamp is not UTC second-precision RFC 3339");
+    }
+    Ok(parsed)
+}
+
+fn parse_envelope(
+    bytes: &[u8],
+    maximum: usize,
+    label: &'static str,
+) -> Result<(SignedEnvelope, Vec<u8>), CatalogError> {
+    let envelope: SignedEnvelope = parse_strict(bytes, maximum, label)?;
+    let canonical = canonical_bytes(&envelope, label)?;
+    Ok((envelope, canonical))
+}
+
+fn decode_signed<T: DeserializeOwned>(
+    envelope: &SignedEnvelope,
+    label: &'static str,
+) -> Result<T, CatalogError> {
+    serde_json::from_value(envelope.signed.clone())
+        .map_err(|error| invalid_error(label, &format!("closed signed schema failed: {error}")))
+}
+
+fn parse_strict<T: DeserializeOwned>(
+    bytes: &[u8],
+    maximum: usize,
+    label: &'static str,
+) -> Result<T, CatalogError> {
+    if bytes.len() > maximum {
+        return Err(CatalogError::Limit(label));
+    }
+    let mut deserializer = serde_json::Deserializer::from_slice(bytes);
+    let value = deserializer
+        .deserialize_any(StrictValueVisitor)
+        .map_err(|error| invalid_error(label, &format!("JSON failed: {error}")))?;
+    deserializer
+        .end()
+        .map_err(|error| invalid_error(label, &format!("trailing JSON failed: {error}")))?;
+    serde_json::from_value(value)
+        .map_err(|error| invalid_error(label, &format!("closed schema failed: {error}")))
+}
+
+fn canonical_bytes<T: Serialize>(value: &T, label: &'static str) -> Result<Vec<u8>, CatalogError> {
+    let value = serde_json::to_value(value)
+        .map_err(|error| invalid_error(label, &format!("encoding failed: {error}")))?;
+    canonical_value(&value)
+}
+
+fn canonical_value(value: &Value) -> Result<Vec<u8>, CatalogError> {
+    serde_json::to_vec(&canonicalize(value.clone()))
+        .map_err(|error| invalid_error("canonical JSON", &format!("encoding failed: {error}")))
+}
+
+fn canonicalize(value: Value) -> Value {
+    match value {
+        Value::Array(values) => Value::Array(values.into_iter().map(canonicalize).collect()),
+        Value::Object(object) => {
+            let mut entries = object.into_iter().collect::<Vec<_>>();
+            entries.sort_by(|left, right| left.0.cmp(&right.0));
+            let mut canonical = Map::new();
+            for (key, value) in entries {
+                canonical.insert(key, canonicalize(value));
+            }
+            Value::Object(canonical)
+        }
+        other => other,
+    }
+}
+
+fn decode_base64url(
+    value: &str,
+    expected: usize,
+    label: &'static str,
+) -> Result<Vec<u8>, CatalogError> {
+    let decoded = URL_SAFE_NO_PAD
+        .decode(value)
+        .map_err(|_| CatalogError::Signature(label))?;
+    if decoded.len() != expected || URL_SAFE_NO_PAD.encode(&decoded) != value {
+        return invalid(
+            label,
+            "base64url value is not canonical or has the wrong length",
+        );
+    }
+    Ok(decoded)
+}
+
+fn validate_sha256(value: &str, label: &'static str) -> Result<(), CatalogError> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return invalid(label, "SHA-256 is not canonical lowercase hexadecimal");
+    }
+    Ok(())
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+fn require_exact_keys(
+    object: &Map<String, Value>,
+    expected: &[&str],
+    label: &'static str,
+) -> Result<(), CatalogError> {
+    let actual = object.keys().map(String::as_str).collect::<BTreeSet<_>>();
+    let expected = expected.iter().copied().collect::<BTreeSet<_>>();
+    if actual != expected {
+        return invalid(label, "top-level fields do not match the closed schema");
+    }
+    Ok(())
+}
+
+fn get_str<'a>(
+    object: &'a Map<String, Value>,
+    key: &str,
+    label: &'static str,
+) -> Result<&'a str, CatalogError> {
+    object
+        .get(key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| invalid_error(label, &format!("{key} is not a string")))
+}
+
+fn get_u64(
+    object: &Map<String, Value>,
+    key: &str,
+    label: &'static str,
+) -> Result<u64, CatalogError> {
+    object
+        .get(key)
+        .and_then(Value::as_u64)
+        .ok_or_else(|| invalid_error(label, &format!("{key} is not an unsigned integer")))
+}
+
+fn is_sorted_unique_by<T, K: Ord + ?Sized>(values: &[T], key: impl Fn(&T) -> &K) -> bool {
+    values.windows(2).all(|pair| key(&pair[0]) < key(&pair[1]))
+}
+
+fn invalid<T>(subject: &'static str, detail: &str) -> Result<T, CatalogError> {
+    Err(invalid_error(subject, detail))
+}
+
+fn invalid_error(subject: &'static str, detail: &str) -> CatalogError {
+    CatalogError::Invalid {
+        subject,
+        detail: detail.to_owned(),
+    }
+}
+
+struct StrictValueVisitor;
+
+impl<'de> Visitor<'de> for StrictValueVisitor {
+    type Value = Value;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("JSON without duplicate keys or floating-point numbers")
+    }
+
+    fn visit_bool<E: de::Error>(self, value: bool) -> Result<Self::Value, E> {
+        Ok(Value::Bool(value))
+    }
+
+    fn visit_i64<E: de::Error>(self, value: i64) -> Result<Self::Value, E> {
+        if value < 0 {
+            return Err(E::custom("negative integers are not allowed"));
+        }
+        Ok(Value::Number(value.into()))
+    }
+
+    fn visit_u64<E: de::Error>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(Value::Number(value.into()))
+    }
+
+    fn visit_f64<E: de::Error>(self, _value: f64) -> Result<Self::Value, E> {
+        Err(E::custom("floating-point numbers are not allowed"))
+    }
+
+    fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+        Ok(Value::String(value.to_owned()))
+    }
+
+    fn visit_string<E: de::Error>(self, value: String) -> Result<Self::Value, E> {
+        Ok(Value::String(value))
+    }
+
+    fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
+        Ok(Value::Null)
+    }
+
+    fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+        Ok(Value::Null)
+    }
+
+    fn visit_some<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+        deserializer.deserialize_any(Self)
+    }
+
+    fn visit_seq<A: SeqAccess<'de>>(self, mut sequence: A) -> Result<Self::Value, A::Error> {
+        let mut values = Vec::new();
+        while let Some(value) = sequence.next_element_seed(StrictValueSeed)? {
+            values.push(value);
+        }
+        Ok(Value::Array(values))
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+        let mut object = Map::new();
+        while let Some(key) = map.next_key::<String>()? {
+            if object.contains_key(&key) {
+                return Err(de::Error::custom("duplicate JSON object key"));
+            }
+            let value = map.next_value_seed(StrictValueSeed)?;
+            object.insert(key, value);
+        }
+        Ok(Value::Object(object))
+    }
+}
+
+struct StrictValueSeed;
+
+impl<'de> de::DeserializeSeed<'de> for StrictValueSeed {
+    type Value = Value;
+
+    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Value, D::Error> {
+        deserializer.deserialize_any(StrictValueVisitor)
+    }
+}

--- a/crates/oore-catalog/src/lib.rs
+++ b/crates/oore-catalog/src/lib.rs
@@ -18,7 +18,13 @@ use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
+mod detached;
 mod records;
+
+pub use detached::{
+    AcceptedSignature, DetachedSignature, ReleaseBinding, SigningRequest, SigningRole, VerifierKey,
+    assemble_envelope,
+};
 
 const SCHEMA_VERSION: u8 = 1;
 const OFFICIAL_REPOSITORY: &str = "oore-official";

--- a/crates/oore-catalog/src/lib.rs
+++ b/crates/oore-catalog/src/lib.rs
@@ -18,6 +18,8 @@ use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
+mod records;
+
 const SCHEMA_VERSION: u8 = 1;
 const OFFICIAL_REPOSITORY: &str = "oore-official";
 const MAX_ROOT_BYTES: usize = 1024 * 1024;
@@ -258,7 +260,8 @@ impl CatalogVerifier {
 
         let (targets_envelope, targets_canonical) =
             parse_envelope(update.targets, MAX_TARGETS_BYTES, "Targets")?;
-        let targets = CatalogHeader::from_value(&targets_envelope.signed, now)?;
+        let targets =
+            records::CatalogDocument::from_value(&targets_envelope.signed, now, &keys.keys)?;
         keys.verify(
             &root.roles.targets,
             &canonical_value(&targets_envelope.signed)?,
@@ -590,82 +593,6 @@ impl Keyring {
     }
 }
 
-#[derive(Clone, Debug)]
-struct CatalogHeader {
-    channel: CatalogChannel,
-    catalog_revision: u64,
-    component_count: usize,
-    catalog_sha256: String,
-}
-
-impl CatalogHeader {
-    fn from_value(value: &Value, now: DateTime<Utc>) -> Result<Self, CatalogError> {
-        let object = value
-            .as_object()
-            .ok_or_else(|| invalid_error("Targets", "signed value is not an object"))?;
-        require_exact_keys(
-            object,
-            &[
-                "catalog_id",
-                "catalog_revision",
-                "channel",
-                "components",
-                "expires",
-                "generated_at",
-                "policy",
-                "revocations",
-                "schema_version",
-            ],
-            "Targets",
-        )?;
-        let schema = get_u64(object, "schema_version", "Targets")?;
-        let revision = get_u64(object, "catalog_revision", "Targets")?;
-        if schema != u64::from(SCHEMA_VERSION) || revision == 0 {
-            return invalid("Targets", "schema or catalog revision is invalid");
-        }
-        if get_str(object, "catalog_id", "Targets")? != OFFICIAL_REPOSITORY {
-            return invalid("Targets", "catalog ID is not official");
-        }
-        let channel: CatalogChannel = serde_json::from_value(
-            object
-                .get("channel")
-                .cloned()
-                .ok_or_else(|| invalid_error("Targets", "channel is missing"))?,
-        )
-        .map_err(|error| invalid_error("Targets", &format!("channel is invalid: {error}")))?;
-        validate_window(
-            get_str(object, "generated_at", "Targets")?,
-            get_str(object, "expires", "Targets")?,
-            TARGETS_VALIDITY,
-            now,
-            "Targets",
-        )?;
-        let components = object
-            .get("components")
-            .and_then(Value::as_array)
-            .ok_or_else(|| invalid_error("Targets", "components is not an array"))?;
-        if components.len() > MAX_COMPONENTS {
-            return Err(CatalogError::Limit("Targets components"));
-        }
-        for component in components {
-            if canonical_value(component)?.len() > MAX_COMPONENT_RECORD_BYTES {
-                return Err(CatalogError::Limit("component record"));
-            }
-        }
-        if !object.get("revocations").is_some_and(Value::is_array)
-            || !object.get("policy").is_some_and(Value::is_object)
-        {
-            return invalid("Targets", "revocations or policy has the wrong type");
-        }
-        Ok(Self {
-            channel,
-            catalog_revision: revision,
-            component_count: components.len(),
-            catalog_sha256: sha256(&canonical_value(value)?),
-        })
-    }
-}
-
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct SnapshotMetadata {
@@ -907,41 +834,6 @@ fn validate_sha256(value: &str, label: &'static str) -> Result<(), CatalogError>
 
 fn sha256(bytes: &[u8]) -> String {
     format!("{:x}", Sha256::digest(bytes))
-}
-
-fn require_exact_keys(
-    object: &Map<String, Value>,
-    expected: &[&str],
-    label: &'static str,
-) -> Result<(), CatalogError> {
-    let actual = object.keys().map(String::as_str).collect::<BTreeSet<_>>();
-    let expected = expected.iter().copied().collect::<BTreeSet<_>>();
-    if actual != expected {
-        return invalid(label, "top-level fields do not match the closed schema");
-    }
-    Ok(())
-}
-
-fn get_str<'a>(
-    object: &'a Map<String, Value>,
-    key: &str,
-    label: &'static str,
-) -> Result<&'a str, CatalogError> {
-    object
-        .get(key)
-        .and_then(Value::as_str)
-        .ok_or_else(|| invalid_error(label, &format!("{key} is not a string")))
-}
-
-fn get_u64(
-    object: &Map<String, Value>,
-    key: &str,
-    label: &'static str,
-) -> Result<u64, CatalogError> {
-    object
-        .get(key)
-        .and_then(Value::as_u64)
-        .ok_or_else(|| invalid_error(label, &format!("{key} is not an unsigned integer")))
 }
 
 fn is_sorted_unique_by<T, K: Ord + ?Sized>(values: &[T], key: impl Fn(&T) -> &K) -> bool {

--- a/crates/oore-catalog/src/lib.rs
+++ b/crates/oore-catalog/src/lib.rs
@@ -18,9 +18,14 @@ use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
+mod authoring;
 mod detached;
 mod records;
 
+pub use authoring::{
+    build_root_payload, build_snapshot_payload, build_targets_payload, build_timestamp_payload,
+    import_component_release,
+};
 pub use detached::{
     AcceptedSignature, DetachedSignature, ReleaseBinding, SigningRequest, SigningRole, VerifierKey,
     assemble_envelope,
@@ -343,8 +348,9 @@ impl CatalogVerifier {
             channel: targets.channel,
             catalog_revision: targets.catalog_revision,
             component_count: targets.component_count,
-            catalog_sha256: targets.catalog_sha256,
+            catalog_sha256: targets.catalog_sha256.clone(),
             state: next,
+            catalog: targets,
         })
     }
 }
@@ -360,6 +366,7 @@ pub struct VerifiedMetadataChain {
     component_count: usize,
     catalog_sha256: String,
     state: CatalogState,
+    catalog: records::CatalogDocument,
 }
 
 impl VerifiedMetadataChain {
@@ -391,6 +398,140 @@ impl VerifiedMetadataChain {
     #[must_use]
     pub fn state(&self) -> &CatalogState {
         &self.state
+    }
+
+    /// Selects one active component for an exact host pair.
+    pub fn component_for_host(
+        &self,
+        component_id: &str,
+        os: &str,
+        arch: &str,
+    ) -> Result<Option<VerifiedComponent>, CatalogError> {
+        self.catalog.select_component(component_id, os, arch)
+    }
+}
+
+/// One component selected from a complete verified metadata chain.
+#[derive(Clone, Debug)]
+pub struct VerifiedComponent {
+    component_id: String,
+    component_version: String,
+    os: String,
+    arch: String,
+    minimum_os_version: Option<String>,
+    entrypoint: String,
+    archive_length: u64,
+    archive_sha256: String,
+    archive_path: String,
+    expanded_bytes: u64,
+    file_count: u64,
+    manifest_length: u64,
+    manifest_sha256: String,
+    files: Vec<VerifiedFile>,
+}
+
+impl VerifiedComponent {
+    /// Returns the component ID.
+    #[must_use]
+    pub fn component_id(&self) -> &str {
+        &self.component_id
+    }
+    /// Returns the component version.
+    #[must_use]
+    pub fn component_version(&self) -> &str {
+        &self.component_version
+    }
+    /// Returns the target operating system.
+    #[must_use]
+    pub fn os(&self) -> &str {
+        &self.os
+    }
+    /// Returns the target architecture.
+    #[must_use]
+    pub fn arch(&self) -> &str {
+        &self.arch
+    }
+    /// Returns the minimum operating-system version, when present.
+    #[must_use]
+    pub fn minimum_os_version(&self) -> Option<&str> {
+        self.minimum_os_version.as_deref()
+    }
+    /// Returns the relative executable path.
+    #[must_use]
+    pub fn entrypoint(&self) -> &str {
+        &self.entrypoint
+    }
+    /// Returns the compressed archive byte length.
+    #[must_use]
+    pub const fn archive_length(&self) -> u64 {
+        self.archive_length
+    }
+    /// Returns the compressed archive SHA-256.
+    #[must_use]
+    pub fn archive_sha256(&self) -> &str {
+        &self.archive_sha256
+    }
+    /// Returns the digest-qualified archive path.
+    #[must_use]
+    pub fn archive_path(&self) -> &str {
+        &self.archive_path
+    }
+    /// Returns the exact expanded byte count.
+    #[must_use]
+    pub const fn expanded_bytes(&self) -> u64 {
+        self.expanded_bytes
+    }
+    /// Returns the exact archive file count.
+    #[must_use]
+    pub const fn file_count(&self) -> u64 {
+        self.file_count
+    }
+    /// Returns the exact embedded-manifest byte length.
+    #[must_use]
+    pub const fn manifest_length(&self) -> u64 {
+        self.manifest_length
+    }
+    /// Returns the exact embedded-manifest SHA-256.
+    #[must_use]
+    pub fn manifest_sha256(&self) -> &str {
+        &self.manifest_sha256
+    }
+    /// Returns the exact non-manifest file inventory.
+    #[must_use]
+    pub fn files(&self) -> &[VerifiedFile] {
+        &self.files
+    }
+}
+
+/// One verified regular file in a component archive.
+#[derive(Clone, Debug)]
+pub struct VerifiedFile {
+    path: String,
+    mode: u32,
+    length: u64,
+    sha256: String,
+}
+
+impl VerifiedFile {
+    /// Returns the relative file path.
+    #[must_use]
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+    /// Returns the Unix permission bits.
+    #[must_use]
+    pub const fn mode(&self) -> u32 {
+        self.mode
+    }
+    /// Returns the exact file byte length.
+    #[must_use]
+    pub const fn length(&self) -> u64 {
+        self.length
+    }
+    /// Returns the exact file SHA-256.
+    #[must_use]
+    pub fn sha256(&self) -> &str {
+        &self.sha256
     }
 }
 
@@ -599,7 +740,7 @@ impl Keyring {
     }
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 struct SnapshotMetadata {
     schema_version: u8,
@@ -629,7 +770,7 @@ impl SnapshotMetadata {
     }
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 struct TimestampMetadata {
     schema_version: u8,
@@ -658,7 +799,7 @@ impl TimestampMetadata {
     }
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 struct MetadataDescription {
     version: u64,

--- a/crates/oore-catalog/src/records.rs
+++ b/crates/oore-catalog/src/records.rs
@@ -1,0 +1,937 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use chrono::{DateTime, Utc};
+use semver::Version;
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::{
+    CatalogChannel, CatalogError, MAX_COMPONENT_RECORD_BYTES, MAX_COMPONENTS, OFFICIAL_REPOSITORY,
+    SCHEMA_VERSION, TARGETS_VALIDITY, canonical_value, invalid, invalid_error, parse_timestamp,
+    sha256, validate_sha256, validate_window,
+};
+
+const MAX_BUNDLE_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+const MAX_EXPANDED_BYTES: u64 = 8 * 1024 * 1024 * 1024;
+const MAX_FILE_COUNT: u64 = 100_000;
+const MAX_PATH_BYTES: usize = 256;
+const MAX_CLOSURE_NODES: usize = 128;
+const MAX_CLOSURE_EDGES: usize = 256;
+const MAX_DIRECT_DEPENDENCIES: usize = 64;
+const MAX_CAPABILITIES: usize = 128;
+const MAX_NETWORK_HOSTS: usize = 16;
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct CatalogDocument {
+    schema_version: u8,
+    catalog_id: String,
+    pub(super) channel: CatalogChannel,
+    pub(super) catalog_revision: u64,
+    generated_at: String,
+    expires: String,
+    components: Vec<ComponentRecord>,
+    revocations: Vec<Revocation>,
+    policy: CatalogPolicy,
+    #[serde(skip)]
+    pub(super) component_count: usize,
+    #[serde(skip)]
+    pub(super) catalog_sha256: String,
+}
+
+impl CatalogDocument {
+    pub(super) fn from_value(
+        value: &Value,
+        now: DateTime<Utc>,
+        root_keys: &BTreeMap<String, Vec<u8>>,
+    ) -> Result<Self, CatalogError> {
+        let mut catalog: Self = serde_json::from_value(value.clone()).map_err(|error| {
+            invalid_error("Targets", &format!("closed catalog failed: {error}"))
+        })?;
+        if catalog.schema_version != SCHEMA_VERSION
+            || catalog.catalog_id != OFFICIAL_REPOSITORY
+            || catalog.catalog_revision == 0
+        {
+            return invalid("Targets", "catalog identity or revision is invalid");
+        }
+        validate_window(
+            &catalog.generated_at,
+            &catalog.expires,
+            TARGETS_VALIDITY,
+            now,
+            "Targets",
+        )?;
+        catalog.policy.validate()?;
+        if catalog.components.len() > MAX_COMPONENTS {
+            return Err(CatalogError::Limit("Targets components"));
+        }
+        for component in &catalog.components {
+            if canonical_value(
+                &serde_json::to_value(component)
+                    .map_err(|error| invalid_error("component", &error.to_string()))?,
+            )?
+            .len()
+                > MAX_COMPONENT_RECORD_BYTES
+            {
+                return Err(CatalogError::Limit("component record"));
+            }
+            component.validate(catalog.catalog_revision)?;
+        }
+        if catalog
+            .components
+            .windows(2)
+            .any(|pair| pair[0].identity_key() >= pair[1].identity_key())
+        {
+            return invalid(
+                "component records",
+                "records are not sorted and unique by immutable identity",
+            );
+        }
+        catalog.validate_dependency_graph()?;
+        for revocation in &catalog.revocations {
+            revocation.validate(catalog.catalog_revision)?;
+        }
+        ensure_sorted_unique(&catalog.revocations, "revocations")?;
+        catalog.validate_revocations(root_keys)?;
+        catalog.component_count = catalog.components.len();
+        catalog.catalog_sha256 = sha256(&canonical_value(value)?);
+        Ok(catalog)
+    }
+
+    fn validate_dependency_graph(&self) -> Result<(), CatalogError> {
+        let records = self
+            .components
+            .iter()
+            .map(|record| (record.owned_identity_key(), record))
+            .collect::<BTreeMap<_, _>>();
+        if records.len() != self.components.len() {
+            return invalid("component records", "immutable identities are ambiguous");
+        }
+        for record in &self.components {
+            let mut visiting = BTreeSet::new();
+            let mut visited = BTreeSet::new();
+            let mut expected = BTreeSet::new();
+            let mut edge_count = 0usize;
+            collect_dependency_closure(
+                record,
+                &records,
+                &mut visiting,
+                &mut visited,
+                &mut expected,
+                &mut edge_count,
+            )?;
+            if expected != record.dependency_closure.iter().cloned().collect() {
+                return invalid(
+                    "dependency closure",
+                    "closure does not match the exact catalog graph",
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_revocations(
+        &self,
+        root_keys: &BTreeMap<String, Vec<u8>>,
+    ) -> Result<(), CatalogError> {
+        for revocation in &self.revocations {
+            match revocation {
+                Revocation::Component { identity, .. } => {
+                    let matches = self
+                        .components
+                        .iter()
+                        .filter(|record| record.matches_identity(identity))
+                        .count();
+                    if matches != 1 {
+                        return invalid(
+                            "component revocation",
+                            "identity does not resolve to one catalog record",
+                        );
+                    }
+                }
+                Revocation::Signer { key_id, .. } if !root_keys.contains_key(key_id) => {
+                    return invalid(
+                        "signer revocation",
+                        "key is not authorized by the current Root",
+                    );
+                }
+                Revocation::Signer { .. } => {}
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct ComponentRecord {
+    component_id: String,
+    component_version: String,
+    release_counter: u64,
+    target: Target,
+    protocol: Protocol,
+    entrypoint: String,
+    capabilities: Vec<Capability>,
+    dependencies: Vec<Dependency>,
+    dependency_closure: Vec<Dependency>,
+    bundle: Bundle,
+    requirements: Requirements,
+    service: Option<Service>,
+    lifecycle: Lifecycle,
+    provenance_policy: Option<ProvenancePolicy>,
+}
+
+impl ComponentRecord {
+    fn identity_key(&self) -> (&str, &str, &Target) {
+        (&self.component_id, &self.component_version, &self.target)
+    }
+
+    fn owned_identity_key(&self) -> RecordKey {
+        RecordKey(
+            self.component_id.clone(),
+            self.component_version.clone(),
+            self.target.clone(),
+        )
+    }
+
+    fn matches_dependency(&self, dependency: &Dependency) -> bool {
+        self.component_id == dependency.component_id
+            && self.component_version == dependency.component_version
+            && self.target == dependency.target
+            && self.protocol == dependency.protocol
+            && self.bundle.sha256 == dependency.bundle.sha256
+            && self.bundle.length == dependency.bundle.length
+    }
+
+    fn matches_identity(&self, identity: &IdentityReference) -> bool {
+        self.component_id == identity.component_id
+            && self.component_version == identity.component_version
+            && self.target == identity.target
+            && self.protocol == identity.protocol
+            && self.release_counter == identity.release_counter
+            && self.bundle.sha256 == identity.bundle.sha256
+            && self.bundle.length == identity.bundle.length
+    }
+
+    fn validate(&self, revision: u64) -> Result<(), CatalogError> {
+        validate_component_id(&self.component_id)?;
+        validate_semver(&self.component_version, "component version")?;
+        if self.release_counter == 0 {
+            return invalid("component", "release counter is zero");
+        }
+        self.target.validate()?;
+        self.protocol.validate()?;
+        validate_relative_path(&self.entrypoint, "entrypoint")?;
+        if self.capabilities.is_empty() || self.capabilities.len() > MAX_CAPABILITIES {
+            return invalid("component", "capability count is invalid");
+        }
+        for capability in &self.capabilities {
+            capability.validate()?;
+        }
+        ensure_sorted_unique(&self.capabilities, "capabilities")?;
+        validate_dependencies(&self.dependencies, &self.target, &self.protocol)?;
+        validate_dependencies(&self.dependency_closure, &self.target, &self.protocol)?;
+        if self.dependencies.len() > MAX_DIRECT_DEPENDENCIES
+            || self.dependency_closure.len() > MAX_CLOSURE_NODES
+            || !self
+                .dependencies
+                .iter()
+                .all(|dependency| self.dependency_closure.contains(dependency))
+        {
+            return invalid("component", "dependency closure is invalid");
+        }
+        self.bundle.validate()?;
+        self.requirements.validate(&self.target, &self.bundle)?;
+        if let Some(service) = &self.service {
+            service.validate(&self.target, &self.capabilities)?;
+        }
+        self.lifecycle.validate(revision)?;
+        if let Some(policy) = &self.provenance_policy {
+            policy.validate()?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct Target {
+    os: TargetOs,
+    arch: TargetArch,
+    minimum_os_version: Option<String>,
+}
+
+impl Target {
+    fn validate(&self) -> Result<(), CatalogError> {
+        if let Some(version) = &self.minimum_os_version {
+            validate_version_text(version, "minimum OS version")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+enum TargetOs {
+    Macos,
+    Linux,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+enum TargetArch {
+    Arm64,
+    X86_64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct Protocol {
+    wire: String,
+    major: u16,
+    min_minor: u16,
+    max_minor: u16,
+}
+
+impl Protocol {
+    fn validate(&self) -> Result<(), CatalogError> {
+        if self.wire != "oore-component" || self.major != 1 || self.min_minor > self.max_minor {
+            return invalid("protocol", "only a bounded oore-component/1 range is valid");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct Capability {
+    id: String,
+    mode: CapabilityMode,
+    gate_ids: Vec<String>,
+}
+
+impl Capability {
+    fn validate(&self) -> Result<(), CatalogError> {
+        validate_capability_id(&self.id)?;
+        ensure_sorted_unique(&self.gate_ids, "capability gate IDs")?;
+        for gate in &self.gate_ids {
+            validate_token(gate, 64, "gate ID")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+enum CapabilityMode {
+    OneShot,
+    Service,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct Dependency {
+    component_id: String,
+    component_version: String,
+    target: Target,
+    protocol: Protocol,
+    bundle: BundleReference,
+    dependency_kind: DependencyKind,
+}
+
+impl Dependency {
+    fn record_key(&self) -> RecordKey {
+        RecordKey(
+            self.component_id.clone(),
+            self.component_version.clone(),
+            self.target.clone(),
+        )
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct RecordKey(String, String, Target);
+
+fn collect_dependency_closure(
+    record: &ComponentRecord,
+    records: &BTreeMap<RecordKey, &ComponentRecord>,
+    visiting: &mut BTreeSet<RecordKey>,
+    visited: &mut BTreeSet<RecordKey>,
+    expected: &mut BTreeSet<Dependency>,
+    edge_count: &mut usize,
+) -> Result<(), CatalogError> {
+    let owner = record.owned_identity_key();
+    if !visiting.insert(owner.clone()) {
+        return invalid("dependency graph", "cycle detected");
+    }
+    visited.insert(owner.clone());
+    for dependency in &record.dependencies {
+        *edge_count = edge_count
+            .checked_add(1)
+            .ok_or(CatalogError::Limit("dependency edges"))?;
+        if *edge_count > MAX_CLOSURE_EDGES {
+            return Err(CatalogError::Limit("dependency edges"));
+        }
+        let child = records
+            .get(&dependency.record_key())
+            .ok_or_else(|| invalid_error("dependency", "exact child record is missing"))?;
+        if !child.matches_dependency(dependency) {
+            return invalid(
+                "dependency",
+                "child record differs from the exact reference",
+            );
+        }
+        expected.insert(dependency.clone());
+        let child_key = child.owned_identity_key();
+        if visiting.contains(&child_key) {
+            return invalid("dependency graph", "cycle detected");
+        }
+        if !visited.contains(&child_key) {
+            collect_dependency_closure(child, records, visiting, visited, expected, edge_count)?;
+        }
+    }
+    visiting.remove(&owner);
+    Ok(())
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+enum DependencyKind {
+    Runtime,
+    Service,
+    Data,
+}
+
+fn validate_dependencies(
+    values: &[Dependency],
+    target: &Target,
+    protocol: &Protocol,
+) -> Result<(), CatalogError> {
+    ensure_sorted_unique(values, "dependencies")?;
+    for value in values {
+        validate_component_id(&value.component_id)?;
+        validate_semver(&value.component_version, "dependency version")?;
+        value.target.validate()?;
+        value.protocol.validate()?;
+        value.bundle.validate()?;
+        if &value.target != target || value.protocol.major != protocol.major {
+            return invalid(
+                "dependency",
+                "target or protocol major differs from its owner",
+            );
+        }
+    }
+    Ok(())
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct BundleReference {
+    sha256: String,
+    length: u64,
+}
+
+impl BundleReference {
+    fn validate(&self) -> Result<(), CatalogError> {
+        validate_sha256(&self.sha256, "bundle digest")?;
+        if self.length == 0 || self.length > MAX_BUNDLE_BYTES {
+            return invalid("bundle", "length is invalid");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct Bundle {
+    format: BundleFormat,
+    digest_algorithm: DigestAlgorithm,
+    length: u64,
+    sha256: String,
+    path: String,
+    expanded_bytes: u64,
+    file_count: u64,
+}
+
+impl Bundle {
+    fn validate(&self) -> Result<(), CatalogError> {
+        validate_sha256(&self.sha256, "bundle digest")?;
+        validate_relative_path(&self.path, "bundle path")?;
+        if !self.path.contains(&self.sha256)
+            || self.length == 0
+            || self.length > MAX_BUNDLE_BYTES
+            || self.expanded_bytes == 0
+            || self.expanded_bytes > MAX_EXPANDED_BYTES
+            || self.file_count == 0
+            || self.file_count > MAX_FILE_COUNT
+        {
+            return invalid("bundle", "limits or digest-qualified path are invalid");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+enum BundleFormat {
+    TarZst,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+enum DigestAlgorithm {
+    Sha256,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct Requirements {
+    host: Target,
+    toolchains: Vec<ToolchainRequirement>,
+    workspace: WorkspaceRequirement,
+    network: NetworkRequirement,
+    license: Option<LicenseRequirement>,
+    privileges: Vec<Privilege>,
+    download: DownloadRequirement,
+    destructive: Vec<DestructiveGate>,
+}
+
+impl Requirements {
+    fn validate(&self, target: &Target, bundle: &Bundle) -> Result<(), CatalogError> {
+        self.host.validate()?;
+        if &self.host != target {
+            return invalid("requirements", "host differs from component target");
+        }
+        ensure_sorted_unique(&self.toolchains, "toolchains")?;
+        for toolchain in &self.toolchains {
+            toolchain.validate()?;
+        }
+        self.network.validate()?;
+        if let Some(license) = &self.license {
+            license.validate()?;
+        }
+        ensure_sorted_unique(&self.privileges, "privileges")?;
+        ensure_sorted_unique(&self.destructive, "destructive gates")?;
+        if self.download.compressed_bytes != bundle.length
+            || self.download.expanded_bytes != bundle.expanded_bytes
+            || self.download.file_count != bundle.file_count
+        {
+            return invalid("requirements", "download facts differ from the bundle");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct ToolchainRequirement {
+    id: String,
+    minimum_version: String,
+    maximum_version: Option<String>,
+}
+
+impl ToolchainRequirement {
+    fn validate(&self) -> Result<(), CatalogError> {
+        validate_token(&self.id, 128, "toolchain ID")?;
+        validate_version_text(&self.minimum_version, "toolchain minimum")?;
+        if let Some(version) = &self.maximum_version {
+            validate_version_text(version, "toolchain maximum")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+enum WorkspaceRequirement {
+    Private0700,
+    RepositoryCheckout,
+    ExternalArtifact,
+    GuiSession,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct NetworkRequirement {
+    enabled: bool,
+    hosts: Vec<NetworkHost>,
+}
+
+impl NetworkRequirement {
+    fn validate(&self) -> Result<(), CatalogError> {
+        if self.hosts.len() > MAX_NETWORK_HOSTS || (!self.enabled && !self.hosts.is_empty()) {
+            return invalid("network requirement", "host list is invalid");
+        }
+        ensure_sorted_unique(&self.hosts, "network hosts")?;
+        for host in &self.hosts {
+            validate_hostname(&host.hostname)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct NetworkHost {
+    hostname: String,
+    transport: NetworkTransport,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+enum NetworkTransport {
+    Https,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct LicenseRequirement {
+    id: String,
+    text_sha256: String,
+}
+
+impl LicenseRequirement {
+    fn validate(&self) -> Result<(), CatalogError> {
+        validate_token(&self.id, 128, "license ID")?;
+        validate_sha256(&self.text_sha256, "license digest")
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Privilege {
+    User,
+    Admin,
+    Root,
+    Keychain,
+    Launchd,
+    Systemd,
+    Network,
+    ExternalFilesystem,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct DownloadRequirement {
+    compressed_bytes: u64,
+    expanded_bytes: u64,
+    file_count: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+enum DestructiveGate {
+    ReplaceActive,
+    RemoveService,
+    AlterVendorState,
+    PurgeCache,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct Service {
+    service_id: String,
+    host_service: HostService,
+    health_capability: String,
+    startup_timeout_ms: u32,
+    stability_window_ms: u32,
+    stop_grace_ms: u32,
+    restart_policy: RestartPolicy,
+}
+
+impl Service {
+    fn validate(&self, target: &Target, capabilities: &[Capability]) -> Result<(), CatalogError> {
+        validate_token(&self.service_id, 128, "service ID")?;
+        validate_capability_id(&self.health_capability)?;
+        if !capabilities.iter().any(|capability| {
+            capability.id == self.health_capability && capability.mode == CapabilityMode::Service
+        }) || !matches!(
+            (&target.os, &self.host_service),
+            (TargetOs::Macos, HostService::Launchd) | (TargetOs::Linux, HostService::Systemd)
+        ) || !(1_000..=300_000).contains(&self.startup_timeout_ms)
+            || !(1_000..=600_000).contains(&self.stability_window_ms)
+            || !(100..=120_000).contains(&self.stop_grace_ms)
+        {
+            return invalid("service", "health, host, or timeout policy is invalid");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+enum HostService {
+    Launchd,
+    Systemd,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+enum RestartPolicy {
+    OnFailure,
+    Always,
+    Manual,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct Lifecycle {
+    status: LifecycleStatus,
+    effective_at: String,
+    stop_new_locks_at: Option<String>,
+    replacement: Option<IdentityReference>,
+    reason: String,
+}
+
+impl Lifecycle {
+    fn validate(&self, revision: u64) -> Result<(), CatalogError> {
+        parse_timestamp(&self.effective_at, "lifecycle time")?;
+        if let Some(time) = &self.stop_new_locks_at {
+            parse_timestamp(time, "stop-new-locks time")?;
+        }
+        if let Some(replacement) = &self.replacement {
+            replacement.validate(revision)?;
+        }
+        match self.status {
+            LifecycleStatus::Active
+                if self.stop_new_locks_at.is_some() || self.replacement.is_some() =>
+            {
+                return invalid(
+                    "lifecycle",
+                    "active records cannot stop locks or name a replacement",
+                );
+            }
+            LifecycleStatus::Revoked if self.stop_new_locks_at.is_none() => {
+                return invalid("lifecycle", "revoked records must stop new locks");
+            }
+            _ => {}
+        }
+        validate_token(&self.reason, 128, "lifecycle reason")
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+enum LifecycleStatus {
+    Active,
+    Deprecated,
+    Revoked,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct IdentityReference {
+    component_id: String,
+    component_version: String,
+    target: Target,
+    protocol: Protocol,
+    release_counter: u64,
+    catalog_revision: u64,
+    bundle: BundleReference,
+}
+
+impl IdentityReference {
+    fn validate(&self, revision: u64) -> Result<(), CatalogError> {
+        validate_component_id(&self.component_id)?;
+        validate_semver(&self.component_version, "identity version")?;
+        self.target.validate()?;
+        self.protocol.validate()?;
+        self.bundle.validate()?;
+        if self.release_counter == 0 || self.catalog_revision != revision {
+            return invalid("identity", "counter or catalog revision is invalid");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+enum ProvenancePolicy {
+    GithubActionsOidc {
+        repository: String,
+        workflow: String,
+        issuer: String,
+    },
+}
+
+impl ProvenancePolicy {
+    fn validate(&self) -> Result<(), CatalogError> {
+        let Self::GithubActionsOidc {
+            repository,
+            workflow,
+            issuer,
+        } = self;
+        if repository != "oore-ci/components"
+            || issuer != "https://token.actions.githubusercontent.com"
+        {
+            return invalid("provenance policy", "issuer or repository is not official");
+        }
+        validate_relative_path(workflow, "provenance workflow")
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd)]
+#[serde(tag = "kind", rename_all = "lowercase", deny_unknown_fields)]
+enum Revocation {
+    Component {
+        identity: IdentityReference,
+        effective_at: String,
+        reason: String,
+    },
+    Signer {
+        key_id: String,
+        effective_at: String,
+        reason: String,
+    },
+}
+
+impl Revocation {
+    fn validate(&self, revision: u64) -> Result<(), CatalogError> {
+        match self {
+            Self::Component {
+                identity,
+                effective_at,
+                reason,
+            } => {
+                identity.validate(revision)?;
+                parse_timestamp(effective_at, "revocation time")?;
+                validate_token(reason, 128, "revocation reason")
+            }
+            Self::Signer {
+                key_id,
+                effective_at,
+                reason,
+            } => {
+                validate_sha256(key_id, "revoked signer key ID")?;
+                parse_timestamp(effective_at, "revocation time")?;
+                validate_token(reason, 128, "revocation reason")
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CatalogPolicy {
+    max_components: u64,
+    max_bundle_bytes: u64,
+    max_expanded_bytes: u64,
+    max_file_count: u64,
+    max_path_bytes: u64,
+    max_closure_nodes: u64,
+    max_closure_edges: u64,
+}
+
+impl CatalogPolicy {
+    fn validate(&self) -> Result<(), CatalogError> {
+        if self.max_components != MAX_COMPONENTS as u64
+            || self.max_bundle_bytes != MAX_BUNDLE_BYTES
+            || self.max_expanded_bytes != MAX_EXPANDED_BYTES
+            || self.max_file_count != MAX_FILE_COUNT
+            || self.max_path_bytes != MAX_PATH_BYTES as u64
+            || self.max_closure_nodes != MAX_CLOSURE_NODES as u64
+            || self.max_closure_edges != MAX_CLOSURE_EDGES as u64
+        {
+            return invalid("catalog policy", "limits differ from the v0.2 contract");
+        }
+        Ok(())
+    }
+}
+
+fn validate_component_id(value: &str) -> Result<(), CatalogError> {
+    if value.is_empty()
+        || value.len() > 128
+        || value.starts_with('-')
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+    {
+        return invalid("component ID", "value is not lower-case kebab-case");
+    }
+    Ok(())
+}
+
+fn validate_capability_id(value: &str) -> Result<(), CatalogError> {
+    if value.len() > 192
+        || value
+            .split('.')
+            .any(|part| validate_component_id(part).is_err())
+    {
+        return invalid("capability ID", "value is not a bounded dotted ID");
+    }
+    Ok(())
+}
+
+fn validate_semver(value: &str, label: &'static str) -> Result<(), CatalogError> {
+    let version =
+        Version::parse(value).map_err(|error| invalid_error(label, &error.to_string()))?;
+    if !version.build.is_empty() || version.to_string() != value {
+        return invalid(label, "version is not canonical or contains build metadata");
+    }
+    Ok(())
+}
+
+fn validate_relative_path(value: &str, label: &'static str) -> Result<(), CatalogError> {
+    if value.is_empty()
+        || value.len() > MAX_PATH_BYTES
+        || value.starts_with('/')
+        || value.contains('\\')
+        || value.bytes().any(|byte| byte.is_ascii_control())
+        || value
+            .split('/')
+            .any(|part| part.is_empty() || part == "." || part == "..")
+        || value.contains("://")
+    {
+        return invalid(label, "path is not a safe relative path");
+    }
+    Ok(())
+}
+
+fn validate_token(value: &str, maximum: usize, label: &'static str) -> Result<(), CatalogError> {
+    if value.is_empty()
+        || value.len() > maximum
+        || !value.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':' | b'/')
+        })
+    {
+        return invalid(label, "token is outside its closed character set");
+    }
+    Ok(())
+}
+
+fn validate_version_text(value: &str, label: &'static str) -> Result<(), CatalogError> {
+    if value.is_empty()
+        || value.len() > 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_'))
+    {
+        return invalid(label, "version text is invalid");
+    }
+    Ok(())
+}
+
+fn validate_hostname(value: &str) -> Result<(), CatalogError> {
+    if value.len() > 253
+        || value.is_empty()
+        || value.split('.').any(|label| {
+            label.is_empty()
+                || label.len() > 63
+                || label.starts_with('-')
+                || label.ends_with('-')
+                || !label
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        })
+    {
+        return invalid("network hostname", "hostname is invalid");
+    }
+    Ok(())
+}
+
+fn ensure_sorted_unique<T: Ord>(values: &[T], label: &'static str) -> Result<(), CatalogError> {
+    if values.windows(2).any(|pair| pair[0] >= pair[1]) {
+        return invalid(label, "values are not sorted and unique");
+    }
+    Ok(())
+}

--- a/crates/oore-catalog/src/records.rs
+++ b/crates/oore-catalog/src/records.rs
@@ -21,7 +21,7 @@ const MAX_DIRECT_DEPENDENCIES: usize = 64;
 const MAX_CAPABILITIES: usize = 128;
 const MAX_NETWORK_HOSTS: usize = 16;
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, serde::Serialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct CatalogDocument {
     schema_version: u8,
@@ -40,6 +40,65 @@ pub(super) struct CatalogDocument {
 }
 
 impl CatalogDocument {
+    pub(super) fn compose(
+        channel: CatalogChannel,
+        catalog_revision: u64,
+        components: Vec<ComponentRecord>,
+        now: DateTime<Utc>,
+    ) -> Result<Vec<u8>, CatalogError> {
+        let expires = now
+            .checked_add_signed(TARGETS_VALIDITY)
+            .ok_or_else(|| invalid_error("Targets", "expiry overflowed"))?;
+        let value = serde_json::to_value(Self {
+            schema_version: SCHEMA_VERSION,
+            catalog_id: OFFICIAL_REPOSITORY.to_owned(),
+            channel,
+            catalog_revision,
+            generated_at: now.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            expires: expires.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            components,
+            revocations: Vec::new(),
+            policy: CatalogPolicy::v0_2(),
+            component_count: 0,
+            catalog_sha256: String::new(),
+        })
+        .map_err(|error| invalid_error("Targets", &format!("encoding failed: {error}")))?;
+        Self::from_value(&value, now, &BTreeMap::new())?;
+        canonical_value(&value)
+    }
+
+    pub(super) fn component_from_value(value: Value) -> Result<ComponentRecord, CatalogError> {
+        serde_json::from_value(value)
+            .map_err(|error| invalid_error("component record", &format!("schema failed: {error}")))
+    }
+
+    pub(super) fn select_component(
+        &self,
+        component_id: &str,
+        os: &str,
+        arch: &str,
+    ) -> Result<Option<super::VerifiedComponent>, CatalogError> {
+        validate_component_id(component_id)?;
+        let matches = self
+            .components
+            .iter()
+            .filter(|record| {
+                record.component_id == component_id
+                    && record.target.os.as_str() == os
+                    && record.target.arch.as_str() == arch
+                    && matches!(record.lifecycle.status, LifecycleStatus::Active)
+            })
+            .collect::<Vec<_>>();
+        match matches.as_slice() {
+            [] => Ok(None),
+            [record] => Ok(Some(record.to_verified())),
+            _ => invalid(
+                "component selection",
+                "more than one active record matches the host",
+            ),
+        }
+    }
+
     pub(super) fn from_value(
         value: &Value,
         now: DateTime<Utc>,
@@ -164,7 +223,7 @@ impl CatalogDocument {
 
 #[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
 #[serde(deny_unknown_fields)]
-struct ComponentRecord {
+pub(super) struct ComponentRecord {
     component_id: String,
     component_version: String,
     release_counter: u64,
@@ -175,6 +234,8 @@ struct ComponentRecord {
     dependencies: Vec<Dependency>,
     dependency_closure: Vec<Dependency>,
     bundle: Bundle,
+    manifest: ManifestBinding,
+    files: Vec<FileEntry>,
     requirements: Requirements,
     service: Option<Service>,
     lifecycle: Lifecycle,
@@ -182,7 +243,7 @@ struct ComponentRecord {
 }
 
 impl ComponentRecord {
-    fn identity_key(&self) -> (&str, &str, &Target) {
+    pub(super) fn identity_key(&self) -> (&str, &str, &Target) {
         (&self.component_id, &self.component_version, &self.target)
     }
 
@@ -213,7 +274,7 @@ impl ComponentRecord {
             && self.bundle.length == identity.bundle.length
     }
 
-    fn validate(&self, revision: u64) -> Result<(), CatalogError> {
+    pub(super) fn validate(&self, revision: u64) -> Result<(), CatalogError> {
         validate_component_id(&self.component_id)?;
         validate_semver(&self.component_version, "component version")?;
         if self.release_counter == 0 {
@@ -241,6 +302,8 @@ impl ComponentRecord {
             return invalid("component", "dependency closure is invalid");
         }
         self.bundle.validate()?;
+        self.manifest.validate()?;
+        validate_files(&self.files, &self.entrypoint, &self.bundle, &self.manifest)?;
         self.requirements.validate(&self.target, &self.bundle)?;
         if let Some(service) = &self.service {
             service.validate(&self.target, &self.capabilities)?;
@@ -251,11 +314,110 @@ impl ComponentRecord {
         }
         Ok(())
     }
+
+    fn to_verified(&self) -> super::VerifiedComponent {
+        super::VerifiedComponent {
+            component_id: self.component_id.clone(),
+            component_version: self.component_version.clone(),
+            os: self.target.os.as_str().to_owned(),
+            arch: self.target.arch.as_str().to_owned(),
+            minimum_os_version: self.target.minimum_os_version.clone(),
+            entrypoint: self.entrypoint.clone(),
+            archive_length: self.bundle.length,
+            archive_sha256: self.bundle.sha256.clone(),
+            archive_path: self.bundle.path.clone(),
+            expanded_bytes: self.bundle.expanded_bytes,
+            file_count: self.bundle.file_count,
+            manifest_length: self.manifest.length,
+            manifest_sha256: self.manifest.sha256.clone(),
+            files: self
+                .files
+                .iter()
+                .map(|file| super::VerifiedFile {
+                    path: file.path.clone(),
+                    mode: file.mode,
+                    length: file.length,
+                    sha256: file.sha256.clone(),
+                })
+                .collect(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
 #[serde(deny_unknown_fields)]
-struct Target {
+struct ManifestBinding {
+    path: String,
+    length: u64,
+    sha256: String,
+}
+
+impl ManifestBinding {
+    fn validate(&self) -> Result<(), CatalogError> {
+        if self.path != "component.manifest.json"
+            || self.length == 0
+            || self.length > MAX_COMPONENT_RECORD_BYTES as u64
+        {
+            return invalid("component manifest", "path or length is invalid");
+        }
+        validate_sha256(&self.sha256, "component manifest digest")
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+struct FileEntry {
+    path: String,
+    mode: u32,
+    length: u64,
+    sha256: String,
+}
+
+fn validate_files(
+    files: &[FileEntry],
+    entrypoint: &str,
+    bundle: &Bundle,
+    manifest: &ManifestBinding,
+) -> Result<(), CatalogError> {
+    if files.is_empty()
+        || files.len() as u64 + 1 != bundle.file_count
+        || files.windows(2).any(|pair| pair[0].path >= pair[1].path)
+    {
+        return invalid(
+            "component files",
+            "inventory is not sorted, unique, or complete",
+        );
+    }
+    let mut expanded = manifest.length;
+    let mut found_entrypoint = false;
+    for file in files {
+        validate_relative_path(&file.path, "component file")?;
+        validate_sha256(&file.sha256, "component file digest")?;
+        if file.path == manifest.path || file.mode & !0o777 != 0 {
+            return invalid("component file", "path or mode is invalid");
+        }
+        expanded = expanded
+            .checked_add(file.length)
+            .ok_or(CatalogError::Limit("expanded component bytes"))?;
+        if file.path == entrypoint {
+            if file.mode & 0o111 == 0 {
+                return invalid("component entrypoint", "file is not executable");
+            }
+            found_entrypoint = true;
+        }
+    }
+    if !found_entrypoint || expanded != bundle.expanded_bytes {
+        return invalid(
+            "component files",
+            "entrypoint or expanded byte count differs from the bundle",
+        );
+    }
+    Ok(())
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct Target {
     os: TargetOs,
     arch: TargetArch,
     minimum_os_version: Option<String>,
@@ -277,11 +439,29 @@ enum TargetOs {
     Linux,
 }
 
+impl TargetOs {
+    const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Macos => "macos",
+            Self::Linux => "linux",
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
 #[serde(rename_all = "lowercase")]
 enum TargetArch {
     Arm64,
     X86_64,
+}
+
+impl TargetArch {
+    const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Arm64 => "arm64",
+            Self::X86_64 => "x86_64",
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
@@ -706,7 +886,7 @@ impl Lifecycle {
             }
             _ => {}
         }
-        validate_token(&self.reason, 128, "lifecycle reason")
+        validate_reason(&self.reason)
     }
 }
 
@@ -770,7 +950,7 @@ impl ProvenancePolicy {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, serde::Serialize)]
 #[serde(tag = "kind", rename_all = "lowercase", deny_unknown_fields)]
 enum Revocation {
     Component {
@@ -810,7 +990,7 @@ impl Revocation {
     }
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, serde::Serialize)]
 #[serde(deny_unknown_fields)]
 struct CatalogPolicy {
     max_components: u64,
@@ -823,6 +1003,18 @@ struct CatalogPolicy {
 }
 
 impl CatalogPolicy {
+    const fn v0_2() -> Self {
+        Self {
+            max_components: MAX_COMPONENTS as u64,
+            max_bundle_bytes: MAX_BUNDLE_BYTES,
+            max_expanded_bytes: MAX_EXPANDED_BYTES,
+            max_file_count: MAX_FILE_COUNT,
+            max_path_bytes: MAX_PATH_BYTES as u64,
+            max_closure_nodes: MAX_CLOSURE_NODES as u64,
+            max_closure_edges: MAX_CLOSURE_EDGES as u64,
+        }
+    }
+
     fn validate(&self) -> Result<(), CatalogError> {
         if self.max_components != MAX_COMPONENTS as u64
             || self.max_bundle_bytes != MAX_BUNDLE_BYTES
@@ -895,6 +1087,19 @@ fn validate_token(value: &str, maximum: usize, label: &'static str) -> Result<()
         })
     {
         return invalid(label, "token is outside its closed character set");
+    }
+    Ok(())
+}
+
+fn validate_reason(value: &str) -> Result<(), CatalogError> {
+    if value.is_empty()
+        || value.len() > 128
+        || value.trim() != value
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_graphic() || byte == b' ')
+    {
+        return invalid("lifecycle reason", "text is not one bounded line");
     }
     Ok(())
 }

--- a/crates/oore-component-store/Cargo.toml
+++ b/crates/oore-component-store/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "oore-component-store"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+
+[dependencies]
+oore-catalog = { path = "../oore-catalog" }
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+tar.workspace = true
+tempfile.workspace = true
+thiserror.workspace = true
+zstd.workspace = true
+libc.workspace = true
+rustix.workspace = true

--- a/crates/oore-component-store/README.md
+++ b/crates/oore-component-store/README.md
@@ -1,0 +1,10 @@
+# oore-component-store
+
+`oore-component-store` installs a component selected from Oore's verified
+catalog.
+
+The store accepts only exact archive bytes from a verified component record.
+It rejects links, special files, extra files, missing files, and changed file
+metadata. It publishes a component only after every signed fact matches.
+
+The crate does not download catalogs, choose trust roots, or run components.

--- a/crates/oore-component-store/src/lib.rs
+++ b/crates/oore-component-store/src/lib.rs
@@ -1,0 +1,415 @@
+//! Verified, immutable storage for Oore components.
+
+#![deny(missing_docs)]
+#![forbid(unsafe_code)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Seek as _, Write};
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _, PermissionsExt as _};
+use std::path::{Path, PathBuf};
+
+use oore_catalog::{VerifiedComponent, VerifiedFile};
+use serde::Serialize;
+use sha2::{Digest as _, Sha256};
+use thiserror::Error;
+
+const MANIFEST_PATH: &str = "component.manifest.json";
+
+/// A component-store failure that occurs before activation.
+#[derive(Debug, Error)]
+pub enum StoreError {
+    /// The local filesystem rejected a bounded operation.
+    #[error("component store I/O failed: {0}")]
+    Io(#[from] std::io::Error),
+    /// The archive or extracted files differ from signed catalog facts.
+    #[error("component archive is invalid: {0}")]
+    Invalid(&'static str),
+    /// The completion record could not be encoded.
+    #[error("component completion record could not be encoded")]
+    Encode,
+}
+
+/// One installed component selected from the immutable store.
+#[derive(Clone, Debug)]
+pub struct InstalledComponent {
+    root: PathBuf,
+    entrypoint: PathBuf,
+}
+
+impl InstalledComponent {
+    /// Returns the immutable component directory.
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Returns the verified executable path.
+    #[must_use]
+    pub fn entrypoint(&self) -> &Path {
+        &self.entrypoint
+    }
+}
+
+#[derive(Serialize)]
+struct Completion<'a> {
+    schema_version: u8,
+    component_id: &'a str,
+    component_version: &'a str,
+    archive_sha256: &'a str,
+}
+
+/// Installs one exact local archive and activates its immutable digest.
+pub fn install_archive(
+    component: &VerifiedComponent,
+    archive_path: &Path,
+    store_root: &Path,
+) -> Result<InstalledComponent, StoreError> {
+    ensure_private_directory(store_root)?;
+    let objects = store_root.join("objects").join("sha256");
+    let active = store_root.join("active");
+    ensure_private_directory(&objects)?;
+    ensure_private_directory(&active)?;
+
+    let mut archive = open_regular_nofollow(archive_path)?;
+    verify_archive(
+        &mut archive,
+        component.archive_length(),
+        component.archive_sha256(),
+    )?;
+    let final_root = objects.join(component.archive_sha256());
+    if final_root.exists() {
+        verify_complete(&final_root, component)?;
+    } else {
+        let staging = tempfile::Builder::new()
+            .prefix(".staging-")
+            .tempdir_in(&objects)?;
+        extract_verified(component, archive, staging.path())?;
+        write_completion(staging.path(), component)?;
+        let staged = staging.keep();
+        fs::rename(&staged, &final_root)?;
+        sync_directory(&objects)?;
+    }
+    activate(&active, component)?;
+    let entrypoint = final_root.join(component.entrypoint());
+    Ok(InstalledComponent {
+        root: final_root,
+        entrypoint,
+    })
+}
+
+/// Opens the active component only after every stored file matches again.
+pub fn load_active(
+    component: &VerifiedComponent,
+    store_root: &Path,
+) -> Result<InstalledComponent, StoreError> {
+    ensure_private_directory(store_root)?;
+    let active_path = store_root.join("active").join(component.component_id());
+    let digest = read_small_nofollow(&active_path, 65)?;
+    if digest != format!("{}\n", component.archive_sha256()).as_bytes() {
+        return Err(StoreError::Invalid("active component digest differs"));
+    }
+    let root = store_root
+        .join("objects")
+        .join("sha256")
+        .join(component.archive_sha256());
+    verify_complete(&root, component)?;
+    Ok(InstalledComponent {
+        entrypoint: root.join(component.entrypoint()),
+        root,
+    })
+}
+
+fn verify_archive(file: &mut File, length: u64, expected_digest: &str) -> Result<(), StoreError> {
+    let metadata = file.metadata()?;
+    if !metadata.file_type().is_file() || metadata.len() != length {
+        return Err(StoreError::Invalid("compressed length differs"));
+    }
+    let mut hasher = Sha256::new();
+    let copied = std::io::copy(file, &mut hasher)?;
+    if copied != length || format!("{:x}", hasher.finalize()) != expected_digest {
+        return Err(StoreError::Invalid("compressed digest differs"));
+    }
+    file.rewind()?;
+    Ok(())
+}
+
+fn extract_verified(
+    component: &VerifiedComponent,
+    archive: File,
+    destination: &Path,
+) -> Result<(), StoreError> {
+    let mut expected = component
+        .files()
+        .iter()
+        .map(|file| (file.path(), ExpectedFile::Catalog(file)))
+        .collect::<BTreeMap<_, _>>();
+    expected.insert(MANIFEST_PATH, ExpectedFile::Manifest);
+    let decoder = zstd::Decoder::new(archive)?;
+    let mut tar = tar::Archive::new(decoder);
+    let mut seen = BTreeSet::new();
+    let mut expanded = 0u64;
+    for entry in tar.entries()? {
+        let mut entry = entry?;
+        if !entry.header().entry_type().is_file() {
+            return Err(StoreError::Invalid("archive contains a non-regular file"));
+        }
+        let path_bytes = entry.path_bytes();
+        let path = path_bytes
+            .as_ref()
+            .strip_prefix(b"./")
+            .unwrap_or(path_bytes.as_ref());
+        let path = std::str::from_utf8(path)
+            .map_err(|_| StoreError::Invalid("archive path is not UTF-8"))?;
+        let Some(expected_file) = expected.get(path) else {
+            return Err(StoreError::Invalid("archive contains an unexpected file"));
+        };
+        if !seen.insert(path.to_owned()) {
+            return Err(StoreError::Invalid("archive contains a duplicate file"));
+        }
+        let (length, digest, mode) = expected_file.facts(component);
+        let header_mode = entry.header().mode()? & 0o777;
+        if entry.size() != length || header_mode != mode {
+            return Err(StoreError::Invalid("file length or mode differs"));
+        }
+        expanded = expanded
+            .checked_add(length)
+            .ok_or(StoreError::Invalid("expanded length overflowed"))?;
+        let output = destination.join(path);
+        let parent = output
+            .parent()
+            .ok_or(StoreError::Invalid("file has no parent directory"))?;
+        fs::create_dir_all(parent)?;
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        options.mode(mode);
+        let mut file = options.open(&output)?;
+        let mut hasher = Sha256::new();
+        let mut bounded = Read::by_ref(&mut entry).take(length + 1);
+        let copied = std::io::copy(&mut bounded, &mut DigestWriter(&mut file, &mut hasher))?;
+        if copied != length || format!("{:x}", hasher.finalize()) != digest {
+            return Err(StoreError::Invalid("file content differs"));
+        }
+        file.sync_all()?;
+    }
+    if seen.len() as u64 != component.file_count()
+        || seen.len() != expected.len()
+        || expanded != component.expanded_bytes()
+    {
+        return Err(StoreError::Invalid("archive inventory is incomplete"));
+    }
+    Ok(())
+}
+
+enum ExpectedFile<'a> {
+    Catalog(&'a VerifiedFile),
+    Manifest,
+}
+
+impl ExpectedFile<'_> {
+    fn facts<'a>(&'a self, component: &'a VerifiedComponent) -> (u64, &'a str, u32) {
+        match self {
+            Self::Catalog(file) => (file.length(), file.sha256(), file.mode()),
+            Self::Manifest => (
+                component.manifest_length(),
+                component.manifest_sha256(),
+                0o644,
+            ),
+        }
+    }
+}
+
+struct DigestWriter<'a>(&'a mut File, &'a mut Sha256);
+
+impl Write for DigestWriter<'_> {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        let count = self.0.write(bytes)?;
+        self.1.update(&bytes[..count]);
+        Ok(count)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.0.flush()
+    }
+}
+
+fn write_completion(root: &Path, component: &VerifiedComponent) -> Result<(), StoreError> {
+    let bytes = serde_json::to_vec(&Completion {
+        schema_version: 1,
+        component_id: component.component_id(),
+        component_version: component.component_version(),
+        archive_sha256: component.archive_sha256(),
+    })
+    .map_err(|_| StoreError::Encode)?;
+    write_new(root.join(".complete"), &bytes, 0o600)
+}
+
+fn verify_complete(root: &Path, component: &VerifiedComponent) -> Result<(), StoreError> {
+    let metadata = fs::symlink_metadata(root)?;
+    if !metadata.file_type().is_dir() {
+        return Err(StoreError::Invalid("digest object is not a directory"));
+    }
+    let expected = serde_json::to_vec(&Completion {
+        schema_version: 1,
+        component_id: component.component_id(),
+        component_version: component.component_version(),
+        archive_sha256: component.archive_sha256(),
+    })
+    .map_err(|_| StoreError::Encode)?;
+    let actual = read_small_nofollow(&root.join(".complete"), 4 * 1024)?;
+    if actual != expected {
+        return Err(StoreError::Invalid("completion record differs"));
+    }
+    let mut expected_paths = component
+        .files()
+        .iter()
+        .map(|file| file.path().to_owned())
+        .collect::<BTreeSet<_>>();
+    expected_paths.insert(MANIFEST_PATH.to_owned());
+    expected_paths.insert(".complete".to_owned());
+    let mut actual_paths = BTreeSet::new();
+    collect_regular_files(root, root, &mut actual_paths, expected_paths.len())?;
+    if actual_paths != expected_paths {
+        return Err(StoreError::Invalid("installed file inventory differs"));
+    }
+    verify_stored_file(
+        &root.join(MANIFEST_PATH),
+        component.manifest_length(),
+        component.manifest_sha256(),
+        0o644,
+    )?;
+    for file in component.files() {
+        verify_stored_file(
+            &root.join(file.path()),
+            file.length(),
+            file.sha256(),
+            file.mode(),
+        )?;
+    }
+    Ok(())
+}
+
+fn collect_regular_files(
+    root: &Path,
+    directory: &Path,
+    files: &mut BTreeSet<String>,
+    maximum: usize,
+) -> Result<(), StoreError> {
+    for entry in fs::read_dir(directory)? {
+        let entry = entry?;
+        let metadata = entry.file_type()?;
+        let path = entry.path();
+        if metadata.is_dir() {
+            collect_regular_files(root, &path, files, maximum)?;
+        } else if metadata.is_file() {
+            let relative = path
+                .strip_prefix(root)
+                .map_err(|_| StoreError::Invalid("stored path escaped its root"))?
+                .to_str()
+                .ok_or(StoreError::Invalid("stored path is not UTF-8"))?;
+            if !files.insert(relative.to_owned()) || files.len() > maximum {
+                return Err(StoreError::Invalid("stored file inventory is invalid"));
+            }
+        } else {
+            return Err(StoreError::Invalid(
+                "stored object contains a link or special file",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn verify_stored_file(path: &Path, length: u64, digest: &str, mode: u32) -> Result<(), StoreError> {
+    let mut file = open_regular_nofollow(path)?;
+    let metadata = file.metadata()?;
+    #[cfg(unix)]
+    if metadata.mode() & 0o777 != mode {
+        return Err(StoreError::Invalid("stored file mode differs"));
+    }
+    if metadata.len() != length {
+        return Err(StoreError::Invalid("stored file length differs"));
+    }
+    let mut hasher = Sha256::new();
+    let copied = std::io::copy(&mut file, &mut hasher)?;
+    if copied != length || format!("{:x}", hasher.finalize()) != digest {
+        return Err(StoreError::Invalid("stored file digest differs"));
+    }
+    Ok(())
+}
+
+fn activate(active: &Path, component: &VerifiedComponent) -> Result<(), StoreError> {
+    let bytes = format!("{}\n", component.archive_sha256());
+    let temporary = tempfile::NamedTempFile::new_in(active)?;
+    #[cfg(unix)]
+    temporary
+        .as_file()
+        .set_permissions(fs::Permissions::from_mode(0o600))?;
+    temporary.as_file().write_all(bytes.as_bytes())?;
+    temporary.as_file().sync_all()?;
+    temporary
+        .persist(active.join(component.component_id()))
+        .map_err(|error| error.error)?;
+    sync_directory(active)
+}
+
+fn ensure_private_directory(path: &Path) -> Result<(), StoreError> {
+    fs::create_dir_all(path)?;
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.file_type().is_dir() {
+        return Err(StoreError::Invalid("store path is not a directory"));
+    }
+    #[cfg(unix)]
+    {
+        if metadata.uid() != rustix::process::getuid().as_raw() {
+            return Err(StoreError::Invalid("store directory has another owner"));
+        }
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+    }
+    Ok(())
+}
+
+fn open_regular_nofollow(path: &Path) -> Result<File, StoreError> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    let file = options.open(path)?;
+    if !file.metadata()?.file_type().is_file() {
+        return Err(StoreError::Invalid("archive is not a regular file"));
+    }
+    Ok(file)
+}
+
+fn read_small_nofollow(path: &Path, limit: u64) -> Result<Vec<u8>, StoreError> {
+    let file = open_regular_nofollow(path)?;
+    let metadata = file.metadata()?;
+    if metadata.len() > limit {
+        return Err(StoreError::Invalid("small store file exceeds its limit"));
+    }
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take(limit + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > limit {
+        return Err(StoreError::Invalid(
+            "small store file grew beyond its limit",
+        ));
+    }
+    Ok(bytes)
+}
+
+fn write_new(path: PathBuf, bytes: &[u8], mode: u32) -> Result<(), StoreError> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    options.mode(mode);
+    let mut file = options.open(path)?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn sync_directory(path: &Path) -> Result<(), StoreError> {
+    File::open(path)?.sync_all()?;
+    Ok(())
+}


### PR DESCRIPTION
## What changed

- import published Components release evidence into the closed Oore catalog
- build and sign all four catalog metadata roles
- select components only from a complete verified chain
- download exact component bytes on demand
- install into a private content-addressed store
- verify every stored file before each launch
- route `oore apple` to the verified Apple component

## Manual evidence

A disposable 2-of-3 Root and Targets chain installed the published `oore-apple-sign` macOS arm64 release. The shell then launched `oore apple --help` successfully. A changed installed file mode was rejected before launch.

## Limits

- catalog keys are disposable test keys, not production keys
- the alpha transport URL is package configuration; signed length and SHA-256 remain the authority
- no automated tests were added or run under the v0.2.0 test freeze

Closes #239
Advances #240 and #244