### PR TITLE
feat(gitlab): prepare v0.1.42 alpha follow-up

### DIFF
--- a/apps/docs/content/docs/reference/cli/oore-setup.mdx
+++ b/apps/docs/content/docs/reference/cli/oore-setup.mdx
@@ -132,26 +132,28 @@ x-oore-trusted-proxy-secret
 
 ## Main options
 
-| Option                                                     | Purpose                                                                |
-| ---------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `--config <PATH>`                                          | Read setup values from a YAML or JSON file.                            |
-| `--plan`                                                   | Print the setup plan without changes.                                  |
-| `--json`                                                   | Print the final setup state as JSON.                                   |
-| `--interface <auto\|terminal\|browser>`                    | Select the setup interface.                                            |
-| `--access <this-device\|identity-provider\|trusted-proxy>` | Select the access result.                                              |
-| `--owner-email <EMAIL>`                                    | Set the local account label or expected proxy owner email.             |
-| `--daemon-listen <IP:PORT>`                                | Set the local control-plane address. The default is `127.0.0.1:8787`.  |
-| `--web-listen <IP:PORT>`                                   | Set the local web address. The default is `127.0.0.1:4173`.            |
-| `--backend-url <URL>`                                      | Set the control-plane URL for a Runner, Web node, or CLI only profile. |
-| `--runner-token <TOKEN>`                                   | Supply an Oore API or session token for Runner registration.           |
-| `--runner-name <NAME>`                                     | Set the Runner registration name.                                      |
-| `--pairing-code <CODE>`                                    | Supply a single-use Web node pairing code.                             |
-| `--state-file <PATH>`                                      | Set the local control-plane database path.                             |
-| `--daemon-url <URL>`                                       | Override the control-plane URL used by the CLI.                        |
-| `--browser-transport-protected`                            | Assert protected ingress for non-loopback browser traffic.             |
-| `--backend-transport-protected`                            | Assert a protected private network for a remote HTTP backend.          |
+| Option                                                     | Purpose                                                                    |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `--config <PATH>`                                          | Read setup values from a YAML or JSON file.                                |
+| `--plan`                                                   | Print the setup plan without changes.                                      |
+| `--json`                                                   | Print the final setup state as JSON.                                       |
+| `--interface <auto\|terminal\|browser>`                    | Select the setup interface.                                                |
+| `--access <this-device\|identity-provider\|trusted-proxy>` | Select the access result.                                                  |
+| `--owner-email <EMAIL>`                                    | Set the local account label or expected proxy owner email.                 |
+| `--daemon-listen <IP:PORT>`                                | Set the managed control-plane address. The default is `127.0.0.1:8787`.    |
+| `--web-listen <IP:PORT>`                                   | Set the local web address. The default is `127.0.0.1:4173`.                |
+| `--backend-url <URL>`                                      | Set the control-plane URL for a Runner, Web node, or CLI only profile.     |
+| `--runner-token <TOKEN>`                                   | Supply an Oore API or session token for Runner registration.               |
+| `--runner-name <NAME>`                                     | Set the Runner registration name.                                          |
+| `--pairing-code <CODE>`                                    | Supply a single-use Web node pairing code.                                 |
+| `--state-file <PATH>`                                      | Set the local control-plane database path.                                 |
+| `--daemon-url <URL>`                                       | Override the control-plane URL used by the CLI.                            |
+| `--browser-transport-protected`                            | Assert protected ingress for non-loopback browser traffic.                 |
+| `--backend-transport-protected`                            | Assert a protected private network for non-loopback control-plane traffic. |
 
 Transport options are assertions. They do not create encryption.
+
+Use `--backend-transport-protected` with a concrete private IP when a private overlay network protects the control-plane listener. Oore also starts a loopback listener on the same port for its local CLI and runner.
 
 ## Configuration files
 

--- a/apps/docs/public/openapi.json
+++ b/apps/docs/public/openapi.json
@@ -2902,6 +2902,150 @@
         ]
       }
     },
+    "/v1/integrations/{id}/gitlab-token": {
+      "put": {
+        "tags": [
+          "Integrations"
+        ],
+        "summary": "Replace a saved GitLab personal access token",
+        "operationId": "replace_gitlab_personal_token",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Integration ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReplaceGitLabTokenRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Replacement token status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GitLabCredentialStatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Token rejected or required scopes are missing",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "GitLab source not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Token belongs to another account or saved credentials are missing",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "GitLab could not validate the token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/v1/integrations/{id}/gitlab-token/check": {
+      "post": {
+        "tags": [
+          "Integrations"
+        ],
+        "summary": "Check a saved GitLab personal access token",
+        "operationId": "check_gitlab_personal_token",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Integration ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Token status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GitLabCredentialStatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Source does not use a personal access token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "GitLab source not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/v1/integrations/{id}/installations": {
       "get": {
         "tags": [
@@ -9696,6 +9840,29 @@
           }
         }
       },
+      "GitLabCredentialStatusResponse": {
+        "type": "object",
+        "required": [
+          "status",
+          "checked_at"
+        ],
+        "properties": {
+          "checked_at": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "expires_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
       "GitLabRepositoryWebhookSecretResponse": {
         "type": "object",
         "required": [
@@ -11465,6 +11632,17 @@
           "oidc",
           "trusted_proxy"
         ]
+      },
+      "ReplaceGitLabTokenRequest": {
+        "type": "object",
+        "required": [
+          "access_token"
+        ],
+        "properties": {
+          "access_token": {
+            "type": "string"
+          }
+        }
       },
       "RepositoryWorkflowExecutionPreview": {
         "type": "object",

--- a/apps/web/src/hooks/use-integrations.ts
+++ b/apps/web/src/hooks/use-integrations.ts
@@ -3,9 +3,11 @@ import type {
   GitLabAuthorizeRequest,
   GitLabStartRequest,
   ListIntegrationsResponse,
+  ReplaceGitLabTokenRequest,
 } from '@/lib/types'
 import {
   browseLocalGitDirectories,
+  checkGitLabToken,
   deleteIntegration,
   getIntegration,
   gitlabAuthorize,
@@ -13,6 +15,7 @@ import {
   listAllIntegrations,
   listInstallations,
   listIntegrationRepos,
+  replaceGitLabToken,
   rotateGitLabRepositoryWebhookSecret,
   syncInstallations,
 } from '@/lib/api'
@@ -104,6 +107,47 @@ export function useGitLabAuthorize() {
     },
     onSuccess: (data) => {
       window.location.href = data.authorize_url
+    },
+  })
+}
+
+export function useGitLabTokenStatus(integrationId: string, enabled: boolean) {
+  const { baseUrl, instance, token } = useApiContext()
+
+  return useQuery({
+    queryKey: [
+      instance?.id ?? '__none__',
+      'gitlab-token-status',
+      integrationId,
+    ],
+    queryFn: () => checkGitLabToken(baseUrl!, token!, integrationId),
+    enabled: enabled && !!baseUrl && !!token && !!integrationId,
+    retry: false,
+  })
+}
+
+export function useReplaceGitLabToken(integrationId: string) {
+  const queryClient = useQueryClient()
+  const { baseUrl, instance, token } = useApiContext()
+
+  return useMutation({
+    mutationFn: (data: ReplaceGitLabTokenRequest) => {
+      if (!baseUrl || !token) {
+        return Promise.reject(new Error('Not authenticated'))
+      }
+      return replaceGitLabToken(baseUrl, token, integrationId, data)
+    },
+    onSuccess: (status) => {
+      queryClient.setQueryData(
+        [instance?.id ?? '__none__', 'gitlab-token-status', integrationId],
+        status,
+      )
+      void queryClient.invalidateQueries({
+        queryKey: [instance?.id ?? '__none__', 'integration', integrationId],
+      })
+      void queryClient.invalidateQueries({
+        queryKey: [instance?.id ?? '__none__', 'integrations'],
+      })
     },
   })
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -35,6 +35,7 @@ import type {
   GitLabAuthorizeRequest,
   GitLabAuthorizeResponse,
   GitLabCompleteResponse,
+  GitLabCredentialStatusResponse,
   GitLabRepositoryWebhookSecretResponse,
   GitLabStartRequest,
   InstancePreferencesResponse,
@@ -68,6 +69,7 @@ import type {
   PipelineIosSigningResponse,
   ProjectDetailResponse,
   ReEnableUserResponse,
+  ReplaceGitLabTokenRequest,
   RegisterIosDeviceRequest,
   RegisterIosDeviceResponse,
   RerunBuildResponse,
@@ -670,6 +672,38 @@ export function gitlabAuthorize(
     '/v1/integrations/gitlab/authorize',
     {
       method: 'POST',
+      headers: authHeaders(token),
+      body: JSON.stringify(data),
+    },
+  )
+}
+
+export function checkGitLabToken(
+  baseUrl: string,
+  token: string,
+  integrationId: string,
+): Promise<GitLabCredentialStatusResponse> {
+  return request<GitLabCredentialStatusResponse>(
+    baseUrl,
+    `/v1/integrations/${integrationId}/gitlab-token/check`,
+    {
+      method: 'POST',
+      headers: authHeaders(token),
+    },
+  )
+}
+
+export function replaceGitLabToken(
+  baseUrl: string,
+  token: string,
+  integrationId: string,
+  data: ReplaceGitLabTokenRequest,
+): Promise<GitLabCredentialStatusResponse> {
+  return request<GitLabCredentialStatusResponse>(
+    baseUrl,
+    `/v1/integrations/${integrationId}/gitlab-token`,
+    {
+      method: 'PUT',
       headers: authHeaders(token),
       body: JSON.stringify(data),
     },

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -298,6 +298,22 @@ export interface GitLabAuthorizeResponse {
   authorize_url: string
 }
 
+export type GitLabCredentialStatus =
+  | 'valid'
+  | 'expired'
+  | 'rejected'
+  | 'unknown'
+
+export interface GitLabCredentialStatusResponse {
+  status: GitLabCredentialStatus
+  expires_at?: number
+  checked_at: number
+}
+
+export interface ReplaceGitLabTokenRequest {
+  access_token: string
+}
+
 export interface LocalGitDirectoryEntry {
   name: string
   path: string

--- a/apps/web/src/routes/settings/integrations/$integrationId.tsx
+++ b/apps/web/src/routes/settings/integrations/$integrationId.tsx
@@ -42,6 +42,7 @@ import {
   IntegrationRepositoryInventory,
 } from './-integration-inventory'
 import { GitLabWebhookTokenDialogs } from './-gitlab-webhook-tokens'
+import { GitLabTokenSettings } from './-gitlab-token-settings'
 import { IntegrationConnectionDetails } from './-integration-connection-details'
 import { IntegrationDisconnectDialog } from './-integration-disconnect-dialog'
 import { loadAffectedProjects } from './-integration-disconnect-impact'
@@ -510,15 +511,24 @@ function IntegrationDetailPage() {
         </TabsContent>
 
         <TabsContent value="connection" className="pt-4">
-          <IntegrationConnectionDetails
-            canWrite={canWrite}
-            gitLabWebhookUrl={gitLabWebhookUrl}
-            integration={integration}
-            lastWebhookAt={detail.last_webhook_at}
-            networkSettingsError={networkSettingsQuery.error}
-            networkSettingsLoading={networkSettingsQuery.isLoading}
-            onRetryNetworkSettings={() => void networkSettingsQuery.refetch()}
-          />
+          <div className="space-y-4">
+            <IntegrationConnectionDetails
+              canWrite={canWrite}
+              gitLabWebhookUrl={gitLabWebhookUrl}
+              integration={integration}
+              lastWebhookAt={detail.last_webhook_at}
+              networkSettingsError={networkSettingsQuery.error}
+              networkSettingsLoading={networkSettingsQuery.isLoading}
+              onRetryNetworkSettings={() => void networkSettingsQuery.refetch()}
+            />
+            {integration.provider === 'gitlab' &&
+            integration.auth_mode === 'personal_token' ? (
+              <GitLabTokenSettings
+                canWrite={canWrite}
+                integrationId={integration.id}
+              />
+            ) : null}
+          </div>
         </TabsContent>
       </Tabs>
 

--- a/apps/web/src/routes/settings/integrations/-gitlab-token-settings.test.tsx
+++ b/apps/web/src/routes/settings/integrations/-gitlab-token-settings.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { GitLabTokenSettings } from './-gitlab-token-settings'
+
+const refetch = vi.fn()
+const replace = vi.fn()
+
+vi.mock('@/hooks/use-integrations', () => ({
+  useGitLabTokenStatus: () => ({
+    data: {
+      status: 'expired',
+      expires_at: 1_786_665_600,
+      checked_at: 1_786_752_000,
+    },
+    error: null,
+    isFetching: false,
+    isLoading: false,
+    refetch,
+  }),
+  useReplaceGitLabToken: () => ({
+    isPending: false,
+    mutate: replace,
+  }),
+}))
+
+vi.mock('@/lib/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+describe('GitLabTokenSettings', () => {
+  beforeEach(() => {
+    refetch.mockReset()
+    replace.mockReset()
+  })
+
+  it('shows the saved token status and expiry', () => {
+    render(<GitLabTokenSettings canWrite integrationId="gitlab-source" />)
+
+    expect(screen.getByText('Expired')).toBeTruthy()
+    expect(screen.getByText('Check again')).toBeTruthy()
+    expect(screen.getByText('Replace access token')).toBeTruthy()
+  })
+
+  it('submits a replacement without disconnecting the source', async () => {
+    render(<GitLabTokenSettings canWrite integrationId="gitlab-source" />)
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Replace access token' }),
+    )
+    fireEvent.change(screen.getByLabelText('New access token'), {
+      target: { value: 'glpat-new-token' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Replace token' }))
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith(
+        { access_token: 'glpat-new-token' },
+        expect.any(Object),
+      )
+    })
+  })
+})

--- a/apps/web/src/routes/settings/integrations/-gitlab-token-settings.tsx
+++ b/apps/web/src/routes/settings/integrations/-gitlab-token-settings.tsx
@@ -1,0 +1,201 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import * as z from 'zod'
+
+import { toast } from '@/lib/toast'
+import type { GitLabCredentialStatusResponse } from '@/lib/types'
+import {
+  useGitLabTokenStatus,
+  useReplaceGitLabToken,
+} from '@/hooks/use-integrations'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+
+const replaceTokenSchema = z.object({
+  access_token: z.string().trim().min(1, 'Access token is required'),
+})
+
+type ReplaceTokenForm = z.infer<typeof replaceTokenSchema>
+
+function statusLabel(status: GitLabCredentialStatusResponse['status']) {
+  if (status === 'valid') return 'Valid'
+  if (status === 'expired') return 'Expired'
+  if (status === 'rejected') return 'Rejected by GitLab'
+  return 'Could not check'
+}
+
+export function GitLabTokenSettings({
+  canWrite,
+  integrationId,
+}: {
+  canWrite: boolean
+  integrationId: string
+}) {
+  const [replaceOpen, setReplaceOpen] = useState(false)
+  const statusQuery = useGitLabTokenStatus(integrationId, true)
+  const replaceMutation = useReplaceGitLabToken(integrationId)
+  const form = useForm<ReplaceTokenForm>({
+    resolver: zodResolver(replaceTokenSchema),
+    defaultValues: { access_token: '' },
+  })
+  const status = statusQuery.data
+
+  function handleOpenChange(open: boolean) {
+    setReplaceOpen(open)
+    if (!open) form.reset()
+  }
+
+  function handleReplace(values: ReplaceTokenForm) {
+    replaceMutation.mutate(values, {
+      onSuccess: () => {
+        toast.success('GitLab access token replaced')
+        handleOpenChange(false)
+      },
+      onError: (error) => {
+        form.setError('access_token', { message: error.message })
+      },
+    })
+  }
+
+  return (
+    <>
+      <Card size="sm" aria-labelledby="gitlab-token-title">
+        <CardHeader>
+          <CardTitle id="gitlab-token-title">GitLab access token</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {statusQuery.error ? (
+            <Alert variant="destructive">
+              <AlertDescription>
+                Oore could not check the saved token:{' '}
+                {statusQuery.error.message}
+              </AlertDescription>
+            </Alert>
+          ) : null}
+
+          <div className="grid gap-3 text-sm sm:grid-cols-[12rem_1fr]">
+            <span className="text-muted-foreground">Status</span>
+            <div>
+              {statusQuery.isLoading ? (
+                <Badge variant="outline">Checking</Badge>
+              ) : status ? (
+                <Badge
+                  variant={
+                    status.status === 'valid'
+                      ? 'success'
+                      : status.status === 'unknown'
+                        ? 'outline'
+                        : 'destructive'
+                  }
+                >
+                  {statusLabel(status.status)}
+                </Badge>
+              ) : (
+                <Badge variant="outline">Unknown</Badge>
+              )}
+            </div>
+
+            <span className="text-muted-foreground">Expires</span>
+            <span>
+              {status?.expires_at
+                ? new Date(status.expires_at * 1000).toLocaleString()
+                : 'GitLab did not report an expiry date'}
+            </span>
+
+            <span className="text-muted-foreground">Last check</span>
+            <span>
+              {status?.checked_at
+                ? new Date(status.checked_at * 1000).toLocaleString()
+                : 'Not checked'}
+            </span>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={statusQuery.isFetching}
+              onClick={() => void statusQuery.refetch()}
+            >
+              {statusQuery.isFetching ? 'Checking...' : 'Check again'}
+            </Button>
+            {canWrite ? (
+              <Button size="sm" onClick={() => setReplaceOpen(true)}>
+                Replace access token
+              </Button>
+            ) : null}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Dialog open={replaceOpen} onOpenChange={handleOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Replace GitLab access token</DialogTitle>
+            <DialogDescription>
+              Oore checks the new token before it replaces the saved token.
+              Existing projects and repositories stay connected.
+            </DialogDescription>
+          </DialogHeader>
+          <Form {...form}>
+            <form
+              className="space-y-4"
+              onSubmit={form.handleSubmit(handleReplace)}
+            >
+              <FormField
+                control={form.control}
+                name="access_token"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>New access token</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        type="password"
+                        autoComplete="new-password"
+                        placeholder="glpat-..."
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => handleOpenChange(false)}
+                >
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={replaceMutation.isPending}>
+                  {replaceMutation.isPending ? 'Replacing...' : 'Replace token'}
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/crates/oore-contract/src/lib.rs
+++ b/crates/oore-contract/src/lib.rs
@@ -937,6 +937,19 @@ pub struct GitLabAuthorizeResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct GitLabCredentialStatusResponse {
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<i64>,
+    pub checked_at: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ReplaceGitLabTokenRequest {
+    pub access_token: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct CreateLocalGitIntegrationRequest {
     pub repository_path: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/oore/src/main.rs
+++ b/crates/oore/src/main.rs
@@ -955,7 +955,7 @@ struct SetupArgs {
     #[arg(long)]
     owner_email: Option<String>,
 
-    /// Address for the local control-plane service.
+    /// Address for the managed control-plane service.
     #[arg(long, default_value = "127.0.0.1:8787")]
     daemon_listen: String,
 
@@ -983,7 +983,7 @@ struct SetupArgs {
     #[arg(long, default_value = "false")]
     browser_transport_protected: bool,
 
-    /// Confirm that remote HTTP backend traffic uses a protected private network.
+    /// Confirm that non-loopback control-plane traffic uses a protected private network.
     #[arg(long, default_value = "false")]
     backend_transport_protected: bool,
 
@@ -9059,6 +9059,7 @@ async fn handle_runner_install_service_inner(
         }
         requested_config
     };
+    let _registration_lock = RunnerRegistrationLock::acquire(&requested_config)?;
     if !args.managed_local && !transition_barrier_held {
         let system_service = format!("system/{RUNNER_SERVICE_LABEL}");
         let system_output = system_launchd_service_output(&system_service)?;
@@ -9082,7 +9083,9 @@ async fn handle_runner_install_service_inner(
             );
         }
     }
-    let previous_config = read_runner_config(&requested_config)?;
+    let previous_config_snapshot = RunnerRegistrationConfigSnapshot::capture(&requested_config)?;
+    let previous_config =
+        parse_private_runner_snapshot(&requested_config, &previous_config_snapshot)?;
     let previous_migrated_config = existing_managed_config
         .as_deref()
         .filter(|path| !paths_refer_to_same_file(path, &requested_config))
@@ -9179,7 +9182,8 @@ async fn handle_runner_install_service_inner(
             ensure_runner_service_config(
                 &args,
                 requested_config.clone(),
-                existing_managed_config.is_some(),
+                existing_managed_config.is_some()
+                    || (args.managed_local && previous_config.is_some()),
                 &credential_action,
             )
             .await?;
@@ -13473,6 +13477,16 @@ mod tests {
         assert_eq!(
             daemon_url_from_listen_address(&listen).unwrap(),
             "http://127.0.0.1:9876"
+        );
+    }
+
+    #[test]
+    fn managed_daemon_health_uses_the_loopback_companion() {
+        assert_eq!(
+            managed_services::local_daemon_service_url("100.107.193.1:8787")
+                .unwrap()
+                .as_str(),
+            "http://127.0.0.1:8787/"
         );
     }
 

--- a/crates/oore/src/managed_services.rs
+++ b/crates/oore/src/managed_services.rs
@@ -1804,7 +1804,7 @@ async fn verify_daemon_endpoint(
     let arguments = plist_arguments(document)?;
     let listen =
         option_value(&arguments, "--listen").context("daemon service has no listen address")?;
-    let base = local_service_url(listen)?;
+    let base = local_daemon_service_url(listen)?;
     let health = get_json(client, base.join("healthz")?).await?;
     anyhow::ensure!(
         health.get("ok").and_then(Value::as_bool) == Some(true),
@@ -2869,6 +2869,19 @@ fn local_service_url(listen: &str) -> anyhow::Result<Url> {
         SocketAddr::new(health_ip, address.port())
     ))
     .context("failed to build local service health URL")
+}
+
+pub(super) fn local_daemon_service_url(listen: &str) -> anyhow::Result<Url> {
+    let address = parse_listen_address(listen)?;
+    let health_ip = match address.ip() {
+        IpAddr::V4(_) => IpAddr::V4(Ipv4Addr::LOCALHOST),
+        IpAddr::V6(_) => IpAddr::V6(Ipv6Addr::LOCALHOST),
+    };
+    Url::parse(&format!(
+        "http://{}/",
+        SocketAddr::new(health_ip, address.port())
+    ))
+    .context("failed to build local daemon health URL")
 }
 
 fn validate_web_transport(

--- a/crates/oore/src/setup_journey.rs
+++ b/crates/oore/src/setup_journey.rs
@@ -324,10 +324,7 @@ impl JourneyOptions {
 
     fn validate(&self, profile: InstallProfile) -> anyhow::Result<()> {
         let daemon_listen = parse_listen(&self.daemon_listen, "daemon listen address")?;
-        anyhow::ensure!(
-            daemon_listen.ip().is_loopback(),
-            "the managed control plane must listen on a loopback address"
-        );
+        validate_managed_daemon_listen(daemon_listen, self.backend_transport_protected)?;
         let web_listen = parse_listen(&self.web_listen, "web listen address")?;
         anyhow::ensure!(
             profile != InstallProfile::Complete || web_listen.ip().is_loopback(),
@@ -503,7 +500,7 @@ async fn resolve_plan_access(
         }));
     }
 
-    let daemon_url = local_url(&options.daemon_listen, "daemon listen address")?;
+    let daemon_url = local_daemon_url(&options.daemon_listen)?;
     let status = verify_daemon_instance(&daemon_url).await.ok();
     if let Some(status) = status
         .as_ref()
@@ -578,7 +575,7 @@ async fn revalidate_local_access(
         return Ok(());
     };
 
-    let daemon_url = local_url(&options.daemon_listen, "daemon listen address")?;
+    let daemon_url = local_daemon_url(&options.daemon_listen)?;
     let Ok(status) = verify_daemon_instance(&daemon_url).await else {
         return Ok(());
     };
@@ -931,7 +928,7 @@ async fn ensure_daemon(
     options: &JourneyOptions,
     terminal: Terminal,
 ) -> anyhow::Result<String> {
-    let daemon_url = local_url(&options.daemon_listen, "daemon listen address")?;
+    let daemon_url = local_daemon_url(&options.daemon_listen)?;
     let operation = terminal.operation("Starting the control plane");
     let state_file = super::resolve_db_path(options.state_file.as_deref())?;
     let result =
@@ -1549,8 +1546,7 @@ fn publish_configuring(
                     .to_string(),
             );
             manifest.lifecycle.web_listen = Some(options.web_listen.clone());
-            manifest.lifecycle.backend_url =
-                Some(local_url(&options.daemon_listen, "daemon listen address")?);
+            manifest.lifecycle.backend_url = Some(local_daemon_url(&options.daemon_listen)?);
             manifest.lifecycle.browser_transport_protected = options.browser_transport_protected;
             manifest.lifecycle.backend_transport_protected = options.backend_transport_protected;
         }
@@ -1561,8 +1557,7 @@ fn publish_configuring(
                     .display()
                     .to_string(),
             );
-            manifest.lifecycle.backend_url =
-                Some(local_url(&options.daemon_listen, "daemon listen address")?);
+            manifest.lifecycle.backend_url = Some(local_daemon_url(&options.daemon_listen)?);
             manifest.lifecycle.backend_transport_protected = options.backend_transport_protected;
         }
         InstallProfile::Runner | InstallProfile::WebNode | InstallProfile::CliOnly => {
@@ -1640,6 +1635,14 @@ fn render_plan(
     ) && let Some(backend_url) = options.backend_url.as_deref()
     {
         lines.push(format!("Control plane {backend_url}"));
+    }
+    if matches!(
+        profile,
+        InstallProfile::Complete | InstallProfile::ControlPlane
+    ) && parse_listen(&options.daemon_listen, "daemon listen address")
+        .is_ok_and(|address| !address.ip().is_loopback())
+    {
+        lines.push("Transport     Protected private network confirmed".to_string());
     }
     lines.extend([String::new(), "Required work".to_string()]);
     match profile {
@@ -2309,6 +2312,33 @@ fn parse_listen(value: &str, label: &str) -> anyhow::Result<SocketAddr> {
         .with_context(|| format!("{label} must use the form IP:port"))
 }
 
+fn valid_managed_daemon_ip(ip: IpAddr) -> bool {
+    !ip.is_unspecified()
+        && !ip.is_multicast()
+        && !matches!(ip, IpAddr::V4(address) if address.is_broadcast())
+}
+
+fn validate_managed_daemon_listen(address: SocketAddr, protected: bool) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        valid_managed_daemon_ip(address.ip()),
+        "the managed control plane must listen on a loopback or concrete unicast address"
+    );
+    anyhow::ensure!(
+        address.ip().is_loopback() || protected,
+        "a non-loopback managed control plane requires --backend-transport-protected and a separately protected private network"
+    );
+    Ok(())
+}
+
+fn local_daemon_url(listen: &str) -> anyhow::Result<String> {
+    let address = parse_listen(listen, "daemon listen address")?;
+    let ip = match address.ip() {
+        IpAddr::V4(_) => IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+        IpAddr::V6(_) => IpAddr::V6(std::net::Ipv6Addr::LOCALHOST),
+    };
+    Ok(format!("http://{}", SocketAddr::new(ip, address.port())))
+}
+
 fn local_url(listen: &str, label: &str) -> anyhow::Result<String> {
     let address = parse_listen(listen, label)?;
     let ip = match address.ip() {
@@ -2564,4 +2594,44 @@ async fn print_ready(
     };
     terminal.outro(message)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod managed_daemon_listen_tests {
+    use super::*;
+
+    #[test]
+    fn protected_private_ipv4_should_be_accepted() {
+        let address = "100.107.193.1:8787".parse().unwrap();
+
+        assert!(validate_managed_daemon_listen(address, true).is_ok());
+    }
+
+    #[test]
+    fn unprotected_private_ipv4_should_be_rejected() {
+        let address = "100.107.193.1:8787".parse().unwrap();
+
+        assert!(validate_managed_daemon_listen(address, false).is_err());
+    }
+
+    #[test]
+    fn unspecified_ipv4_should_be_rejected_when_protected() {
+        let address = "0.0.0.0:8787".parse().unwrap();
+
+        assert!(validate_managed_daemon_listen(address, true).is_err());
+    }
+
+    #[test]
+    fn local_daemon_url_should_use_ipv4_loopback_companion() {
+        let url = local_daemon_url("100.107.193.1:8787").unwrap();
+
+        assert_eq!(url, "http://127.0.0.1:8787");
+    }
+
+    #[test]
+    fn local_daemon_url_should_use_ipv6_loopback_companion() {
+        let url = local_daemon_url("[fd00::1]:8787").unwrap();
+
+        assert_eq!(url, "http://[::1]:8787");
+    }
 }

--- a/crates/oored/src/bin/openapi_export.rs
+++ b/crates/oored/src/bin/openapi_export.rs
@@ -99,6 +99,8 @@ use utoipa::{
         paths::gitlab_start,
         paths::gitlab_authorize,
         paths::gitlab_callback,
+        paths::check_gitlab_personal_token,
+        paths::replace_gitlab_personal_token,
         paths::rotate_gitlab_repository_webhook_secret,
         paths::browse_local_git_directories,
         paths::create_local_git_integration,
@@ -260,6 +262,8 @@ use utoipa::{
         oore_contract::GitLabCompleteResponse,
         oore_contract::GitLabAuthorizeRequest,
         oore_contract::GitLabAuthorizeResponse,
+        oore_contract::GitLabCredentialStatusResponse,
+        oore_contract::ReplaceGitLabTokenRequest,
         oore_contract::GitLabRepositoryWebhookSecretResponse,
         oore_contract::LocalGitDirectoryEntry,
         oore_contract::LocalGitPathSuggestion,
@@ -1340,6 +1344,33 @@ mod paths {
         )
     )]
     pub(super) async fn gitlab_callback() {}
+
+    /// Check a saved GitLab personal access token
+    #[utoipa::path(post, path = "/v1/integrations/{id}/gitlab-token/check", tag = "Integrations",
+        params(("id" = String, Path, description = "Integration ID")),
+        security(("bearer_auth" = [])),
+        responses(
+            (status = 200, description = "Token status", body = GitLabCredentialStatusResponse),
+            (status = 400, description = "Source does not use a personal access token", body = ApiError),
+            (status = 404, description = "GitLab source not found", body = ApiError),
+        )
+    )]
+    pub(super) async fn check_gitlab_personal_token() {}
+
+    /// Replace a saved GitLab personal access token
+    #[utoipa::path(put, path = "/v1/integrations/{id}/gitlab-token", tag = "Integrations",
+        params(("id" = String, Path, description = "Integration ID")),
+        request_body = ReplaceGitLabTokenRequest,
+        security(("bearer_auth" = [])),
+        responses(
+            (status = 200, description = "Replacement token status", body = GitLabCredentialStatusResponse),
+            (status = 400, description = "Token rejected or required scopes are missing", body = ApiError),
+            (status = 404, description = "GitLab source not found", body = ApiError),
+            (status = 409, description = "Token belongs to another account or saved credentials are missing", body = ApiError),
+            (status = 502, description = "GitLab could not validate the token", body = ApiError),
+        )
+    )]
+    pub(super) async fn replace_gitlab_personal_token() {}
 
     /// Generate or rotate a repository-scoped GitLab webhook token
     #[utoipa::path(post, path = "/v1/integration-repositories/{id}/gitlab-webhook-secret", tag = "Integrations",

--- a/crates/oored/src/integrations/gitlab.rs
+++ b/crates/oored/src/integrations/gitlab.rs
@@ -7,10 +7,11 @@ use axum::extract::{Path, Query, RawQuery, State};
 use axum::http::{HeaderMap, Method, StatusCode};
 use axum::response::{Html, IntoResponse, Redirect, Response};
 use base64::Engine;
+use chrono::NaiveDate;
 use oore_contract::{
     ApiError, GitLabAuthorizeRequest, GitLabAuthorizeResponse, GitLabCompleteResponse,
-    GitLabRepositoryWebhookSecretResponse, GitLabStartRequest, Integration,
-    IntegrationInstallation,
+    GitLabCredentialStatusResponse, GitLabRepositoryWebhookSecretResponse, GitLabStartRequest,
+    Integration, IntegrationInstallation, ReplaceGitLabTokenRequest,
 };
 use serde::{Deserialize, Serialize};
 use sqlx::{QueryBuilder, Row, Sqlite};
@@ -130,6 +131,97 @@ fn sniff_avatar_content_type(body: &[u8]) -> Option<&'static str> {
 
 fn build_http_client() -> Result<&'static reqwest::Client, &'static str> {
     super::scm_http_client()
+}
+
+#[derive(Deserialize)]
+struct GitLabPersonalTokenMetadata {
+    active: bool,
+    revoked: bool,
+    expires_at: Option<String>,
+    #[serde(default)]
+    scopes: Vec<String>,
+}
+
+#[derive(Debug)]
+enum GitLabPersonalTokenProbeError {
+    Rejected,
+    Unavailable,
+}
+
+fn personal_token_expiry(value: Option<&str>) -> Option<i64> {
+    value
+        .and_then(|date| NaiveDate::parse_from_str(date, "%Y-%m-%d").ok())
+        .and_then(|date| date.and_hms_opt(0, 0, 0))
+        .map(|date| date.and_utc().timestamp())
+}
+
+async fn probe_personal_token(
+    host_url: &str,
+    token: &str,
+) -> Result<GitLabPersonalTokenMetadata, GitLabPersonalTokenProbeError> {
+    let client = build_http_client().map_err(|_| GitLabPersonalTokenProbeError::Unavailable)?;
+    let response = client
+        .get(format!(
+            "{}/api/v4/personal_access_tokens/self",
+            normalize_gitlab_host_url(host_url)
+                .map_err(|_| GitLabPersonalTokenProbeError::Unavailable)?
+        ))
+        .header("PRIVATE-TOKEN", token)
+        .header("User-Agent", "oore-ci")
+        .send()
+        .await
+        .map_err(|_| GitLabPersonalTokenProbeError::Unavailable)?;
+
+    if matches!(
+        response.status(),
+        reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN
+    ) {
+        return Err(GitLabPersonalTokenProbeError::Rejected);
+    }
+    if !response.status().is_success() {
+        return Err(GitLabPersonalTokenProbeError::Unavailable);
+    }
+    response
+        .json()
+        .await
+        .map_err(|_| GitLabPersonalTokenProbeError::Unavailable)
+}
+
+async fn personal_token_username(
+    host_url: &str,
+    token: &str,
+) -> Result<String, GitLabPersonalTokenProbeError> {
+    #[derive(Deserialize)]
+    struct GitLabUser {
+        username: String,
+    }
+
+    let client = build_http_client().map_err(|_| GitLabPersonalTokenProbeError::Unavailable)?;
+    let response = client
+        .get(format!(
+            "{}/api/v4/user",
+            normalize_gitlab_host_url(host_url)
+                .map_err(|_| GitLabPersonalTokenProbeError::Unavailable)?
+        ))
+        .header("PRIVATE-TOKEN", token)
+        .header("User-Agent", "oore-ci")
+        .send()
+        .await
+        .map_err(|_| GitLabPersonalTokenProbeError::Unavailable)?;
+    if matches!(
+        response.status(),
+        reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN
+    ) {
+        return Err(GitLabPersonalTokenProbeError::Rejected);
+    }
+    if !response.status().is_success() {
+        return Err(GitLabPersonalTokenProbeError::Unavailable);
+    }
+    response
+        .json::<GitLabUser>()
+        .await
+        .map(|user| user.username)
+        .map_err(|_| GitLabPersonalTokenProbeError::Unavailable)
 }
 
 async fn access_token(
@@ -1465,6 +1557,312 @@ pub async fn proxy_git_checkout(
         })
 }
 
+async fn personal_token_source(
+    pool: &sqlx::SqlitePool,
+    integration_id: &str,
+) -> Result<String, (StatusCode, Json<ApiError>)> {
+    let row = sqlx::query(
+        "SELECT host_url, auth_mode FROM integrations \
+         WHERE id = ?1 AND provider = 'gitlab'",
+    )
+    .bind(integration_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|error| {
+        error!(%error, integration_id, "failed to load GitLab source");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to load the GitLab source",
+        )
+    })?
+    .ok_or_else(|| {
+        api_err(
+            StatusCode::NOT_FOUND,
+            "not_found",
+            "GitLab source not found",
+        )
+    })?;
+    let auth_mode: String = row.get("auth_mode");
+    if auth_mode != "personal_token" {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "invalid_auth_mode",
+            "This action is available only for a GitLab personal access token",
+        ));
+    }
+    Ok(row.get("host_url"))
+}
+
+/// `POST /v1/integrations/{id}/gitlab-token/check` — check a saved GitLab PAT.
+pub async fn check_personal_token(
+    State(state): State<Arc<AppState>>,
+    auth: AuthUser,
+    Path(integration_id): Path<String>,
+) -> ApiResult<GitLabCredentialStatusResponse> {
+    check_permission(&state.enforcer, &auth.0.role, "integrations", "read").await?;
+    let pool = &state.db;
+    require_remote_mode(pool).await?;
+    let host_url = personal_token_source(pool, &integration_id).await?;
+    let token = access_token(pool, &state.encryption_key, &integration_id).await?;
+    let known_expiry: Option<i64> = sqlx::query_scalar(
+        "SELECT expires_at FROM integration_credentials \
+         WHERE integration_id = ?1 AND credential_type = 'access_token'",
+    )
+    .bind(&integration_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|error| {
+        error!(%error, integration_id, "failed to load GitLab token expiry");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to load source credentials",
+        )
+    })?
+    .flatten();
+    let now = now_unix();
+
+    let (status, expires_at) = match probe_personal_token(&host_url, &token).await {
+        Ok(metadata) => {
+            let expires_at = personal_token_expiry(metadata.expires_at.as_deref());
+            let status = if metadata.revoked || !metadata.active {
+                "rejected"
+            } else if expires_at.is_some_and(|expiry| expiry <= now) {
+                "expired"
+            } else {
+                "valid"
+            };
+            sqlx::query(
+                "UPDATE integration_credentials SET expires_at = ?1 \
+                 WHERE integration_id = ?2 AND credential_type = 'access_token'",
+            )
+            .bind(expires_at)
+            .bind(&integration_id)
+            .execute(pool)
+            .await
+            .map_err(|error| {
+                error!(%error, integration_id, "failed to store GitLab token expiry");
+                api_err(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "store_error",
+                    "Failed to store source credential status",
+                )
+            })?;
+            (status, expires_at)
+        }
+        Err(GitLabPersonalTokenProbeError::Rejected) => {
+            let status = if known_expiry.is_some_and(|expiry| expiry <= now) {
+                "expired"
+            } else {
+                "rejected"
+            };
+            (status, known_expiry)
+        }
+        Err(GitLabPersonalTokenProbeError::Unavailable) => ("unknown", known_expiry),
+    };
+
+    Ok(Json(GitLabCredentialStatusResponse {
+        status: status.to_string(),
+        expires_at,
+        checked_at: now,
+    }))
+}
+
+/// `PUT /v1/integrations/{id}/gitlab-token` — replace a saved GitLab PAT.
+pub async fn replace_personal_token(
+    State(state): State<Arc<AppState>>,
+    auth: AuthUser,
+    Path(integration_id): Path<String>,
+    Json(req): Json<ReplaceGitLabTokenRequest>,
+) -> ApiResult<GitLabCredentialStatusResponse> {
+    check_permission(&state.enforcer, &auth.0.role, "integrations", "write").await?;
+    let pool = &state.db;
+    require_remote_mode(pool).await?;
+    let host_url = personal_token_source(pool, &integration_id).await?;
+    let token = req.access_token.trim();
+    if token.is_empty() {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "invalid_input",
+            "access_token is required",
+        ));
+    }
+
+    let metadata = match probe_personal_token(&host_url, token).await {
+        Ok(metadata) => metadata,
+        Err(GitLabPersonalTokenProbeError::Rejected) => {
+            return Err(api_err(
+                StatusCode::BAD_REQUEST,
+                "gitlab_auth_failed",
+                "GitLab rejected the new access token",
+            ));
+        }
+        Err(GitLabPersonalTokenProbeError::Unavailable) => {
+            return Err(api_err(
+                StatusCode::BAD_GATEWAY,
+                "gitlab_unavailable",
+                "GitLab could not validate the new access token",
+            ));
+        }
+    };
+    let now = now_unix();
+    let expires_at = personal_token_expiry(metadata.expires_at.as_deref());
+    if metadata.revoked || !metadata.active || expires_at.is_some_and(|expiry| expiry <= now) {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "gitlab_auth_failed",
+            "The new GitLab access token is not active",
+        ));
+    }
+    let has_api_scope = metadata
+        .scopes
+        .iter()
+        .any(|scope| matches!(scope.as_str(), "api" | "read_api"));
+    let has_repository_scope = metadata
+        .scopes
+        .iter()
+        .any(|scope| matches!(scope.as_str(), "api" | "read_repository"));
+    if !has_api_scope || !has_repository_scope {
+        return Err(api_err(
+            StatusCode::BAD_REQUEST,
+            "gitlab_scope_missing",
+            "The new token needs read_api and read_repository access",
+        ));
+    }
+
+    let username =
+        personal_token_username(&host_url, token)
+            .await
+            .map_err(|error| match error {
+                GitLabPersonalTokenProbeError::Rejected => api_err(
+                    StatusCode::BAD_REQUEST,
+                    "gitlab_auth_failed",
+                    "GitLab rejected the new access token",
+                ),
+                GitLabPersonalTokenProbeError::Unavailable => api_err(
+                    StatusCode::BAD_GATEWAY,
+                    "gitlab_unavailable",
+                    "GitLab could not validate the token owner",
+                ),
+            })?;
+    let saved_account: Option<String> = sqlx::query_scalar(
+        "SELECT account_name FROM integration_installations \
+         WHERE integration_id = ?1 ORDER BY created_at LIMIT 1",
+    )
+    .bind(&integration_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|error| {
+        error!(%error, integration_id, "failed to load GitLab source account");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to validate the GitLab source account",
+        )
+    })?;
+    let saved_account = saved_account.ok_or_else(|| {
+        api_err(
+            StatusCode::CONFLICT,
+            "missing_source_account",
+            "The GitLab source has no saved account identity",
+        )
+    })?;
+    if saved_account != username {
+        return Err(api_err(
+            StatusCode::CONFLICT,
+            "gitlab_account_mismatch",
+            "The new token belongs to a different GitLab account",
+        ));
+    }
+
+    let encrypted = crypto::encrypt(token, &state.encryption_key).map_err(|error| {
+        error!(%error, integration_id, "failed to encrypt replacement GitLab token");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "encryption_error",
+            "Failed to encrypt the new access token",
+        )
+    })?;
+    let mut tx = pool.begin().await.map_err(|error| {
+        error!(%error, integration_id, "failed to start GitLab token replacement");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to replace the GitLab access token",
+        )
+    })?;
+    let replaced = sqlx::query(
+        "UPDATE integration_credentials \
+         SET encrypted_value = ?1, expires_at = ?2, updated_at = ?3 \
+         WHERE integration_id = ?4 AND credential_type = 'access_token'",
+    )
+    .bind(encrypted)
+    .bind(expires_at)
+    .bind(now)
+    .bind(&integration_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|error| {
+        error!(%error, integration_id, "failed to replace GitLab token");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to replace the GitLab access token",
+        )
+    })?;
+    if replaced.rows_affected() != 1 {
+        return Err(api_err(
+            StatusCode::CONFLICT,
+            "missing_credentials",
+            "The GitLab source has no saved access token",
+        ));
+    }
+    sqlx::query("UPDATE integrations SET status = 'active', updated_at = ?1 WHERE id = ?2")
+        .bind(now)
+        .bind(&integration_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|error| {
+            error!(%error, integration_id, "failed to reactivate GitLab source");
+            api_err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "store_error",
+                "Failed to replace the GitLab access token",
+            )
+        })?;
+    tx.commit().await.map_err(|error| {
+        error!(%error, integration_id, "failed to commit GitLab token replacement");
+        api_err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "store_error",
+            "Failed to replace the GitLab access token",
+        )
+    })?;
+
+    let details = serde_json::json!({
+        "provider": "gitlab",
+        "auth_mode": "personal_token",
+        "expires_at": expires_at,
+    })
+    .to_string();
+    let _ = write_audit_log(
+        pool,
+        Some(&auth.0.user_id),
+        "integration_credential_replaced",
+        "integration",
+        Some(&integration_id),
+        Some(&details),
+    )
+    .await;
+
+    Ok(Json(GitLabCredentialStatusResponse {
+        status: "valid".to_string(),
+        expires_at,
+        checked_at: now,
+    }))
+}
+
 // ── GitLab OAuth flow ────────────────────────────────────────────
 
 /// Encrypted payload stored in the `state` query parameter for GitLab OAuth.
@@ -2082,16 +2480,66 @@ async fn exchange_gitlab_code(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_http_client, consume_pending_oauth_state, fetch_repository_avatar,
-        git_checkout_request_allowed, normalize_gitlab_host_url, oauth_callback_url,
+        GitLabPersonalTokenProbeError, build_http_client, consume_pending_oauth_state,
+        fetch_repository_avatar, git_checkout_request_allowed, normalize_gitlab_host_url,
+        oauth_callback_url, personal_token_expiry, probe_personal_token,
         register_pending_oauth_state, sync_gitlab_projects, validate_redirect_origin,
     };
     use crate::crypto;
     use axum::Json;
     use axum::extract::Query;
-    use axum::http::{HeaderMap, Method};
+    use axum::http::{HeaderMap, Method, StatusCode};
     use axum::routing::get;
     use std::collections::HashMap;
+
+    #[test]
+    fn personal_token_expiry_uses_midnight_utc() {
+        assert_eq!(
+            personal_token_expiry(Some("2026-08-14")),
+            Some(1_786_665_600)
+        );
+        assert_eq!(personal_token_expiry(Some("not-a-date")), None);
+    }
+
+    #[tokio::test]
+    async fn personal_token_probe_reports_metadata_and_rejection() {
+        let app = axum::Router::new().route(
+            "/api/v4/personal_access_tokens/self",
+            get(|headers: HeaderMap| async move {
+                if headers
+                    .get("private-token")
+                    .and_then(|value| value.to_str().ok())
+                    == Some("valid-token")
+                {
+                    return (
+                        StatusCode::OK,
+                        Json(serde_json::json!({
+                            "active": true,
+                            "revoked": false,
+                            "expires_at": "2026-09-01",
+                            "scopes": ["read_api", "read_repository"]
+                        })),
+                    );
+                }
+                (
+                    StatusCode::UNAUTHORIZED,
+                    Json(serde_json::json!({ "message": "401 Unauthorized" })),
+                )
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let host = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let metadata = probe_personal_token(&host, "valid-token").await.unwrap();
+        assert!(metadata.active);
+        assert_eq!(metadata.expires_at.as_deref(), Some("2026-09-01"));
+        assert!(matches!(
+            probe_personal_token(&host, "expired-token").await,
+            Err(GitLabPersonalTokenProbeError::Rejected)
+        ));
+        server.abort();
+    }
 
     #[test]
     fn gitlab_host_accepts_https_and_literal_loopback_http() {

--- a/crates/oored/src/lib.rs
+++ b/crates/oored/src/lib.rs
@@ -2763,6 +2763,14 @@ async fn build_router_inner(
             post(integrations::gitlab::gitlab_authorize),
         )
         .route(
+            "/v1/integrations/{id}/gitlab-token/check",
+            post(integrations::gitlab::check_personal_token),
+        )
+        .route(
+            "/v1/integrations/{id}/gitlab-token",
+            axum::routing::put(integrations::gitlab::replace_personal_token),
+        )
+        .route(
             "/v1/integrations/local-git",
             get(integrations::local_git::list_local_git_integrations)
                 .post(integrations::local_git::create_local_git_integration),

--- a/crates/oored/src/operator.rs
+++ b/crates/oored/src/operator.rs
@@ -279,41 +279,37 @@ async fn ensure_managed_runner(
             anyhow::bail!("the existing runner registration belongs to an operator");
         }
         if hash_token(token) == previous.token_hash {
-            let rollback = if previous.registered_by.is_none() {
-                let changed = sqlx::query(
-                    "UPDATE runners SET name = ?1, capabilities = ?2, updated_at = ?3 \
-                     WHERE id = ?4 AND registered_by IS NULL AND token_hash = ?5",
-                )
-                .bind(name)
-                .bind(&capabilities_json)
-                .bind(now_unix())
-                .bind(&previous.id)
-                .bind(&previous.token_hash)
-                .execute(&mut *transaction)
-                .await?;
-                anyhow::ensure!(changed.rows_affected() == 1, "managed runner changed");
-                Some(ManagedRunnerRollback {
-                    runner_id: previous.id.clone(),
-                    issued_token_hash: previous.token_hash.clone(),
-                    previous: Some(previous.clone()),
-                })
-            } else {
-                None
-            };
+            let changed = sqlx::query(
+                "UPDATE runners SET name = ?1, capabilities = ?2, registered_by = NULL, \
+                 updated_at = ?3 WHERE id = ?4 AND token_hash = ?5 AND \
+                 (registered_by IS NULL OR ?6 = 1)",
+            )
+            .bind(name)
+            .bind(&capabilities_json)
+            .bind(now_unix())
+            .bind(&previous.id)
+            .bind(&previous.token_hash)
+            .bind(i64::from(adopt_installed_registration))
+            .execute(&mut *transaction)
+            .await?;
+            anyhow::ensure!(changed.rows_affected() == 1, "managed runner changed");
+            let rollback = Some(ManagedRunnerRollback {
+                runner_id: previous.id.clone(),
+                issued_token_hash: previous.token_hash.clone(),
+                previous: Some(previous.clone()),
+            });
             let runner_id = previous.id.clone();
-            if rollback.is_some() {
-                store_managed_runner_receipt(
-                    &mut transaction,
-                    &operation_id,
-                    &request_hash,
-                    &runner_id,
-                    name,
-                    &previous.token_hash,
-                    false,
-                    &rollback,
-                )
-                .await?;
-            }
+            store_managed_runner_receipt(
+                &mut transaction,
+                &operation_id,
+                &request_hash,
+                &runner_id,
+                name,
+                &previous.token_hash,
+                false,
+                &rollback,
+            )
+            .await?;
             transaction.commit().await?;
             return Ok(OperatorResponse::ManagedRunner {
                 runner_id,
@@ -680,15 +676,16 @@ async fn restore_managed_runner(
     let changed = if let Some(previous) = rollback.previous {
         sqlx::query(
             "UPDATE runners SET name = ?1, token_hash = ?2, status = ?3, \
-             capabilities = ?4, last_heartbeat_at = ?5, registered_by = NULL, \
-             created_at = ?6, updated_at = ?7 \
-             WHERE id = ?8 AND registered_by IS NULL AND token_hash = ?9",
+             capabilities = ?4, last_heartbeat_at = ?5, registered_by = ?6, \
+             created_at = ?7, updated_at = ?8 \
+             WHERE id = ?9 AND registered_by IS NULL AND token_hash = ?10",
         )
         .bind(previous.name)
         .bind(previous.token_hash)
         .bind(previous.status)
         .bind(previous.capabilities)
         .bind(previous.last_heartbeat_at)
+        .bind(previous.registered_by)
         .bind(previous.created_at)
         .bind(previous.updated_at)
         .bind(&rollback.runner_id)
@@ -720,8 +717,11 @@ fn validate_rollback_record(record: &ManagedRunnerRecord, runner_id: &str) -> an
         "rollback runner identity is invalid"
     );
     anyhow::ensure!(
-        record.registered_by.is_none(),
-        "rollback cannot restore a manual runner"
+        record
+            .registered_by
+            .as_deref()
+            .is_none_or(|owner| !owner.trim().is_empty()),
+        "rollback runner owner is invalid"
     );
     anyhow::ensure!(
         !record.name.trim().is_empty() && record.name.len() <= 255,
@@ -951,5 +951,119 @@ fn parse_setup_state(value: &str) -> anyhow::Result<SetupState> {
         "owner_created" => Ok(SetupState::OwnerCreated),
         "ready" => Ok(SetupState::Ready),
         other => anyhow::bail!("unknown setup state: {other}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn managed_runner_pool(registered_by: Option<&str>) -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::query("CREATE TABLE setup_state (id INTEGER PRIMARY KEY, instance_id TEXT NOT NULL)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO setup_state (id, instance_id) VALUES (1, 'instance-1')")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE runners (\
+               id TEXT PRIMARY KEY, name TEXT NOT NULL, token_hash TEXT NOT NULL, \
+               status TEXT NOT NULL, capabilities TEXT NOT NULL, \
+               last_heartbeat_at INTEGER, registered_by TEXT, \
+               created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL\
+             )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO runners \
+             (id, name, token_hash, status, capabilities, registered_by, created_at, updated_at) \
+             VALUES ('runner-1', 'legacy', ?1, 'offline', '{}', ?2, 1, 1)",
+        )
+        .bind(hash_token(&"a".repeat(64)))
+        .bind(registered_by)
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool
+    }
+
+    fn capabilities() -> ManagedRunnerCapabilities {
+        ManagedRunnerCapabilities {
+            os: "macos".to_string(),
+            os_version: "test".to_string(),
+            arch: "aarch64".to_string(),
+            xcode_version: String::new(),
+            version: "0.1.42".to_string(),
+            protocol_version: RUNNER_PROTOCOL_VERSION,
+        }
+    }
+
+    #[tokio::test]
+    async fn adoption_converts_and_restores_an_operator_runner() {
+        let pool = managed_runner_pool(Some("owner-1")).await;
+        let response = ensure_managed_runner(
+            &pool,
+            Uuid::new_v4().to_string(),
+            "managed".to_string(),
+            capabilities(),
+            Some("runner-1".to_string()),
+            Some("a".repeat(64)),
+            Uuid::new_v4().to_string(),
+            "b".repeat(64),
+            true,
+        )
+        .await
+        .unwrap();
+        let OperatorResponse::ManagedRunner { rollback, .. } = response else {
+            panic!("unexpected operator response");
+        };
+        let rollback = rollback.unwrap();
+        let owner: Option<String> =
+            sqlx::query_scalar("SELECT registered_by FROM runners WHERE id = 'runner-1'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(owner, None);
+
+        restore_managed_runner(&pool, rollback).await.unwrap();
+        let owner: Option<String> =
+            sqlx::query_scalar("SELECT registered_by FROM runners WHERE id = 'runner-1'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(owner.as_deref(), Some("owner-1"));
+    }
+
+    #[tokio::test]
+    async fn operator_runner_requires_explicit_adoption() {
+        let pool = managed_runner_pool(Some("owner-1")).await;
+        let error = ensure_managed_runner(
+            &pool,
+            Uuid::new_v4().to_string(),
+            "managed".to_string(),
+            capabilities(),
+            Some("runner-1".to_string()),
+            Some("a".repeat(64)),
+            Uuid::new_v4().to_string(),
+            "b".repeat(64),
+            false,
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "the existing runner registration belongs to an operator"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- support managed control-plane listeners on protected private addresses
- adopt preserved managed runner registrations during guided migration
- show GitLab personal access token status and known expiry
- validate and replace a GitLab token without disconnecting its source

## Validation

- `make validate`
- office Complete-profile migration on the protected NetBird listener
- office managed runner restored online
- office frontend and trusted-proxy route verified on alpha.1

## Boundaries

- no office host is changed by this PR
- generic incidents, banners, and background credential checks remain deferred
- live GitLab token replacement requires the user-owned token and remains for post-release acceptance