### PR TITLE
fix(release): unlock protected metadata signing

### DIFF
--- a/.github/workflows/sign-release-metadata.yml
+++ b/.github/workflows/sign-release-metadata.yml
@@ -23,6 +23,10 @@ on:
         description: Metadata set to sign
         required: true
         type: string
+    secrets:
+      OORE_RELEASE_SIGNING_KEY:
+        description: Protected Ed25519 release-signing private key
+        required: false
   workflow_dispatch:
 
 permissions:
@@ -207,12 +211,13 @@ jobs:
             exit 1
           }
 
+          umask 077
           temporary="$(mktemp -d)"
           key_file="$temporary/private-key"
           derived_key_file="$temporary/derived.pub"
           trap 'rm -rf "$temporary"' EXIT
-          chmod 0600 "$key_file"
           printf '%s\n' "$OORE_RELEASE_SIGNING_KEY" > "$key_file"
+          chmod 0600 "$key_file"
 
           ssh-keygen -y -f "$key_file" > "$derived_key_file" 2>/dev/null || {
             echo 'The release signing secret is not a readable OpenSSH private key.' >&2


### PR DESCRIPTION
## Summary

- declare the protected signing key for reusable workflow calls
- create the private-key file before applying its restrictive mode

## Evidence

- the first v0.1.42-alpha.1 run stopped before publication because the called signer saw an empty secret
- a direct protected signer run received the secret, then reproduced the missing-file chmod failure
- actionlint and git diff --check pass

No release was published by the failed runs.